### PR TITLE
(fix): popup settings on contextual map

### DIFF
--- a/src/components/map/component.tsx
+++ b/src/components/map/component.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState, useCallback, FC } from 'react';
 import ReactMapGL, { ViewState, ViewStateChangeEvent, useMap } from 'react-map-gl';
 
 import cx from 'classnames';
-import { isEmpty } from 'lodash-es';
 import { useDebouncedCallback } from 'use-debounce';
 
 // * If you plan to use Mapbox (and not a fork):
@@ -11,8 +10,6 @@ import { useDebouncedCallback } from 'use-debounce';
 // * 2) install Mapbox v1/v2 (v2 requires token)
 // * 3) if you installed v2: provide the token to the map through the `mapboxAccessToken` property
 // * 4) remove `mapLib` property
-
-import RestorationPopup from 'containers/map/restoration-popup';
 
 import { DEFAULT_VIEW_STATE } from './constants';
 import type { CustomMapProps } from './types';
@@ -52,15 +49,6 @@ export const CustomMap: FC<CustomMapProps> = ({
   const [isFlying, setFlying] = useState(false);
   const [loaded, setLoaded] = useState(false);
   const [cursor, setCursor] = useState<string>('auto');
-
-  const [restorationPopUp, setRestorationPopUp] = useState({
-    popup: [],
-    popupInfo: null,
-    popUpPosition: {
-      x: null,
-      y: null,
-    },
-  });
 
   /**
    * CALLBACKS
@@ -144,24 +132,6 @@ export const CustomMap: FC<CustomMapProps> = ({
   const onMouseEnter = useCallback(() => setCursor('pointer'), []);
   const onMouseLeave = useCallback(() => setCursor('auto'), []);
 
-  const onClickHandler = (e) => {
-    const restorationData = e?.features.find(
-      ({ layer }) => layer.id === 'mangrove_restoration'
-    )?.properties;
-
-    if (restorationData) {
-      setRestorationPopUp({
-        ...restorationPopUp,
-        popup: [e?.lngLat.lat, e?.lngLat.lng],
-        popupInfo: restorationData,
-        popUpPosition: {
-          x: e.point.x,
-          y: e.point.y,
-        },
-      });
-    }
-  };
-
   return (
     <div
       className={cx({
@@ -180,19 +150,12 @@ export const CustomMap: FC<CustomMapProps> = ({
         mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN}
         onMove={handleMapMove}
         onLoad={handleMapLoad}
-        onClick={onClickHandler}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         {...mapboxProps}
         {...localViewState}
       >
         {!!mapRef && loaded && children(mapRef.getMap())}
-        {!!restorationPopUp?.popup?.length && !isEmpty(restorationPopUp?.popupInfo) ? (
-          <RestorationPopup
-            restorationPopUpInfo={restorationPopUp}
-            setRestorationPopUp={setRestorationPopUp}
-          />
-        ) : null}
       </ReactMapGL>
     </div>
   );

--- a/src/components/popup/index.tsx
+++ b/src/components/popup/index.tsx
@@ -1,0 +1,41 @@
+import { ReactNode } from 'react';
+
+import { Popup as PopupReactMapGL } from 'react-map-gl';
+
+const Popup = ({
+  children,
+  popUpPosition,
+  longitude,
+  latitude,
+  onClose,
+}: {
+  children: ReactNode;
+  longitude: number;
+  latitude: number;
+  popUpPosition: { x: number; y: number };
+  onClose: () => void;
+}) => {
+  const popUpWidth = 440;
+  const sidebarWidth = 630;
+
+  const anchor = () => {
+    if (popUpPosition.x < sidebarWidth + popUpWidth) return 'left';
+    else if (popUpPosition.y - popUpWidth < 0) return 'top';
+    else if (popUpPosition.x - popUpWidth > popUpWidth) return 'right';
+    else return 'bottom';
+  };
+
+  return (
+    <PopupReactMapGL
+      anchor={anchor()}
+      longitude={longitude || null}
+      latitude={latitude || null}
+      onClose={onClose}
+      className="c-restoration-popup"
+    >
+      {children}
+    </PopupReactMapGL>
+  );
+};
+
+export default Popup;

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -36,6 +36,7 @@ import type { DrawControlProps } from 'components/map/drawing-tool';
 import DrawControl from 'components/map/drawing-tool';
 import { CustomMapProps } from 'components/map/types';
 import { Media } from 'components/media-query';
+import Popup from 'components/popup';
 import { breakpoints } from 'styles/styles.config';
 
 import LayerManager from './layer-manager';
@@ -190,6 +191,10 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
     }
   };
 
+  const removePopup = () => {
+    setRestorationPopUp(null);
+  };
+
   return (
     <div className="absolute top-0 left-0 z-0 h-screen w-screen">
       <Map
@@ -226,10 +231,14 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
               <PitchReset mapId={mapId} />
             </Controls>
             {!!restorationPopUp?.popup?.length && !isEmpty(restorationPopUp?.popupInfo) ? (
-              <RestorationPopup
-                restorationPopUpInfo={restorationPopUp}
-                setRestorationPopUp={setRestorationPopUp}
-              />
+              <Popup
+                popUpPosition={restorationPopUp.popUpPosition}
+                longitude={restorationPopUp.popup[1]}
+                latitude={restorationPopUp.popup[0]}
+                onClose={removePopup}
+              >
+                <RestorationPopup restorationPopUpInfo={restorationPopUp} />
+              </Popup>
             ) : null}
           </>
         )}

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -192,7 +192,14 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   };
 
   const removePopup = () => {
-    setRestorationPopUp(null);
+    setRestorationPopUp({
+      popup: [],
+      popupInfo: null,
+      popUpPosition: {
+        x: null,
+        y: null,
+      },
+    });
   };
 
   return (

--- a/src/containers/map/restoration-popup/index.tsx
+++ b/src/containers/map/restoration-popup/index.tsx
@@ -60,24 +60,22 @@ const PopupRestoration = ({
       onClose={removePopUp}
       className="c-restoration-popup"
     >
-      <div className="w-fit-content">
-        <div className="relative flex flex-col items-start rounded-[20px] bg-white">
-          <RestorationScores
-            data={popupInfo}
-            isOpen={open === 'restoration'}
-            handleClick={() => handleClick('restoration')}
-          />
-          <Details
-            data={popupInfo}
-            isOpen={open === 'details'}
-            handleClick={() => handleClick('details')}
-          />
-          <EcosystemServices
-            data={popupInfo}
-            isOpen={open === 'ecosystem'}
-            handleClick={() => handleClick('ecosystem')}
-          />
-        </div>
+      <div className="relative flex w-[460px] flex-col items-start rounded-[20px] bg-white">
+        <RestorationScores
+          data={popupInfo}
+          isOpen={open === 'restoration'}
+          handleClick={() => handleClick('restoration')}
+        />
+        <Details
+          data={popupInfo}
+          isOpen={open === 'details'}
+          handleClick={() => handleClick('details')}
+        />
+        <EcosystemServices
+          data={popupInfo}
+          isOpen={open === 'ecosystem'}
+          handleClick={() => handleClick('ecosystem')}
+        />
       </div>
     </Popup>
   );

--- a/src/containers/map/restoration-popup/index.tsx
+++ b/src/containers/map/restoration-popup/index.tsx
@@ -10,25 +10,16 @@ import type { RestorationPopUp } from 'types/map';
 
 const PopupRestoration = ({
   restorationPopUpInfo,
-  setRestorationPopUp,
 }: {
   restorationPopUpInfo: {
     popup: number[];
     popupInfo: RestorationPopUp;
     popUpPosition: { x: number; y: number };
   };
-  setRestorationPopUp: (restorationPopUpInfo) => void;
 }) => {
   const [open, setOpen] = useState('');
 
-  const {
-    popUpPosition: { x, y },
-    popup,
-    popupInfo,
-  } = restorationPopUpInfo;
-
-  const popUpWidth = 440;
-  const sidebarWidth = 630;
+  const { popupInfo } = restorationPopUpInfo;
 
   const handleClick = useCallback(
     (id: string) => {
@@ -41,43 +32,36 @@ const PopupRestoration = ({
     [open]
   );
 
-  const removePopUp = () => {
-    setRestorationPopUp({});
-  };
-
-  const anchor = () => {
-    if (x < sidebarWidth + popUpWidth) return 'left';
-    else if (y - popUpWidth < 0) return 'top';
-    else if (x - popUpWidth > popUpWidth) return 'right';
-    else return 'bottom';
-  };
+  // const removePopUp = () => {
+  //   setRestorationPopUp({});
+  // };
 
   return (
-    <Popup
-      anchor={anchor()}
-      longitude={popup[1] || null}
-      latitude={popup[0] || null}
-      onClose={removePopUp}
-      className="c-restoration-popup"
-    >
-      <div className="relative flex w-[460px] flex-col items-start rounded-[20px] bg-white">
-        <RestorationScores
-          data={popupInfo}
-          isOpen={open === 'restoration'}
-          handleClick={() => handleClick('restoration')}
-        />
-        <Details
-          data={popupInfo}
-          isOpen={open === 'details'}
-          handleClick={() => handleClick('details')}
-        />
-        <EcosystemServices
-          data={popupInfo}
-          isOpen={open === 'ecosystem'}
-          handleClick={() => handleClick('ecosystem')}
-        />
-      </div>
-    </Popup>
+    // <Popup
+    //   anchor={anchor()}
+    //   longitude={popup[1] || null}
+    //   latitude={popup[0] || null}
+    //   onClose={removePopUp}
+    //   className=""
+    // >
+    <div className="c-restoration-popup relative flex w-[460px] flex-col items-start rounded-[20px] bg-white">
+      <RestorationScores
+        data={popupInfo}
+        isOpen={open === 'restoration'}
+        handleClick={() => handleClick('restoration')}
+      />
+      <Details
+        data={popupInfo}
+        isOpen={open === 'details'}
+        handleClick={() => handleClick('details')}
+      />
+      <EcosystemServices
+        data={popupInfo}
+        isOpen={open === 'ecosystem'}
+        handleClick={() => handleClick('ecosystem')}
+      />
+    </div>
+    // </Popup>
   );
 };
 


### PR DESCRIPTION
## Manage popup settings on contextual map

### Overview
This PR fixes [https://github.com/Vizzuality/mangrove-atlas/pull/773](https://github.com/Vizzuality/mangrove-atlas/pull/773) and move the handling of the pop up to the map container so it can scale better.
Also introduce Popup component with children working as specific popup.

### Feature relevant tickets
[GMW-563](https://vizzuality.atlassian.net/browse/GMW-563)


[GMW-563]: https://vizzuality.atlassian.net/browse/GMW-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ