### PR TITLE
fix bug causing extent widget not to be shown in US

### DIFF
--- a/src/widget-components/mangrove-extent/config.js
+++ b/src/widget-components/mangrove-extent/config.js
@@ -13,7 +13,7 @@ const widgetData = (data, unit) => {
     const { location_coast_length_m: total } = metadata;
 
     return list.filter(d => d.length_m).map((d) => {
-      const year = new Date(d.date).getFullYear();
+      const year = new Date(d.date).getUTCFullYear();
 
       return ({
         x: Number(year),
@@ -37,7 +37,7 @@ const widgetMeta = ({ list, metadata }) => {
     return {
       years: Array.from(
         new Set(
-          list.filter(d => d.length_m).map(d => new Date(d.date).getFullYear())
+          list.filter(d => d.length_m).map(d => new Date(d.date).getUTCFullYear())
         )
       ),
       total: metadata.location_coast_length_m


### PR DESCRIPTION
Mangrove extent widget is currently not shown in the US, this issue is because we where using `getFullYear` when fetching year, we need to use `getUTCFullYear` as its timezone aware. currently if using `getFullYear` you will get for example in this case `2015` instead of `2016` as the date in this widget is in January. US time differs from European as they calculate with one day offset. 

This is re-produceable on your machine without a VPN, try setting your timezone on your computer to US. Previous code will not show the widget. with this fix the widget should appear correctly. 