### PR TITLE
fix/map-zoom

### DIFF
--- a/src/components/map/component.js
+++ b/src/components/map/component.js
@@ -9,8 +9,6 @@ import isEmpty from 'lodash/isEmpty';
 import { easeCubic } from 'd3-ease';
 
 import MapPopupHotspots from 'components/map-popup-hotspots';
-import MapControls from './map-controls';
-import ZoomControl from './map-controls/zoom';
 import styles from './style.module.scss';
 
 const DEFAULT_VIEWPORT = {
@@ -212,11 +210,14 @@ class Map extends Component {
     const ms = { ...mapStyle };
 
     const onClickHandler = (e) => {
-      onClick({
-        event: e,
-        map: this.map,
-        mapContainer: this.mapContainer
-      });
+      // This makes sure that if you click on controls, map events does not get triggered
+      if (e.target.className === 'overlays') {
+        onClick({
+          event: e,
+          map: this.map,
+          mapContainer: this.mapContainer
+        });
+      }
     };
 
 

--- a/src/components/map/map-controls/zoom/component.js
+++ b/src/components/map/map-controls/zoom/component.js
@@ -41,7 +41,7 @@ class ZoomControl extends PureComponent {
       [className]: !!className
     });
 
-    const zoomInClass = classnames('zoom-control--btn','zoom-in', { '-disabled': zoom >= maxZoom });
+    const zoomInClass = classnames('zoom-control--btn', 'zoom-in', { '-disabled': zoom >= maxZoom });
     const zoomOutClass = classnames('zoom-control--btn', 'zoom-out', { '-disabled': zoom <= minZoom });
 
     return (


### PR DESCRIPTION
This pr fixes an issue when you click on zoom controls and a shape is right underneath it, it triggers the event to focus on that location. Now we make sure that if map controls are being interacted with, we ignore the event that triggers the shape pan. 