### PR TITLE
margin btn widgets collapsed

### DIFF
--- a/src/components/widget/style.module.scss
+++ b/src/components/widget/style.module.scss
@@ -26,7 +26,7 @@
   }
 
   &.collapsed {
-    margin-bottom: -45px;
+    margin-bottom: -90px;
     background-position: 0;
     @media screen and (max-width: map-get($breakpoints, md)) {
       margin-bottom: -37px;


### PR DESCRIPTION
Adapt collapsed widgets margin to design

<img width="591" alt="Screenshot 2019-09-02 at 12 49 56" src="https://user-images.githubusercontent.com/33252015/64118090-2f5eab80-cd97-11e9-815f-93f097e31b2b.png">


<img width="466" alt="Screenshot 2019-09-02 at 15 32 40" src="https://user-images.githubusercontent.com/33252015/64118087-2d94e800-cd97-11e9-8619-2353085bb3af.png">

