### PR TITLE
species location layer

### DIFF
--- a/public/images/small-pattern.svg
+++ b/public/images/small-pattern.svg
@@ -1,0 +1,30 @@
+<svg width="8" height="17" viewBox="0 0 8 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.760986 -41.2393L-55.8076 15.3293" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M2.88232 -39.1182L-53.6862 17.4504" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M5.00366 -36.9961L-51.5649 19.5725" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M7.125 -34.875L-49.4435 21.6935" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M9.24609 -32.7539L-47.3225 23.8146" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M11.3674 -30.6328L-45.2011 25.9357" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M13.4888 -28.5107L-43.0798 28.0578" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M15.6101 -26.3896L-40.9584 30.1789" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M17.7314 -24.2686L-38.8371 32.3" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M19.8528 -22.1475L-36.7158 34.4211" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M21.9741 -20.0254L-34.5944 36.5432" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M24.0955 -17.9043L-32.4731 38.6642" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M26.2168 -15.7832L-30.3517 40.7853" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M28.3381 -13.6621L-28.2304 42.9064" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M30.4595 -11.541L-26.1091 45.0275" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M32.5808 -9.41895L-23.9877 47.1496" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M34.7021 -7.29785L-21.8664 49.2707" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M36.8235 -5.17676L-19.7451 51.3918" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M38.9446 -3.05566L-17.624 53.5129" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M41.0659 -0.933594L-15.5026 55.635" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M43.1873 1.1875L-13.3813 57.756" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M45.3086 3.30859L-11.26 59.8771" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M47.4299 5.42969L-9.13861 61.9982" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M49.5513 7.55176L-7.01727 64.1203" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M51.6726 9.67285L-4.89594 66.2414" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M53.7939 11.7939L-2.7746 68.3625" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M55.9153 13.915L-0.653261 70.4836" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M58.0366 16.0361L1.46808 72.6047" stroke="#00857F" stroke-linejoin="round"/>
+</svg>

--- a/public/images/stripes-pattern.svg
+++ b/public/images/stripes-pattern.svg
@@ -1,0 +1,51 @@
+<svg width="113" height="158" viewBox="0 0 113 158" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.5">
+<path d="M27.7842 -64L-85.0001 48.7842" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M32.0269 -59.7578L-80.7574 53.0264" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M36.2695 -55.5146L-76.5147 57.2696" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M40.5122 -51.2725L-72.272 61.5118" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M44.7546 -47.0293L-68.0296 65.7549" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M48.9973 -42.7871L-63.7869 69.9971" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M53.24 -38.5439L-59.5442 74.2403" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M57.4827 -34.3018L-55.3016 78.4825" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M61.7253 -30.0586L-51.0589 82.7256" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M65.968 -25.8164L-46.8162 86.9678" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M70.2107 -21.5732L-42.5735 91.211" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M74.4531 -17.3311L-38.3311 95.4532" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M78.6958 -13.0879L-34.0884 99.6963" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M82.9385 -8.8457L-29.8458 103.939" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M87.1812 -4.60352L-25.6031 108.181" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M91.4238 -0.360352L-21.3604 112.424" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M95.6665 3.88184L-17.1177 116.666" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M99.9092 8.125L-12.8751 120.909" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M104.152 12.3672L-8.63238 125.151" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M108.395 16.6104L-4.38971 129.395" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M112.637 20.8525L-0.147032 133.637" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M116.879 25.0957L4.09516 137.88" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M121.122 29.3379L8.33783 142.122" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M125.365 33.5811L12.5805 146.365" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M129.607 37.8232L16.8232 150.607" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M133.85 42.0664L21.0659 154.851" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M138.093 46.3086L25.3085 159.093" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M142.335 50.5518L29.5512 163.336" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M146.578 54.7939L33.7939 167.578" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M150.821 59.0361L38.0366 171.82" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M155.063 63.2793L42.2792 176.064" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M159.306 67.5215L46.5219 180.306" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M163.549 71.7646L50.7646 184.549" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M167.792 76.0068L55.0073 188.791" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M172.034 80.25L59.2499 193.034" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M176.276 84.4922L63.4921 197.276" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M180.519 88.7354L67.7348 201.52" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M184.762 92.9775L71.9775 205.762" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M189.004 97.2207L76.2202 210.005" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M193.247 101.463L80.4628 214.247" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M197.49 105.706L84.7055 218.49" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M201.732 109.948L88.9482 222.732" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M205.975 114.19L93.1909 226.975" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M210.218 118.434L97.4335 231.218" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M214.46 122.676L101.676 235.46" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M218.703 126.919L105.919 239.703" stroke="#00857F" stroke-linejoin="round"/>
+<path d="M222.946 131.161L110.162 243.945" stroke="#00857F" stroke-linejoin="round"/>
+</g>
+</svg>

--- a/src/containers/datasets/locations/hooks.tsx
+++ b/src/containers/datasets/locations/hooks.tsx
@@ -1,7 +1,4 @@
-import { useMemo } from 'react';
-
 import { useQuery, UseQueryOptions, useQueryClient } from '@tanstack/react-query';
-import { data } from 'cypress/types/jquery';
 
 import API from 'services/api';
 
@@ -23,7 +20,7 @@ export const fetchLocations = () =>
     url: '/locations',
   }).then((response) => response.data);
 
-export function useLocations<T = Location[]>(
+export function useLocations<T = DataResponse>(
   queryOptions: UseQueryOptions<DataResponse, Error, T> = {}
 ) {
   const queryClient = useQueryClient();

--- a/src/containers/datasets/locations/hooks.tsx
+++ b/src/containers/datasets/locations/hooks.tsx
@@ -1,4 +1,7 @@
+import { useMemo } from 'react';
+
 import { useQuery, UseQueryOptions, useQueryClient } from '@tanstack/react-query';
+import { data } from 'cypress/types/jquery';
 
 import API from 'services/api';
 

--- a/src/containers/datasets/species-location/hooks.tsx
+++ b/src/containers/datasets/species-location/hooks.tsx
@@ -28,7 +28,7 @@ export function useMangroveSpeciesLocation<T>(
     }).then(({ data }) => data);
 
   return useQuery([QUERY_KEY], fetchMangroveSpecies, {
-    placeholderData: queryClient.getQueryData([QUERY_KEY]) || {
+    placeholderData: queryClient.getQueryData<DataResponse>([QUERY_KEY]) || {
       data: [],
     },
     ...queryOptions,
@@ -44,14 +44,14 @@ export function useSource(): SourceProps {
 }
 
 export function useLayer(): LayerProps[] {
-  const data = useRecoilValue<DataResponse['data'][number]>(SpeciesLocationState);
+  const data = useRecoilValue(SpeciesLocationState);
   const locationsIds = data?.location_ids;
   const { data: locations } = useLocations();
 
   const dataFiltered = useMemo(() => {
-    return locations?.data
-      ?.filter((location) => locationsIds.includes(location.id))
-      .map((location) => location.location_id) satisfies string[];
+    return locations.data
+      .filter((location) => locationsIds?.includes(location.id))
+      .map((location) => location.location_id);
   }, [locationsIds, locations]);
 
   return [

--- a/src/containers/datasets/species-location/types.d.ts
+++ b/src/containers/datasets/species-location/types.d.ts
@@ -1,11 +1,11 @@
-export type Specie = Readonly<{
+export type Specie = {
   scientific_name: string;
   common_name: string;
   iucn_url: string;
   id: number;
   red_list_cat: 'cr' | 'en' | 'vu' | 'nt' | 'lc' | 'dd';
   location_ids: number[];
-}>;
+};
 
 export type DataResponse = {
   data: Specie[];

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -51,7 +51,7 @@ const SpeciesLocation = () => {
       const specie = species.find(({ scientific_name }) => scientific_name === specieName);
       if (specie) setSpecie(specie);
     },
-    [species]
+    [species, setSpecie]
   );
 
   const totalLocations = useMemo(() => specieSelected?.location_ids?.length || 0, [specieSelected]);

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -1,7 +1,9 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import { SpeciesLocationState } from 'store/widgets/species-location';
 
 import * as RadioGroup from '@radix-ui/react-radio-group';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 
 import { getWidgetActive } from 'containers/widget/selector';
 
@@ -22,7 +24,9 @@ import { useMangroveSpeciesLocation } from './hooks';
 import type { DataResponse } from './types';
 
 const SpeciesLocation = () => {
-  const [specieSelected, setSpecie] = useState<DataResponse['data'][number]>();
+  const [specieSelected, setSpecie] =
+    useRecoilState<DataResponse['data'][number]>(SpeciesLocationState);
+
   const {
     data: species,
     isLoading,
@@ -51,7 +55,6 @@ const SpeciesLocation = () => {
   );
 
   const totalLocations = useMemo(() => specieSelected?.location_ids?.length || 0, [specieSelected]);
-
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading
@@ -70,11 +73,9 @@ const SpeciesLocation = () => {
               Select one species from the list below to see where it&apos;s located.
             </p>
           )}
-          {isWidgetActive && (
+          {isWidgetActive && specieSelected && (
             <div className="mb-8 flex items-center space-x-2">
-              <svg width="6" height="12" xmlns="http://www.w3.org/2000/svg" className="rounded-lg">
-                <rect width="6" height="12" className="fill-brand-400" />
-              </svg>
+              <div className="my-0.5 mr-2.5 h-4 w-2 rounded-md border border-brand-800 bg-[url('/images/small-pattern.svg')] bg-center text-sm" />
               <span className="text-sm font-bold text-black/85">
                 Countries where the specie is located
               </span>

--- a/src/store/widgets/species-location.ts
+++ b/src/store/widgets/species-location.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const SpeciesLocationState = atom({
+  key: 'species-location',
+  default: null,
+});

--- a/src/store/widgets/species-location.ts
+++ b/src/store/widgets/species-location.ts
@@ -1,6 +1,8 @@
 import { atom } from 'recoil';
 
-export const SpeciesLocationState = atom({
+import type { DataResponse } from 'containers/datasets/species-location/types';
+
+export const SpeciesLocationState = atom<DataResponse['data'][number]>({
   key: 'species-location',
   default: null,
 });


### PR DESCRIPTION
## Species location layer with filters

### Overview

This PR adds filtering by country presence to the species location layer

### Designs

[Designs](https://www.figma.com/file/GJCx8yGfx6JERPuxlpG3nK/Mangrove-Watch-%5BInternal%5D?type=design&node-id=1804-8662&t=82j0pN2BRMSbDi5N-0)

### Testing instructions

Select different species in different locations. Map layer and widget legend should change accordingly

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
