### PR TITLE
fixes displaying incorrect route for worldwide case in location list

### DIFF
--- a/src/containers/datasets/locations/types.d.ts
+++ b/src/containers/datasets/locations/types.d.ts
@@ -2,7 +2,7 @@ import { GeoJSONSourceRaw } from 'react-map-gl';
 
 export interface Location {
   name: string;
-  location_type: string;
+  location_type: 'worldwide' | 'country' | 'wdpa';
   iso: string;
   location_id: string;
   bounds: GeoJSONSourceRaw;

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -41,9 +41,16 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
   const handleLocation = useCallback(
     async (location: Location) => {
       const queryParams = asPath.split('?')[1];
-      const url = `/${location.location_type}/${
-        location.location_type === 'country' ? location.iso : location.location_id
-      }?${queryParams}`;
+
+      const locationType = location.location_type === 'worldwide' ? '/' : location.location_type;
+      const locationId =
+        location.location_type === 'worldwide'
+          ? ''
+          : location.location_type === 'country'
+          ? location.iso
+          : location.location_id;
+
+      const url = `/${locationType}/${locationId}?${queryParams}`;
 
       await replace(url, null);
 


### PR DESCRIPTION
## Fixes displaying incorrect route for `worldwide` case in location list

### Overview

![image](https://github.com/Vizzuality/mangrove-atlas/assets/999124/52385b28-0dba-4050-b1e5-2e8151d01410)

Clicking on _Worldwide_ now will lead to `/` route instead of `/worldwide/worldwide`.


### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
