### PR TITLE
fix: search location modal 

### DIFF
--- a/src/components/drawing-tool-controls/component.js
+++ b/src/components/drawing-tool-controls/component.js
@@ -35,6 +35,7 @@ const DrawingToolControls = ({
   const modalStatus = myStorage.getItem("drawingAlert");
 
   const [isOpenModalAlert, toggleModalAlert] = useState(false);
+
   const [sidebarActive, setSidebarActive] = useState(null);
   const handleDrawing = useCallback(
     (value, type) => {
@@ -124,10 +125,7 @@ const DrawingToolControls = ({
           className={cx(styles.btn, {
             [styles._active]: drawingMode,
           })}
-          onClick={() => {
-            handleDrawing(drawingMode, null);
-            drawingMode && toggleModalAlert(true);
-          }}
+          onClick={() => handleDrawing(drawingMode, "worldwide")}
         >
           <Icon
             alt={isDrawingMobileMenu  ? "worldwide location" : "create custom area"}
@@ -153,7 +151,7 @@ const DrawingToolControls = ({
             ) : (
               <Link
                 to={{ type: "PAGE/APP" }}
-                // onClick={handleDrawing}
+                onClick={() => handleDrawing(drawingMode, 'worldwide')}
                 className={cx(styles.sidebarItem, {
                   [styles._active]: locationType === "PAGE/APP" && !drawingMode,
                 })}

--- a/src/components/locations-list/component.js
+++ b/src/components/locations-list/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'redux-first-router-link';
 import classnames from 'classnames';
@@ -10,7 +10,15 @@ const locationNames = {
   wdpa: 'WDPA'
 };
 
-const LocationsList = ({ locationsData }) => {
+const LocationsList = ({ closeSearchPanel, locationsData }) => {
+  const [ newLocation, saveNewLocation ] = useState(null);
+
+  useEffect(() => {
+    if(newLocation) {
+      closeSearchPanel()
+    }
+  },[newLocation]);
+
   const getType = (location) => {
     if (location.location_type === 'worldwide') return 'PAGE/APP';
     if (location.location_type === 'custom-area') return 'PAGE/CUSTOM';
@@ -31,7 +39,7 @@ const LocationsList = ({ locationsData }) => {
       {locationsData.map(location => (
         <li key={location.id} className={classnames(styles.listItem, 'notranslate')}>
           <Link to={{ type: getType(location), payload: getPayload(location) }}>
-            <div className={styles.items}>
+            <div className={styles.items} onClick={() => saveNewLocation(location)}>
               <span>
                 {location.name}
               </span>

--- a/src/components/locations-list/index.js
+++ b/src/components/locations-list/index.js
@@ -1,1 +1,11 @@
-export { default } from './component';
+import { connect } from "react-redux";
+
+import { closeSearchPanel } from "modules/locations/actions";
+
+import Component from "./component";
+
+const mapDispatchToProps = {
+  closeSearchPanel,
+};
+
+export default connect(null, mapDispatchToProps)(Component);

--- a/src/modules/pages/sagas.js
+++ b/src/modules/pages/sagas.js
@@ -33,7 +33,6 @@ function* setLocation({ payload }) {
   // In case user sets location from widget modal
 
   if (current) {
-    console.log({ current, targetLocation })
     if (current.iso !== 'custom-area' && (current.iso !== targetLocation.toLowerCase()
     || current.id !== targetLocation.toLowerCase())) {
       // yield put(closeSearchPanel());

--- a/src/modules/pages/sagas.js
+++ b/src/modules/pages/sagas.js
@@ -33,8 +33,10 @@ function* setLocation({ payload }) {
   // In case user sets location from widget modal
 
   if (current) {
+    console.log({ current, targetLocation })
     if (current.iso !== 'custom-area' && (current.iso !== targetLocation.toLowerCase()
     || current.id !== targetLocation.toLowerCase())) {
+      // yield put(closeSearchPanel());
       yield put(closeInfoPanel());
     }
   }

--- a/src/modules/pages/sagas.js
+++ b/src/modules/pages/sagas.js
@@ -35,7 +35,6 @@ function* setLocation({ payload }) {
   if (current) {
     if (current.iso !== 'custom-area' && (current.iso !== targetLocation.toLowerCase()
     || current.id !== targetLocation.toLowerCase())) {
-      yield put(closeSearchPanel());
       yield put(closeInfoPanel());
     }
   }


### PR DESCRIPTION
## Search location modal was not opening correctly + Reset screen on worldwide icon

This PR includes two fixes:

1. The locations modal was closing automatically so I deleted the action in sagas that depended on the location and put it in the component directly so it wouldn't interfere with other operations.

2. Reset modal didn`t appear when user upload drawing file and then click on worldwide icon:
[GMW-362](https://vizzuality.atlassian.net/jira/software/c/projects/GMW/boards/40?modal=detail&selectedIssue=GMW-362)

