### PR TITLE
Fix bug causing worldwide not to be selectable

### DIFF
--- a/src/components/locations-list/component.js
+++ b/src/components/locations-list/component.js
@@ -20,11 +20,11 @@ function LocationsList({ locationsData }) {
     return null;
   };
 
-  const getPayload = location => (
-    (location.location_type === 'country')
-      ? { iso: location.iso }
-      : { id: location.id }
-  );
+  const getPayload = location => ({
+    ...(location.location_type === 'country' && { iso: location.iso }),
+    ...(location.location_type !== 'country' && { id: location.id }),
+    ...(location.location_type === 'worldwide' && { id: 'worldwide' })
+  });
 
   return (
     <ul className={styles.list}>


### PR DESCRIPTION
This pr fixes a bug where "worldwide" would not be selectable on the search interface: 

https://www.pivotaltracker.com/n/projects/2347787/stories/174253548

Instructions to reproduce within the task. 