### PR TITLE
locations with no data

### DIFF
--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -105,6 +105,7 @@ export function useMangroveBiomass(
     ...queryOptions,
   });
   const { data, isError, isFetching, refetch } = query;
+  const noData = !data?.data?.length;
 
   return useMemo(() => {
     const years = data?.metadata.year;
@@ -150,6 +151,7 @@ export function useMangroveBiomass(
       mean: numberFormat(avgBiomassFiltered),
       unit,
       year: selectedYear,
+      noData,
       config,
       location,
       isFetching,

--- a/src/containers/datasets/biomass/types.d.ts
+++ b/src/containers/datasets/biomass/types.d.ts
@@ -57,6 +57,7 @@ export type BiomassData = {
   year: number;
   config: ChartConfig;
   location: string;
+  noData: boolean;
 };
 
 export type ColorKeysTypes = {

--- a/src/containers/datasets/biomass/widget.tsx
+++ b/src/containers/datasets/biomass/widget.tsx
@@ -22,11 +22,8 @@ const BiomassWidget = () => {
     setIsCanceled(true);
   }, []);
 
-  const { year, mean, unit, config, isFetching, location, refetch, isError } = useMangroveBiomass(
-    {},
-    { enabled: !isCanceled },
-    handleQueryCancellation
-  );
+  const { year, mean, unit, config, isFetching, location, refetch, isError, noData } =
+    useMangroveBiomass({}, { enabled: !isCanceled }, handleQueryCancellation);
 
   if (year !== defaultYear) setYear(year);
 
@@ -44,6 +41,7 @@ const BiomassWidget = () => {
 
   const { legend } = config;
 
+  if (noData) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <div className="flex flex-col items-center space-y-4">

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -99,6 +99,7 @@ export function useMangroveBlueCarbon(
     ...queryOptions,
   });
   const { data } = query;
+  const noData = !data?.data?.length;
 
   return useMemo(() => {
     const orderedData = orderBy(
@@ -207,6 +208,7 @@ export function useMangroveBlueCarbon(
       soc: formatMillion(soc),
       config,
       location,
+      noData,
     } satisfies BlueCarbon;
 
     return {

--- a/src/containers/datasets/blue-carbon/types.d.ts
+++ b/src/containers/datasets/blue-carbon/types.d.ts
@@ -43,4 +43,5 @@ export type BlueCarbon = {
   config: ChartConfig;
   location: string;
   metadata?: Metadata;
+  noData: boolean;
 };

--- a/src/containers/datasets/blue-carbon/widget.tsx
+++ b/src/containers/datasets/blue-carbon/widget.tsx
@@ -37,7 +37,9 @@ const BlueCarbonWidget = () => {
     setIsCanceled(false);
   }, [refetch]);
 
-  const { location, agb, toc, soc, config } = data;
+  const { location, agb, toc, soc, config, noData } = data;
+
+  if (noData) return null;
 
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>

--- a/src/containers/datasets/carbon-market-potential/hooks.tsx
+++ b/src/containers/datasets/carbon-market-potential/hooks.tsx
@@ -86,6 +86,7 @@ export function useCarbonMarketPotential(
     }
   );
   const { isLoading, isFetched, isPlaceholderData, data } = query;
+  const noData = !data?.data?.length;
 
   const investibleBlueCarbonValue = useMemo(
     () => data?.data?.find((d) => d.label === label)?.value,
@@ -186,6 +187,7 @@ export function useCarbonMarketPotential(
   const DATA = useMemo(
     () =>
       ({
+        noData,
         location,
         labels,
         units,

--- a/src/containers/datasets/carbon-market-potential/types.d.ts
+++ b/src/containers/datasets/carbon-market-potential/types.d.ts
@@ -23,6 +23,7 @@ export type Data = {
 };
 
 export type CarbonMarketPotentialData = {
+  noData: boolean;
   data: Data[];
   location: string;
   labels: string[];

--- a/src/containers/datasets/carbon-market-potential/widget.tsx
+++ b/src/containers/datasets/carbon-market-potential/widget.tsx
@@ -31,7 +31,9 @@ const CarbonMarketPotentialWidget = () => {
     label,
   });
 
-  const { location, units, labels, config, investibleBlueCarbonValue } = data;
+  const { noData, location, units, labels, config, investibleBlueCarbonValue } = data;
+
+  if (noData) return null;
 
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>

--- a/src/containers/datasets/drivers-change/hooks.tsx
+++ b/src/containers/datasets/drivers-change/hooks.tsx
@@ -58,6 +58,7 @@ export function useMangroveDriversChange(
   });
 
   const { data, isLoading, isFetched, isPlaceholderData } = query;
+  const noData = !data?.data?.length;
 
   return useMemo(() => {
     const colorKeys = getColorKeys(data?.data);
@@ -93,6 +94,7 @@ export function useMangroveDriversChange(
     };
 
     return {
+      noData,
       config,
       primaryDriver,
       isLoading,

--- a/src/containers/datasets/drivers-change/types.d.ts
+++ b/src/containers/datasets/drivers-change/types.d.ts
@@ -47,6 +47,7 @@ type ChartConfig = {
 };
 
 export type DriversChangeData = {
+  noData: boolean;
   primaryDriver: string;
   isLoading: boolean;
   isFetched: boolean;

--- a/src/containers/datasets/drivers-change/widget.tsx
+++ b/src/containers/datasets/drivers-change/widget.tsx
@@ -6,10 +6,13 @@ import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 
 const DriversChangeWidget = () => {
-  const { primaryDriver, config, isLoading, location, isFetched, isPlaceholderData } =
+  const { noData, primaryDriver, config, isLoading, location, isFetched, isPlaceholderData } =
     useMangroveDriversChange();
 
   const { legend } = config;
+
+  if (noData) return null;
+
   return (
     primaryDriver && (
       <div className={WIDGET_CARD_WRAPER_STYLE}>

--- a/src/containers/datasets/emissions-mitigation/hooks.tsx
+++ b/src/containers/datasets/emissions-mitigation/hooks.tsx
@@ -129,6 +129,7 @@ export function useMangroveEmissionsMitigation(
   });
 
   const { data } = query;
+  const noData = !data?.data?.length;
 
   const DATA = useMemo(() => {
     const COLOR_RAMP = chroma
@@ -209,6 +210,7 @@ export function useMangroveEmissionsMitigation(
 
     return {
       location,
+      noData,
       config,
     } satisfies emissionsMitigationData;
   }, [query, data]);

--- a/src/containers/datasets/emissions-mitigation/types.d.ts
+++ b/src/containers/datasets/emissions-mitigation/types.d.ts
@@ -8,6 +8,7 @@ export type Data = {
 export type emissionsMitigationData = {
   config: Config;
   location: string;
+  noData: boolean;
 };
 
 export type Metadata = {

--- a/src/containers/datasets/emissions-mitigation/widget.tsx
+++ b/src/containers/datasets/emissions-mitigation/widget.tsx
@@ -22,8 +22,11 @@ const EmissionsMitigationWidget = () => {
       setFilteredIndicators(updatedIndicators);
     }
   };
-  const { config, location } = data;
+  const { config, location, noData } = data;
   const { legend, ...restConfig } = config;
+
+  if (noData) return null;
+
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading

--- a/src/containers/datasets/habitat-change/hooks.tsx
+++ b/src/containers/datasets/habitat-change/hooks.tsx
@@ -76,6 +76,8 @@ export function useMangroveHabitatChange(
   });
 
   const { data } = query;
+  const noData = !data?.data?.length;
+
   return useMemo(() => {
     const years = data?.metadata?.years;
     const unit = data?.metadata?.units?.[0]?.value || [];
@@ -253,6 +255,7 @@ export function useMangroveHabitatChange(
       currentStartYear,
       currentEndYear,
       config: CONFIG,
+      noData,
     };
   }, [query, data]);
 }

--- a/src/containers/datasets/habitat-change/widget.tsx
+++ b/src/containers/datasets/habitat-change/widget.tsx
@@ -51,9 +51,11 @@ const HabitatExtent = () => {
     currentEndYear,
     isFetched,
     isPlaceholderData,
+    noData,
   } = useMangroveHabitatChange({ startYear, endYear, limit });
 
   const isLoading = false;
+  if (noData) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -91,6 +91,8 @@ export function useMangroveHabitatExtent(
 
   const { data } = query;
 
+  const noData = !data?.data?.length;
+
   const { unit, year } = params;
   const DATA = useMemo(() => {
     const metadata = data.metadata;
@@ -193,6 +195,7 @@ export function useMangroveHabitatExtent(
       defaultYear: currentYear,
       unitOptions,
       defaultUnitLinearCoverage,
+      noData,
     };
   }, [data, unit, year]);
 

--- a/src/containers/datasets/habitat-extent/types.d.ts
+++ b/src/containers/datasets/habitat-extent/types.d.ts
@@ -81,4 +81,5 @@ export type ExtentData = {
   unitOptions: string[];
   defaultUnitLinearCoverage: string;
   location: string;
+  noData: boolean;
 };

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -65,6 +65,7 @@ const HabitatExtent = () => {
     unitOptions,
     config,
     defaultUnitLinearCoverage,
+    noData,
   } = data;
 
   const handleClick = useCallback(
@@ -73,6 +74,8 @@ const HabitatExtent = () => {
     },
     [setYear]
   );
+
+  if (noData) return null;
 
   return (
     <>

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -39,7 +39,7 @@ const getColorKeys = (data: Data[]) =>
   }, {} satisfies ColorKeysTypes);
 
 const getData = (data: Data[], unit, COLORS_BY_INDICATOR: ColorKeysTypes) => {
-  if (!data || !data.length) return null;
+  if (!data || !data?.length) return null;
   const barsValues = data?.map(({ value }) => value);
   const total = barsValues.reduce((previous, current) => current + previous);
   return [
@@ -136,6 +136,8 @@ export function useMangroveHeight(
   });
 
   const { data } = query;
+  const noData = !data?.data?.length;
+
   const mean = data?.metadata?.avg_height?.[0].value;
   const unit = data?.metadata?.units?.value;
   const years = data?.metadata?.year;
@@ -215,6 +217,7 @@ export function useMangroveHeight(
       year,
       legend: legendData,
       config,
+      noData,
     };
   }, [query, data]);
 }

--- a/src/containers/datasets/height/widget.tsx
+++ b/src/containers/datasets/height/widget.tsx
@@ -28,7 +28,7 @@ const HeightWidget = () => {
     });
   }, [queryClient]);
 
-  const { location, legend, isFetching, isError, data, mean, unit, year, config, refetch } =
+  const { noData, location, legend, isFetching, isError, data, mean, unit, year, config, refetch } =
     useMangroveHeight({}, { enabled: !isCanceled }, handleQueryCancellation);
 
   const handleTryAgain = useCallback(async () => {
@@ -36,6 +36,7 @@ const HeightWidget = () => {
     setIsCanceled(false);
   }, [refetch]);
 
+  if (noData) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <div className="flex flex-col items-center space-y-4">

--- a/src/containers/datasets/international-status/hooks.tsx
+++ b/src/containers/datasets/international-status/hooks.tsx
@@ -78,6 +78,7 @@ export function useMangroveInternationalStatus(
   );
 
   const { data, isLoading, isFetched, isPlaceholderData } = query;
+  const noData = !Object.values(!data?.data?.[0]).length;
 
   return useMemo(() => {
     const {

--- a/src/containers/datasets/international-status/hooks.tsx
+++ b/src/containers/datasets/international-status/hooks.tsx
@@ -130,6 +130,7 @@ export function useMangroveInternationalStatus(
       isLoading,
       isFetched,
       isPlaceholderData,
+      noData,
     };
   }, [data]);
 }

--- a/src/containers/datasets/international-status/types.d.ts
+++ b/src/containers/datasets/international-status/types.d.ts
@@ -15,7 +15,6 @@ export type Data = {
   isLoading: boolean;
   isFetched: boolean;
   isPlaceholderData: boolean;
-  noData: boolean;
 };
 
 type Metadata = {
@@ -55,4 +54,5 @@ export type InternationalStatusTypes = {
   isLoading: boolean;
   isFetched: boolean;
   isPlaceholderData: boolean;
+  noData: boolean;
 };

--- a/src/containers/datasets/international-status/types.d.ts
+++ b/src/containers/datasets/international-status/types.d.ts
@@ -15,6 +15,7 @@ export type Data = {
   isLoading: boolean;
   isFetched: boolean;
   isPlaceholderData: boolean;
+  noData: boolean;
 };
 
 type Metadata = {

--- a/src/containers/datasets/international-status/widget.tsx
+++ b/src/containers/datasets/international-status/widget.tsx
@@ -33,10 +33,11 @@ const InternationalStatus = () => {
     isLoading,
     isFetched,
     isPlaceholderData,
+    noData,
   } = useMangroveInternationalStatus();
 
   const apostrophe = location?.[location?.length - 1] === 's' ? "'" : "'s";
-
+  if (noData) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -40,7 +40,7 @@ const getFormat = (v) => {
 };
 
 const getWidgetData = (data: Data[], unit = '') => {
-  if (!data.length) return null;
+  if (!data?.length) return null;
   const firstYear = Math.min(...data.map((d) => d.year));
   const netChangeValues = data.map((d) => d.net_change);
   netChangeValues.shift();
@@ -141,6 +141,8 @@ export function useMangroveNetChange(
 
   const { data } = query;
 
+  const noData = !data?.data?.length;
+
   return useMemo(() => {
     const years = data.metadata?.year.sort();
     const unit = selectedUnit || data.metadata?.units.net_change;
@@ -206,6 +208,7 @@ export function useMangroveNetChange(
       netChange: numberFormat(Math.abs(change)),
       direction,
       unitOptions,
+      noData,
       ...query,
     };
   }, [data, query, startYear, endYear, location, selectedUnit]);

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -55,6 +55,7 @@ const NetChangeWidget = () => {
     currentStartYear,
     refetch,
     isError,
+    noData,
   } = useMangroveNetChange(
     {
       selectedUnit,
@@ -70,6 +71,7 @@ const NetChangeWidget = () => {
     await refetch();
   }, [refetch]);
 
+  if (noData) return null;
   return (
     <div>
       <div className="flex flex-col items-center space-y-4">

--- a/src/containers/datasets/protection/widget.tsx
+++ b/src/containers/datasets/protection/widget.tsx
@@ -20,7 +20,7 @@ import { useMangroveProtectedAreas } from './hooks';
 const Protection = () => {
   const [selectedUnit, setUnit] = useState('ha');
   const { data, isFetched, isFetching } = useMangroveProtectedAreas({ unit: selectedUnit });
-
+  if (!data?.length) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading visible={isFetching && !isFetched} iconClassName="flex w-10 h-10 m-auto my-10" />

--- a/src/containers/datasets/restoration-sites/widget.tsx
+++ b/src/containers/datasets/restoration-sites/widget.tsx
@@ -60,7 +60,7 @@ const RestorationSitesWidget = () => {
     setMapFilters({ ...filters, [key]: updatedFilters });
   };
 
-  if (!data.data?.length) return null;
+  if (!filtersData) return null;
 
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>

--- a/src/containers/datasets/restoration-sites/widget.tsx
+++ b/src/containers/datasets/restoration-sites/widget.tsx
@@ -60,6 +60,8 @@ const RestorationSitesWidget = () => {
     setMapFilters({ ...filters, [key]: updatedFilters });
   };
 
+  if (!data.data?.length) return null;
+
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-20" />

--- a/src/containers/datasets/restoration/fisheries/widget.tsx
+++ b/src/containers/datasets/restoration/fisheries/widget.tsx
@@ -12,17 +12,19 @@ import SHRIMP_SVG from 'svgs/fisheries/shrimp.svg?sprite';
 
 import { useMangroveEcosystemServices } from './hooks';
 
+const INDICATOR_ICONS = {
+  shrimp: SHRIMP_SVG,
+  fish: FISH_SVG,
+  crab: CRAB_SVG,
+  bivalve: BIVALVE_SVG,
+};
+
 const PotentialBenefitsToFisheries = () => {
   const { isFetched, isFetching, data } = useMangroveEcosystemServices({
     slug: 'fisheries',
   });
 
-  const INDICATOR_ICONS = {
-    shrimp: SHRIMP_SVG,
-    fish: FISH_SVG,
-    crab: CRAB_SVG,
-    bivalve: BIVALVE_SVG,
-  };
+  if (!data?.length) return null;
   return (
     <div
       className={cn({

--- a/src/containers/datasets/restoration/loss/widget.tsx
+++ b/src/containers/datasets/restoration/loss/widget.tsx
@@ -46,6 +46,7 @@ const CustomizedContent = (props: TreemapNode & { data: ChartData[] }) => {
 const LossWidget = () => {
   const { data, isFetched, isFetching } = useMangroveDegradationAndLoss();
 
+  if (!data) return null;
   const config = {
     width: 175,
     height: 175,

--- a/src/containers/datasets/restoration/overview/mean-restoration/widget.tsx
+++ b/src/containers/datasets/restoration/overview/mean-restoration/widget.tsx
@@ -10,6 +10,7 @@ import OverviewChart from './chart';
 const MeanRestoration = () => {
   const { isLoading, data, isFetched, isFetching, isError } = useMangroveRestoration();
 
+  if (!data) return null;
   return (
     <div
       className={cn({

--- a/src/containers/datasets/restoration/overview/restorable-areas/widget.tsx
+++ b/src/containers/datasets/restoration/overview/restorable-areas/widget.tsx
@@ -8,7 +8,7 @@ import { WIDGET_CARD_WRAPER_STYLE } from 'styles/widgets';
 import RestorableAreasChart from './chart';
 const RestorableAreas = () => {
   const { isLoading, isFetched, isFetching, data } = useMangroveRestoration();
-
+  if (!data) return null;
   return (
     <div
       className={cn({

--- a/src/containers/datasets/restoration/restoration-value/widget.tsx
+++ b/src/containers/datasets/restoration/restoration-value/widget.tsx
@@ -7,6 +7,8 @@ const RestorationValue = () => {
   const { isFetched, isFetching, data } = useMangroveEcosystemServices({
     slug: 'restoration-value',
   });
+
+  if (!data || !data?.length) return null;
   return (
     <div className="relative">
       <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />

--- a/src/containers/datasets/species-distribution/hooks.tsx
+++ b/src/containers/datasets/species-distribution/hooks.tsx
@@ -75,13 +75,17 @@ export function useMangroveSpecies(
   const { data } = query;
   const { data: worldwideData } = worldwideQuery;
 
+  const noData = !data?.data?.total;
+
   return useMemo(() => {
     const total = data.data.total;
     const worldwideTotal = worldwideData.data.total;
     const legend = [1, Math.ceil(worldwideTotal / 2), worldwideTotal];
     return {
+      noData,
       location,
       total: total,
+      worldwideTotal,
       legend,
       ...query,
     };

--- a/src/containers/datasets/species-distribution/types.d.ts
+++ b/src/containers/datasets/species-distribution/types.d.ts
@@ -30,8 +30,10 @@ export type DataResponse = {
   metadata: Metadata;
 };
 export type SpeciesData = {
+  noData: boolean;
   location: string;
   total: number;
+  worldwideTotal: number;
   legend: number[];
   isLoading: boolean;
   isFetched: boolean;

--- a/src/containers/datasets/species-distribution/widget.tsx
+++ b/src/containers/datasets/species-distribution/widget.tsx
@@ -13,17 +13,28 @@ import { useMangroveSpecies } from './hooks';
 const SpeciesDistribution = () => {
   const [lineChartWidth, setLineChartWidth] = useState(0);
 
-  const { location, total, legend, isLoading, isFetched, isPlaceholderData } = useMangroveSpecies();
+  const {
+    noData,
+    location,
+    total,
+    legend,
+    worldwideTotal,
+    isLoading,
+    isFetched,
+    isPlaceholderData,
+  } = useMangroveSpecies();
   const isWorldwide = location === 'Worldwide';
   // const total = data?.total;
   const ref = createRef<HTMLDivElement>();
-  const trianglePosition = (lineChartWidth * total) / 100 - 7; // substract icon size
+  const trianglePosition = (total * lineChartWidth) / worldwideTotal - 11; // substract icon size
   // fires synchronously after all DOM mutations.
   useLayoutEffect(() => {
     if (ref && ref.current && ref.current.offsetWidth) {
       setLineChartWidth(ref?.current?.offsetWidth);
     }
   }, [ref]);
+
+  if (noData) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading
@@ -35,8 +46,8 @@ const SpeciesDistribution = () => {
           {/* mangrove sentence styles, create constant */}
           <p className="text-lg font-light text-black/85 first-letter:uppercase">
             <span className="font-bold"> {location}</span> has{' '}
-            <span className="font-bold">{total}</span> of mangroves distributed by country as map
-            shows.
+            <span className="font-bold">{total}</span> species of mangroves distributed by country
+            as map shows.
           </p>
           <div className="relative w-full font-sans text-sm text-black/85 ">
             <p className="w-full text-end opacity-50">total species</p>

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -55,6 +55,8 @@ const SpeciesLocation = () => {
   );
 
   const totalLocations = useMemo(() => specieSelected?.location_ids?.length || 0, [specieSelected]);
+
+  if (!species.length) return null;
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -12,10 +12,12 @@ import { WidgetSlugType } from 'types/widget';
 
 import { getWidgetActive } from './selector';
 
+type ChildrenType = ReactElement<any> & { type?: () => null };
+
 type WidgetLayoutProps = {
   id: WidgetSlugType;
   title: string;
-  children: ReactElement | null;
+  children: ChildrenType | null;
   className?: string;
 };
 

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import React, { useCallback, ReactElement } from 'react';
 
 import cn from 'lib/classnames';
 
@@ -15,11 +15,11 @@ import { getWidgetActive } from './selector';
 type WidgetLayoutProps = {
   id: WidgetSlugType;
   title: string;
-  children: React.ReactNode;
+  children: ReactElement | null;
   className?: string;
 };
 
-const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
+const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps): null | any => {
   const { children, title, id, className } = props;
 
   const isWidgetActive = useRecoilValue(getWidgetActive(id));
@@ -42,6 +42,8 @@ const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps) =>
       marginBottom: '12px',
     },
   };
+
+  if (Boolean(children.type() === null)) return null;
 
   return (
     <AnimatePresence>


### PR DESCRIPTION
## Hide widgets with no data for a given location

### Overview

_This PR prevents charts to render with no data._

### Testing instructions

_Select different locations (check-in [prod](https://www.globalmangrovewatch.org/?activeLayers=mangrove_extent&category=distribution_and_change&zoom=2) to be sure that the selected locations don't have those widgets )._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-592?atlOrigin=eyJpIjoiMjYyMjY0Yjc0NTBjNGNkN2FiYjI4MTdhMzIyOTFiMGEiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
