### PR TITLE
unifies widget and analysis data

### DIFF
--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -13,7 +13,7 @@ import { BiomassYearSettings } from 'store/widgets/biomass';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
-import { useGenericAnalysisData } from 'hooks/analysis';
+import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
 
@@ -55,7 +55,7 @@ export function useMangroveBiomass(
 
   const fetchMangroveBiomass = useCallback(async () => {
     if (isAnalysisEnabled) {
-      return AnalysisAPI.request({
+      return AnalysisAPI.request<AnalysisResponse<DataResponse>>({
         method: 'post',
         url: '/analysis',
         data: {
@@ -64,7 +64,7 @@ export function useMangroveBiomass(
         params: {
           'widgets[]': 'mangrove_biomass',
         },
-      }).then(({ data }) => data);
+      }).then(({ data }) => data['mangrove_biomass']);
     }
 
     return API.request<DataResponse>({
@@ -88,12 +88,6 @@ export function useMangroveBiomass(
           },
         ],
       },
-    },
-    select: (data) => {
-      if (isAnalysisEnabled) {
-        return data['mangrove_biomass'];
-      }
-      return data;
     },
     ...queryOptions,
   });
@@ -175,8 +169,4 @@ export function useLayer(): LayerProps {
     id: 'aboveground_biomass-layer',
     type: 'raster',
   };
-}
-
-export function useAnalysis(queryOptions?: UseQueryOptions<DataResponse>) {
-  return useGenericAnalysisData('mangrove_biomass', queryOptions);
 }

--- a/src/containers/datasets/blue-carbon/types.d.ts
+++ b/src/containers/datasets/blue-carbon/types.d.ts
@@ -8,7 +8,7 @@ type Units = {
 type BlueCarbonIndicator = '0-700' | '700-1400' | '1400-2100' | '2100-2800' | '2800-3500';
 
 export type Data = {
-  year: number;
+  year?: number;
   value: number;
   indicator: BlueCarbonIndicator;
 };

--- a/src/containers/datasets/blue-carbon/widget.tsx
+++ b/src/containers/datasets/blue-carbon/widget.tsx
@@ -2,11 +2,10 @@ import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 import BlueCarbonChart from './chart';
-import { useAnalysis, useMangroveBlueCarbon } from './hooks';
+import { useMangroveBlueCarbon } from './hooks';
 
 const BlueCarbonWidget = () => {
   const { data, isLoading, isPlaceholderData, isFetched } = useMangroveBlueCarbon();
-  const { data: analysisData } = useAnalysis();
   const { location, agb, toc, soc, config } = data;
   const { legend } = config;
   return (

--- a/src/containers/datasets/habitat-change/hooks.tsx
+++ b/src/containers/datasets/habitat-change/hooks.tsx
@@ -5,13 +5,19 @@ import { useRouter } from 'next/router';
 
 import { numberFormat } from 'lib/format';
 
+import { analysisAtom } from 'store/analysis';
+import { drawingToolAtom } from 'store/drawing-tool';
+
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { Rectangle, TooltipProps } from 'recharts';
 import { CartesianViewBox } from 'recharts/types/util/types';
+import { useRecoilValue } from 'recoil';
+
+import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
 
-import API from 'services/api';
+import API, { AnalysisAPI } from 'services/api';
 
 import Tooltip from './tooltip';
 import type { UseParamsOptions } from './types';
@@ -51,8 +57,26 @@ export function useMangroveHabitatChange(
     data: { name: location, id: currentLocation, location_id },
   } = useLocation(locationType, id);
   const { startYear, endYear, limit } = params;
-  const fetchMangroveHabitatChange = () =>
-    API.request({
+  const { uploadedGeojson, customGeojson } = useRecoilValue(drawingToolAtom);
+  const { enabled: isAnalysisEnabled } = useRecoilValue(analysisAtom);
+
+  const geojson = customGeojson || uploadedGeojson;
+
+  const fetchMangroveHabitatChange = () => {
+    if (isAnalysisEnabled) {
+      return AnalysisAPI.request<AnalysisResponse<DataResponse>>({
+        method: 'post',
+        url: '/analysis',
+        data: {
+          geometry: geojson,
+        },
+        params: {
+          'widgets[]': 'mangrove_habitat_change',
+        },
+      }).then(({ data }) => data['mangrove_habitat_change']);
+    }
+
+    return API.request({
       method: 'GET',
       url: '/widgets/country_ranking',
       params: {
@@ -63,15 +87,20 @@ export function useMangroveHabitatChange(
       },
       ...queryOptions,
     }).then((response) => response.data);
+  };
 
-  const query = useQuery(['country_ranking', params, location_id], fetchMangroveHabitatChange, {
-    placeholderData: {
-      data: [],
-      metadata: null,
-    },
+  const query = useQuery(
+    ['country_ranking', params, location_id, geojson],
+    fetchMangroveHabitatChange,
+    {
+      placeholderData: {
+        data: [],
+        metadata: null,
+      },
 
-    ...queryOptions,
-  });
+      ...queryOptions,
+    }
+  );
 
   const { data } = query;
   return useMemo(() => {

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -19,7 +19,7 @@ import {
 import ARROW_SVG from 'svgs/ui/arrow-filled.svg?sprite';
 
 import HabitatExtentChart from './chart';
-import { useAnalysis, useMangroveHabitatExtent } from './hooks';
+import { useMangroveHabitatExtent } from './hooks';
 
 const HabitatExtent = () => {
   const [year, setYear] = useRecoilState(habitatExtentSettings);
@@ -29,8 +29,6 @@ const HabitatExtent = () => {
     year,
     unit: selectedUnitAreaExtent,
   });
-
-  const { data: analysisData } = useAnalysis();
 
   const {
     area,

--- a/src/containers/datasets/height/widget.tsx
+++ b/src/containers/datasets/height/widget.tsx
@@ -2,13 +2,11 @@ import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 import HeightChart from './chart';
-import { useAnalysis, useMangroveHeight } from './hooks';
+import { useMangroveHeight } from './hooks';
 
 const HeightWidget = () => {
   const { location, legend, isLoading, mean, unit, year, config, isPlaceholderData, isFetched } =
     useMangroveHeight();
-
-  const { data: analysisData } = useAnalysis();
 
   if (isLoading) return null;
 

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -19,14 +19,12 @@ import {
 import ARROW_SVG from 'svgs/ui/arrow-filled.svg?sprite';
 
 import NetChangeChart from './chart';
-import { useAnalysis, useMangroveNetChange } from './hooks';
+import { useMangroveNetChange } from './hooks';
 
 const NetChangeWidget = () => {
   const [selectedUnit, setUnit] = useState('km²');
   const [startYear, setStartYear] = useRecoilState(netChangeStartYear);
   const [endYear, setEndYear] = useRecoilState(netChangeEndYear);
-  const { data: analysisData } = useAnalysis();
-
   const {
     isLoading,
     netChange,

--- a/src/containers/widgets/types.d.ts
+++ b/src/containers/widgets/types.d.ts
@@ -34,11 +34,3 @@ type ChartConfig = {
   startIndex?: number;
   endIndex?: number;
 };
-
-type RouterProps = {
-  name: string;
-  id: string;
-  location_id: string;
-};
-
-export type RouterData = { data: RouterProps };

--- a/src/hooks/analysis/index.ts
+++ b/src/hooks/analysis/index.ts
@@ -1,17 +1,15 @@
-import { analysisAtom } from 'store/analysis';
-import { drawingToolAtom } from 'store/drawing-tool';
-
 import { useQuery } from '@tanstack/react-query';
 import type { QueryObserverOptions } from '@tanstack/react-query';
-import { useRecoilValue } from 'recoil';
 
-import { WidgetSlugType } from 'types/widget';
+import { AnalysisWidgetSlug } from 'types/widget';
 
-import API, { AnalysisAPI } from 'services/api';
+import API from 'services/api';
 
 type UploadFileResponse = {
   data: GeoJSON.FeatureCollection;
 };
+
+export type AnalysisResponse<T> = Record<AnalysisWidgetSlug, T>;
 
 const fetchUploadFile = (data: FormData) =>
   API.request<UploadFileResponse>({
@@ -38,43 +36,4 @@ export const useUploadFile = (
       onUploadFile?.(geojson);
     },
   });
-};
-
-const fetchAnalysis = (
-  geojson: UploadFileResponse['data'],
-  widgetKey: Extract<
-    WidgetSlugType,
-    | 'mangrove_habitat_extent'
-    | 'mangrove_height'
-    | 'mangrove_biomass'
-    | 'mangrove_net_change'
-    | 'mangrove_blue_carbon'
-  >
-) =>
-  AnalysisAPI.request<UploadFileResponse>({
-    method: 'post',
-    url: '/analysis',
-    data: {
-      geometry: geojson,
-    },
-    params: {
-      'widgets[]': widgetKey,
-    },
-  }).then(({ data }) => data);
-
-export const useGenericAnalysisData = (
-  widgetKey: Parameters<typeof fetchAnalysis>[1],
-  queryOptions?: QueryObserverOptions
-) => {
-  const { uploadedGeojson, customGeojson } = useRecoilValue(drawingToolAtom);
-  const { enabled: analysisEnabled } = useRecoilValue(analysisAtom);
-
-  return useQuery(
-    ['analysis', widgetKey],
-    () => fetchAnalysis(customGeojson || uploadedGeojson, widgetKey),
-    {
-      enabled: analysisEnabled,
-      ...queryOptions,
-    }
-  );
 };

--- a/src/types/router.d.ts
+++ b/src/types/router.d.ts
@@ -1,7 +1,0 @@
-type RouterProps = {
-  name: string;
-  id: string;
-  location_id: string;
-};
-
-export type RouterData = { data: RouterProps };

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -28,5 +28,12 @@ export type WidgetSlugType =
   | 'mangrove_emissions_mitigation'
   | 'mangrove_international_status'
   | 'mangrove_carbon_market_potential'
-  | 'mangrove_drawing_tool'
-  | 'mangrove_drivers_change';
+  | 'mangrove_drivers_change'
+  | 'mangrove_drawing_tool';
+
+export type AnalysisWidgetSlug =
+  | 'mangrove_extent'
+  | 'mangrove_net_change'
+  | 'mangrove_height'
+  | 'mangrove_biomass'
+  | 'mangrove_blue_carbon';


### PR DESCRIPTION
Unification of widget data and analysis data in widgets

### Overview

This PR adds analysis data in the fetching data flow of several widgets affected by the analysis feature.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
