### PR TITLE
extra title in modal removed

### DIFF
--- a/src/components/info-modal/component.js
+++ b/src/components/info-modal/component.js
@@ -143,9 +143,6 @@ class InfoModal extends PureComponent {
             }
             {widgetType !== 'highlighted_places' && (
               <div className={styles.content}>
-                <h1>
-                  {widgetType}
-                </h1>
                 <span className={styles.info}>
                   {info}
                 </span>


### PR DESCRIPTION
Extra title removed in modal info for desktop view.

https://www.pivotaltracker.com/story/show/169086149