### PR TITLE
units select protected areas, change in sentence

### DIFF
--- a/src/modules/widgets/initial-state.js
+++ b/src/modules/widgets/initial-state.js
@@ -10,7 +10,8 @@ export default {
       year: 2020
     },
     protection: {
-      currentYear: null,
+      year: null,
+      unit: null,
     }
   },
   isCollapsed: true,

--- a/src/widget-components/mangrove-protection/config.js
+++ b/src/widget-components/mangrove-protection/config.js
@@ -35,9 +35,8 @@ const getData = (data) => {
 };
 
 export const CONFIG = {
-  parse: (data) => {
+  parse: (data, unit) => {
     const chartData = getData(data);
-
     const protectedPercentage = data.protected_area * 100 / data.total_area;
 
     return {
@@ -87,7 +86,7 @@ export const CONFIG = {
                 payload={payload}
                 settings={[
                   { label: 'Percentage:', key: 'percentage', format: value => `${numberFormat(value)} %`, position: '_column' },
-                  { label: 'Area:', key: 'protection', format: value => `${numberFormat(value)} ha`, position: '_column' },
+                  { label: 'Area:', key: 'protection', format: value => `${numberFormat(value)} ${unit}`, position: '_column' },
                 ]}
               />
             );


### PR DESCRIPTION
**DESCRIPTION**

This PR 
- Changes text from "Protected mangroves" to "mangroves in protected areas"
- Remove all years except for 2020 (hard-coded) in the protected areas widget
- Include the total area of mangrove in the protected areas widget
- Adds a dropdown unit choose between ha and km2 in the protected areas widget

[Reference here](https://github.com/Vizzuality/mangrove-atlas/issues/333)

**JIRA**
https://vizzuality.atlassian.net/browse/GMW-75?atlOrigin=eyJpIjoiYzk0ZGZlNzg4NjA5NGUzY2FhZDRlYjNiYTQ5NDZkMDAiLCJwIjoiaiJ9