### PR TITLE
[GMW-568] adds query cancellation to analysis widgets

### DIFF
--- a/src/containers/datasets/biomass/types.d.ts
+++ b/src/containers/datasets/biomass/types.d.ts
@@ -1,3 +1,5 @@
+import type { QueryObserverBaseResult } from '@tanstack/react-query';
+
 type Unit = {
   value: string;
 };
@@ -47,9 +49,9 @@ type ChartConfig = {
 };
 
 export type BiomassData = {
-  isLoading: boolean;
-  isFetched: boolean;
-  isPlaceholderData: boolean;
+  isFetching: QueryObserverBaseResult['isFetching'];
+  isError: QueryObserverBaseResult['isError'];
+  refetch: QueryObserverBaseResult['refetch'];
   mean: string;
   unit: string;
   year: number;

--- a/src/containers/datasets/biomass/widget.tsx
+++ b/src/containers/datasets/biomass/widget.tsx
@@ -1,29 +1,76 @@
+import { useCallback, useState } from 'react';
+
+import { analysisAtom } from 'store/analysis';
 import { BiomassYearSettings } from 'store/widgets/biomass';
 
-import { useRecoilState } from 'recoil';
+import { useQueryClient } from '@tanstack/react-query';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 import BiomassChart from './chart';
-import { useMangroveBiomass } from './hooks';
+import { useMangroveBiomass, widgetSlug } from './hooks';
 
 const BiomassWidget = () => {
   const [defaultYear, setYear] = useRecoilState(BiomassYearSettings);
-  const { year, mean, unit, config, isLoading, location, isFetched, isPlaceholderData } =
-    useMangroveBiomass();
+  const [isCanceled, setIsCanceled] = useState(false);
+  const { enabled: isAnalysisRunning } = useRecoilValue(analysisAtom);
+  const queryClient = useQueryClient();
+
+  const handleQueryCancellation = useCallback(() => {
+    setIsCanceled(true);
+  }, []);
+
+  const { year, mean, unit, config, isFetching, location, refetch, isError } = useMangroveBiomass(
+    {},
+    { enabled: !isCanceled },
+    handleQueryCancellation
+  );
 
   if (year !== defaultYear) setYear(year);
+
+  const handleCancelAnalysis = useCallback(async () => {
+    await queryClient.cancelQueries({
+      predicate: ({ queryKey }) => queryKey.includes(widgetSlug),
+      fetchStatus: 'fetching',
+    });
+  }, [queryClient]);
+
+  const handleTryAgain = useCallback(async () => {
+    await refetch();
+    setIsCanceled(false);
+  }, [refetch]);
 
   const { legend } = config;
 
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
-      <Loading
-        visible={(isPlaceholderData || isLoading) && !isFetched}
-        iconClassName="flex w-10 h-10 m-auto my-10"
-      />
-      {isFetched && !isLoading && (
+      <div className="flex flex-col items-center space-y-4">
+        <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
+        {isAnalysisRunning && isFetching && !isCanceled && (
+          <button
+            type="button"
+            onClick={handleCancelAnalysis}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Cancel analysis
+          </button>
+        )}
+      </div>
+      {(isCanceled || isError) && !isFetching && (
+        <div className="flex flex-col items-center space-y-4">
+          <p>An error occurred while fetching the data. You can try again.</p>
+          <button
+            type="button"
+            onClick={handleTryAgain}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+      {mean && !isFetching && !isError && !isCanceled && (
         <>
           <p>
             Mean mangrove aboveground biomass density in{' '}

--- a/src/containers/datasets/blue-carbon/widget.tsx
+++ b/src/containers/datasets/blue-carbon/widget.tsx
@@ -1,20 +1,71 @@
+import { useCallback, useState } from 'react';
+
+import { analysisAtom } from 'store/analysis';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
 import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 import BlueCarbonChart from './chart';
-import { useMangroveBlueCarbon } from './hooks';
+import { useMangroveBlueCarbon, widgetSlug } from './hooks';
 
 const BlueCarbonWidget = () => {
-  const { data, isLoading, isPlaceholderData, isFetched } = useMangroveBlueCarbon();
+  const [isCanceled, setIsCanceled] = useState(false);
+  const queryClient = useQueryClient();
+  const { enabled: isAnalysisRunning } = useRecoilValue(analysisAtom);
+  const handleQueryCancellation = useCallback(() => {
+    setIsCanceled(true);
+  }, []);
+
+  const handleCancelAnalysis = useCallback(async () => {
+    await queryClient.cancelQueries({
+      predicate: ({ queryKey }) => queryKey.includes(widgetSlug),
+      fetchStatus: 'fetching',
+    });
+  }, [queryClient]);
+
+  const { data, isFetching, isError, refetch } = useMangroveBlueCarbon(
+    {},
+    { enabled: !isCanceled },
+    handleQueryCancellation
+  );
+
+  const handleTryAgain = useCallback(async () => {
+    await refetch();
+    setIsCanceled(false);
+  }, [refetch]);
+
   const { location, agb, toc, soc, config } = data;
-  const { legend } = config;
+
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
-      <Loading
-        visible={(isPlaceholderData || isLoading) && !isFetched}
-        iconClassName="flex w-10 h-10 m-auto my-10"
-      />
-      {isFetched && !isLoading && (
+      <div className="flex flex-col items-center space-y-4">
+        <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
+        {isAnalysisRunning && isFetching && !isCanceled && (
+          <button
+            type="button"
+            onClick={handleCancelAnalysis}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Cancel analysis
+          </button>
+        )}
+      </div>
+      {(isCanceled || isError) && !isFetching && (
+        <div className="flex flex-col items-center space-y-4">
+          <p>An error occurred while fetching the data. You can try again.</p>
+          <button
+            type="button"
+            onClick={handleTryAgain}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+      {data && !isFetching && !isError && !isCanceled && (
         <div className="space-y-4">
           <p>
             Total organic carbon stored in <span className="font-bold"> {location}</span> mangroves
@@ -22,7 +73,7 @@ const BlueCarbonWidget = () => {
             <span className="font-bold"> {agb}t CO₂e</span> stored in above-ground biomass and{' '}
             <span className="font-bold"> {soc}t CO₂e</span> stored in the upper 1m of soil.
           </p>
-          <BlueCarbonChart config={config} legend={legend} />
+          <BlueCarbonChart config={config} legend={config.legend} />
           <p className="text-sm italic">
             Note: This information is based on an outdated GMW version. Please use for reference
             only while we are in the process of updating this to the latest GMW version 3.

--- a/src/containers/datasets/height/widget.tsx
+++ b/src/containers/datasets/height/widget.tsx
@@ -1,22 +1,68 @@
+import { useState, useCallback } from 'react';
+
+import { analysisAtom } from 'store/analysis';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
 import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 import HeightChart from './chart';
-import { useMangroveHeight } from './hooks';
+import { useMangroveHeight, widgetSlug } from './hooks';
 
 const HeightWidget = () => {
-  const { location, legend, isLoading, mean, unit, year, config, isPlaceholderData, isFetched } =
-    useMangroveHeight();
+  const [isCanceled, setIsCanceled] = useState(false);
+  const { enabled: isAnalysisRunning } = useRecoilValue(analysisAtom);
 
-  if (isLoading) return null;
+  const queryClient = useQueryClient();
+
+  const handleQueryCancellation = useCallback(() => {
+    setIsCanceled(true);
+  }, []);
+
+  const handleCancelAnalysis = useCallback(async () => {
+    await queryClient.cancelQueries({
+      predicate: ({ queryKey }) => queryKey.includes(widgetSlug),
+      fetchStatus: 'fetching',
+    });
+  }, [queryClient]);
+
+  const { location, legend, isFetching, isError, data, mean, unit, year, config, refetch } =
+    useMangroveHeight({}, { enabled: !isCanceled }, handleQueryCancellation);
+
+  const handleTryAgain = useCallback(async () => {
+    await refetch();
+    setIsCanceled(false);
+  }, [refetch]);
 
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
-      <Loading
-        visible={(isPlaceholderData || isLoading) && !isFetched}
-        iconClassName="flex w-10 h-10 m-auto my-10"
-      />
-      {isFetched && !isLoading && (
+      <div className="flex flex-col items-center space-y-4">
+        <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
+        {isAnalysisRunning && isFetching && !isCanceled && (
+          <button
+            type="button"
+            onClick={handleCancelAnalysis}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Cancel analysis
+          </button>
+        )}
+      </div>
+      {(isCanceled || isError) && !isFetching && (
+        <div className="flex flex-col items-center space-y-4">
+          <p>An error occurred while fetching the data. You can try again.</p>
+          <button
+            type="button"
+            onClick={handleTryAgain}
+            className="rounded-2xl bg-brand-800 px-6 py-1 text-sm text-white active:ring-2 active:ring-inset active:ring-brand-600"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+      {data && !isFetching && !isError && !isCanceled && (
         <div>
           <p>
             Mean mangrove maximum canopy height in <span className="font-bold"> {location}</span>{' '}

--- a/src/store/widgets/net-change.ts
+++ b/src/store/widgets/net-change.ts
@@ -1,11 +1,11 @@
 import { atom } from 'recoil';
 
-export const netChangeStartYear = atom({
+export const netChangeStartYear = atom<number>({
   key: 'net-change-start-year',
   default: null,
 });
 
-export const netChangeEndYear = atom({
+export const netChangeEndYear = atom<number>({
   key: 'net-change-end-year',
   default: null,
 });


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview
![Screenshot 2023-06-05 at 17 41 13](https://github.com/Vizzuality/mangrove-atlas/assets/999124/036a02bf-fcde-4161-987b-2b077ced5a95)
![Screenshot 2023-06-05 at 17 42 06](https://github.com/Vizzuality/mangrove-atlas/assets/999124/5b54beb9-3e5b-4ee8-995f-ff3dead6e7cb)


Adds the ability to cancel fetching of analysis and trigger it again, if needed.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/GMW-568

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
