### PR TITLE
fixes labels on map and layer collocation

### DIFF
--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -444,19 +444,22 @@ export function useSources(): SourceProps[] {
       data: `https://us-central1-mangrove-atlas-246414.cloudfunctions.net/fetch-alerts-heatmap?start_date=${
         startDate?.value || ''
       }&end_date=${endDate?.value || ''}${
-        location_id && location_id !== 'worldwide' ? '&location_id={{location_id}}' : ''
+        location_id && location_id !== 'worldwide' ? `&location_id=${location_id}` : ''
       }`,
     },
   ];
 }
 
-export function useLayers(): { 'alerts-heatmap': LayerProps[]; 'monitored-alerts': LayerProps[] } {
+export function useLayers({ id }: { id: LayerProps['id'] }): {
+  'alerts-heatmap': LayerProps[];
+  'monitored-alerts': LayerProps[];
+} {
   return {
     'alerts-heatmap': [
       {
-        id: 'alerts-style-heat',
+        id,
         type: 'heatmap',
-        source: 'alerts',
+        source: 'alerts-heatmap',
         maxzoom: 12,
         paint: {
           // Increase the heatmap weight based on frequency and property magnitude
@@ -493,7 +496,7 @@ export function useLayers(): { 'alerts-heatmap': LayerProps[]; 'monitored-alerts
         },
       },
       {
-        id: 'alerts-style-point',
+        id: `${id}-points`,
         type: 'circle',
         source: 'alerts',
         minzoom: 0,
@@ -528,7 +531,7 @@ export function useLayers(): { 'alerts-heatmap': LayerProps[]; 'monitored-alerts
     ],
     'monitored-alerts': [
       {
-        id: 'monitored-alerts',
+        id: `${id}-line`,
         type: 'line',
         source: 'monitored-alerts',
         'source-layer': 'alert_region_tiles',
@@ -536,17 +539,6 @@ export function useLayers(): { 'alerts-heatmap': LayerProps[]; 'monitored-alerts
         paint: {
           'line-color': '#00857F',
           'line-width': 1,
-        },
-      },
-      {
-        id: 'monitored-alerts',
-        type: 'fill',
-        source: 'monitored-alerts',
-        'source-layer': 'alert_region_tiles',
-        minzoom: 0,
-        paint: {
-          'fill-color': '#00857F',
-          'fill-outline-color': '#00857F',
         },
       },
     ],

--- a/src/containers/datasets/alerts/layer.tsx
+++ b/src/containers/datasets/alerts/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSources } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCES = useSources();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCES || !LAYERS) return null;
   return SOURCES.map((SOURCE) => (

--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -177,9 +177,9 @@ export function useSource(): SourceProps {
     maxzoom: 12,
   };
 }
-export function useLayer(): LayerProps {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps {
   return {
-    id: 'aboveground_biomass-layer',
+    id,
     type: 'raster',
   };
 }

--- a/src/containers/datasets/biomass/layer.tsx
+++ b/src/containers/datasets/biomass/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayer, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYER = useLayer();
+  const LAYER = useLayer({ id });
 
   if (!SOURCE || !LAYER) return null;
   return (

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -227,9 +227,9 @@ export function useSource(): SourceProps {
     maxzoom: 12,
   };
 }
-export function useLayer(): LayerProps {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps {
   return {
-    id: 'blue-carbon-layer',
+    id,
     type: 'raster',
   };
 }

--- a/src/containers/datasets/blue-carbon/layer.tsx
+++ b/src/containers/datasets/blue-carbon/layer.tsx
@@ -4,14 +4,14 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayer, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYER = useLayer();
+  const LAYER = useLayer({ id });
 
   if (!SOURCE || !LAYER) return null;
   return (
     <Source {...SOURCE}>
-      <Layer {...LAYER} beforeId={beforeId} />
+      <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
     </Source>
   );
 };

--- a/src/containers/datasets/country/hooks.tsx
+++ b/src/containers/datasets/country/hooks.tsx
@@ -8,10 +8,10 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: 'selected-eez-land-v2-201410-line',
+      id: `${id}-line`,
       type: 'line',
       source: 'country-boundaries',
       'source-layer': 'gadm_eez_location_v3',
@@ -20,7 +20,7 @@ export function useLayers(): LayerProps[] {
       },
     },
     {
-      id: 'selected-eez-land-v2-201410',
+      id,
       type: 'fill',
       source: 'country-boundaries',
       'source-layer': 'gadm_eez_location_v3',

--- a/src/containers/datasets/country/layer.tsx
+++ b/src/containers/datasets/country/layer.tsx
@@ -6,9 +6,9 @@ import { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-export const MangrovesCountryBoundariesLayer = ({ beforeId }: LayerProps) => {
+export const MangrovesCountryBoundariesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCE || !LAYERS) return null;
 

--- a/src/containers/datasets/drivers-change/hooks.tsx
+++ b/src/containers/datasets/drivers-change/hooks.tsx
@@ -111,7 +111,7 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   const PRIMARY_DRIVERS = [
     { id: 'Erosion', color: '#CC61B0' },
     { id: 'Episodic Disturbances', color: '#5D69B1' },
@@ -126,7 +126,7 @@ export function useLayers(): LayerProps[] {
 
   return [
     {
-      id: 'mangrove_drivers_change',
+      id,
       type: 'fill',
       source: 'main_loss_drivers',
       'source-layer': 'main_loss_drivers',
@@ -136,7 +136,7 @@ export function useLayers(): LayerProps[] {
       },
     },
     {
-      id: 'mangrove_drivers_change-line',
+      id: `${id}-line`,
       type: 'line',
       source: 'main_loss_drivers',
       'source-layer': 'main_loss_drivers',

--- a/src/containers/datasets/drivers-change/layer.tsx
+++ b/src/containers/datasets/drivers-change/layer.tsx
@@ -6,15 +6,14 @@ import type { LayerProps } from 'types/layers';
 
 const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCE || !LAYERS) return null;
 
-  // !TODO: READ id from layer manager
   return (
     <Source {...SOURCE}>
       {LAYERS.map((LAYER) => (
-        <Layer key={id} id={`${id}-${LAYER.id}`} {...LAYER} beforeId={beforeId} />
+        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
       ))}
     </Source>
   );

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -212,10 +212,10 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(year: number): LayerProps[] {
+export function useLayers({ year, id }: { year: number; id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: `habitat_extent_${year}`,
+      id,
       type: 'fill',
       source: 'habitat_extent',
       'source-layer': `mng_mjr_${year}`,
@@ -228,7 +228,7 @@ export function useLayers(year: number): LayerProps[] {
       },
     },
     {
-      id: `habitat_extent_${year}_line`,
+      id: `${id}_line`,
       type: 'line',
       source: 'habitat_extent',
       'source-layer': `mng_mjr_${year}`,

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -4,11 +4,12 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const year = 2020;
   const SOURCE = useSource();
-  const LAYERS = useLayers(year);
+  const LAYERS = useLayers({ year, id });
   if (!SOURCE || !LAYERS) return null;
+
   return (
     <Source key={SOURCE.id} {...SOURCE}>
       {LAYERS.map((LAYER) => (

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -232,9 +232,9 @@ export function useSource(years: number[]): SourceProps {
     maxzoom: 12,
   };
 }
-export function useLayer(): LayerProps {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps {
   return {
-    id: 'mangrove_canopy_height-v3-layer',
+    id,
     type: 'raster',
   };
 }

--- a/src/containers/datasets/height/layer.tsx
+++ b/src/containers/datasets/height/layer.tsx
@@ -5,14 +5,14 @@ import type { LayerProps } from 'types/layers';
 import { years } from './constants';
 import { useLayer, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource(years);
-  const LAYER = useLayer();
+  const LAYER = useLayer({ id });
 
   if (!SOURCE || !LAYER) return null;
   return (
     <Source {...SOURCE}>
-      <Layer {...LAYER} beforeId={beforeId} />
+      <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
     </Source>
   );
 };

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -211,7 +211,7 @@ export function useMangroveNetChange(
   }, [data, query, startYear, endYear, location, selectedUnit]);
 }
 
-export function useSources(years): SourceProps[] {
+export function useSources(years: number[]): SourceProps[] {
   return years.map((year) => ({
     id: `net-change-${year}`,
     type: 'raster',
@@ -223,9 +223,9 @@ export function useSources(years): SourceProps[] {
     maxZoom: 12,
   }));
 }
-export function useLayer(): LayerProps {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps {
   return {
-    id: 'net-change-layer',
+    id,
     type: 'raster',
   };
 }

--- a/src/containers/datasets/net-change/layer.tsx
+++ b/src/containers/datasets/net-change/layer.tsx
@@ -7,9 +7,9 @@ import { LayerProps } from 'types/layers';
 import { years } from './constants';
 import { useLayer, useSources } from './hooks';
 
-export const MangrovesLayer = ({ beforeId }: LayerProps) => {
+export const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCES = useSources(years);
-  const LAYER = useLayer();
+  const LAYER = useLayer({ id });
 
   if (!SOURCES || !LAYER) return null;
 
@@ -17,7 +17,7 @@ export const MangrovesLayer = ({ beforeId }: LayerProps) => {
     <>
       {SOURCES.map((SOURCE) => (
         <Source key={SOURCE.id} {...SOURCE}>
-          <Layer {...LAYER} beforeId={beforeId} />
+          <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
         </Source>
       ))}
     </>

--- a/src/containers/datasets/protected-areas/hooks.tsx
+++ b/src/containers/datasets/protected-areas/hooks.tsx
@@ -8,10 +8,10 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: 'selected-wdpa-polygons',
+      id,
       type: 'fill',
       source: 'composite',
       'source-layer': 'wdpaclientjuly2022',
@@ -23,7 +23,7 @@ export function useLayers(): LayerProps[] {
       },
     },
     {
-      id: 'selected-wdpa-polygons-border',
+      id: `${id}-border`,
       type: 'line',
       source: 'composite',
       'source-layer': 'wdpaclientjuly2022',
@@ -34,7 +34,7 @@ export function useLayers(): LayerProps[] {
       },
     },
     {
-      id: 'selected-wdpa-polygons-label',
+      id: `${id}-label`,
       type: 'symbol',
       metadata: {
         'mapbox:group': '1f4439315750c8010c95dfe168ea659a',

--- a/src/containers/datasets/protected-areas/layer.tsx
+++ b/src/containers/datasets/protected-areas/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesProtectedAreasLayer = ({ beforeId }: LayerProps) => {
+const MangrovesProtectedAreasLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCE || !LAYERS) return null;
   return (

--- a/src/containers/datasets/protection/hooks.tsx
+++ b/src/containers/datasets/protection/hooks.tsx
@@ -203,10 +203,10 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: 'protection-layer',
+      id,
       source: 'protected-areas',
       'source-layer': 'protected_area_pct',
       type: 'fill',

--- a/src/containers/datasets/protection/layer.tsx
+++ b/src/containers/datasets/protection/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesProtectedAreasLayer = ({ beforeId }: LayerProps) => {
+const MangrovesProtectedAreasLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCE || !LAYERS) return null;
   return (

--- a/src/containers/datasets/restoration-sites/hooks.tsx
+++ b/src/containers/datasets/restoration-sites/hooks.tsx
@@ -119,10 +119,10 @@ export function useSource(): SourceProps {
     cluster: true,
   };
 }
-export function useLayer(): LayerProps[] {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: 'restoration-sites-clusters',
+      id: `${id}-clusters`,
       type: 'circle',
       source: 'restoration-sites',
       filter: ['has', 'point_count'],
@@ -135,7 +135,7 @@ export function useLayer(): LayerProps[] {
     },
 
     {
-      id: 'restoration-sites',
+      id,
       type: 'circle',
       source: 'restoration-sites',
       filter: ['!', ['has', 'point_count']],
@@ -147,7 +147,7 @@ export function useLayer(): LayerProps[] {
       },
     },
     {
-      id: 'restoration-sites-cluster-count',
+      id: `${id}-cluster-count`,
       type: 'symbol',
       source: 'restoration-sites',
       filter: ['has', 'point_count'],

--- a/src/containers/datasets/restoration-sites/layer.tsx
+++ b/src/containers/datasets/restoration-sites/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayer, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayer();
+  const LAYERS = useLayer({ id });
 
   if (!SOURCE || !LAYERS) return null;
   return (

--- a/src/containers/datasets/restoration/hooks.tsx
+++ b/src/containers/datasets/restoration/hooks.tsx
@@ -7,10 +7,10 @@ export function useSource(): SourceProps {
     url: 'mapbox://globalmangrovewatch.7rr6p3ir',
   };
 }
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   return [
     {
-      id: 'mangrove_restoration',
+      id,
       type: 'fill',
       source: 'mangrove_restoration',
       'source-layer': 'MOW_Global_Mangrove_Restoration_202212',

--- a/src/containers/datasets/restoration/layer.tsx
+++ b/src/containers/datasets/restoration/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
   if (!SOURCE || !LAYERS) return null;
   return (
     <Source {...SOURCE}>

--- a/src/containers/datasets/species-distribution/hooks.tsx
+++ b/src/containers/datasets/species-distribution/hooks.tsx
@@ -96,11 +96,12 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayers(): LayerProps[] {
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
   const maxValue = 51;
+
   return [
     {
-      id: 'Species_richness',
+      id,
       'source-layer': 'Species_richness',
       // filter: ['==', 'sp_count', '<0'],
       type: 'fill',
@@ -159,7 +160,7 @@ export function useLayers(): LayerProps[] {
       },
     },
     {
-      id: 'Species_location-layer-border',
+      id: `${id}-border`,
       'source-layer': 'Species_richness',
       type: 'line',
       paint: {

--- a/src/containers/datasets/species-distribution/layer.tsx
+++ b/src/containers/datasets/species-distribution/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesSpeciesDistributionLayer = ({ beforeId }: LayerProps) => {
+const MangrovesSpeciesDistributionLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayers();
+  const LAYERS = useLayers({ id });
 
   if (!SOURCE || !LAYERS) return null;
   return (

--- a/src/containers/datasets/species-location/hooks.tsx
+++ b/src/containers/datasets/species-location/hooks.tsx
@@ -57,7 +57,7 @@ export function useSource(): SourceProps {
   };
 }
 
-export function useLayer(): LayerProps[] {
+export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps[] {
   const data = useRecoilValue(SpeciesLocationState);
   const locationsIds = data?.location_ids;
   const { data: locations } = useLocations();
@@ -70,7 +70,7 @@ export function useLayer(): LayerProps[] {
 
   return [
     {
-      id: 'Species_location-layer-border',
+      id: `${id}-border`,
       'source-layer': 'Species_richness',
       type: 'line',
       filter: ['any', ...dataFiltered?.map((id) => ['in', id, ['get', 'location_idn']])],
@@ -81,7 +81,7 @@ export function useLayer(): LayerProps[] {
       },
     },
     {
-      id: 'Species_location-layer',
+      id,
       'source-layer': 'Species_richness',
       type: 'fill',
       filter: ['any', ...dataFiltered?.map((id) => ['in', id, ['get', 'location_idn']])],

--- a/src/containers/datasets/species-location/layer.tsx
+++ b/src/containers/datasets/species-location/layer.tsx
@@ -4,9 +4,9 @@ import type { LayerProps } from 'types/layers';
 
 import { useLayer, useSource } from './hooks';
 
-const MangrovesSpeciesLocationLayer = ({ beforeId }: LayerProps) => {
+const MangrovesSpeciesLocationLayer = ({ beforeId, id }: LayerProps) => {
   const SOURCE = useSource();
-  const LAYERS = useLayer();
+  const LAYERS = useLayer({ id });
 
   if (!SOURCE || !LAYERS) return null;
   return (

--- a/src/containers/datasets/species-threatened/hooks.tsx
+++ b/src/containers/datasets/species-threatened/hooks.tsx
@@ -1,7 +1,5 @@
 import { useMemo } from 'react';
 
-import type { SourceProps, LayerProps } from 'react-map-gl';
-
 import groupBy from 'lodash-es/groupBy';
 
 import { useRouter } from 'next/router';
@@ -137,39 +135,4 @@ export function useMangroveSpecies(
       isPlaceholderData,
     } satisfies SpeciesData;
   }, [DATA, isLoading, isFetched, isPlaceholderData]);
-}
-
-export function useSource(): SourceProps {
-  return {
-    id: 'Species_richness',
-    type: 'vector',
-    url: 'mapbox://globalmangrovewatch.bkpfnh68',
-  };
-}
-
-export function useLayer(): LayerProps {
-  const minValue = 0;
-  const maxValue = 51;
-
-  return {
-    id: 'Species_richness',
-    'source-layer': 'Species_richness',
-    type: 'fill',
-    paint: {
-      'fill-color': [
-        'interpolate',
-        ['linear'],
-        ['get', 'sp_count'],
-        minValue,
-        '#F9FDB7',
-        maxValue,
-        '#205272',
-      ],
-      'fill-outline-color': 'blue',
-      'fill-opacity': 1,
-    },
-    layout: {
-      visibility: 'visible',
-    },
-  };
 }

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -1,41 +1,46 @@
+import { useMemo } from 'react';
+
 import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilValue } from 'recoil';
 
 import { LAYERS } from 'containers/datasets';
 
+import { WidgetSlugType } from 'types/widget';
+
+const ProtectedAreasLayer = LAYERS['protected-areas'];
+const CountryBoundariesLayer = LAYERS['country-boundaries'];
+
+const EXCLUDED_DATA_LAYERS: WidgetSlugType[] = [
+  'mangrove_habitat_extent',
+] satisfies WidgetSlugType[];
+
 const LayerManagerContainer = () => {
   const layers = useRecoilValue(activeWidgetsAtom);
+  const LAYERS_FILTERED = useMemo(
+    () => [
+      ...layers
+        .filter((layer) => !EXCLUDED_DATA_LAYERS.includes(layer) && !!LAYERS[layer])
+        .reverse(),
+      // ? the habitat extent layer is a special case where, if enabled, it will be placed always at the bottom of the layer stack we handle
+      ...(layers.includes('mangrove_habitat_extent') ? ['mangrove_habitat_extent'] : []),
+    ],
+    [layers]
+  );
 
-  // const layersSettings = useRecoilValue(layersSettingsAtom);
-  const LAYERS_FILTERED = layers.filter((layer) => !!LAYERS[layer]);
-  const ProtectedAreasLayer = LAYERS['protected-areas'];
-  const CountryBoundariesLayer = LAYERS['country-boundaries'];
   return (
     <>
       {LAYERS_FILTERED.map((layer, i) => {
         const LayerComponent = LAYERS[layer];
-        // We need to define where do we want to put the layer
-        // We want to put it before the custom-layers transparent backgrond
         const beforeId = i === 0 ? 'custom-layers' : `${LAYERS_FILTERED[i - 1]}-layer`;
 
-        return (
-          <LayerComponent
-            key={layer}
-            id={`${layer}-layer`}
-            settings={{
-              opacity: 1,
-              visibility: false,
-              expand: false,
-            }}
-            // beforeId={beforeId}
-          />
-        );
+        return <LayerComponent key={layer} id={`${layer}-layer`} beforeId={beforeId} />;
       })}
+
       {/* Countries layer */}
-      {<CountryBoundariesLayer id="country-boundaries-layer" />}
+      {<CountryBoundariesLayer id="country-boundaries-layer" beforeId="Country" />}
       {/* Protected areas layer */}
-      {<ProtectedAreasLayer id="protected-areas-layer" />}
+      {<ProtectedAreasLayer id="protected-areas-layer" beforeId="Country" />}
     </>
   );
 };


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/mangrove-atlas/assets/999124/9d60309d-fe12-44e5-afad-a702db9c3cdb)

- Fixes labels overlapped by layers.
- Now layers IDs are generated by the Layer Manager and passed as property, avoiding any possible disconnection between the Layer Manager and layer declaration.
- Fixes `location_id` parameter in `alerts-heatmap` endpoint.
- The `habitat extent` layer will be always placed at the bottom of the map regardless when it was added.



### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

https://vizzuality.atlassian.net/browse/GMW-583

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
