### PR TITLE
tooltip added to loss widget

### DIFF
--- a/src/containers/datasets/restoration/loss/chart.tsx
+++ b/src/containers/datasets/restoration/loss/chart.tsx
@@ -1,12 +1,18 @@
-import { Treemap } from 'recharts';
+import { Treemap, Tooltip, ResponsiveContainer } from 'recharts';
 
 import Legend from 'containers/legend';
 
+import CustomTooltip from './tooltip';
+
 const LossChart = ({ config, legend }) => {
   return (
-    <div className="flex flex-1 items-center justify-between pb-10">
+    <div className="grid grid-cols-2 items-center justify-between gap-4 pb-10 pt-4">
       <Legend items={legend.items} title={legend?.title} subtitle={legend?.subtitle} />
-      <Treemap {...config} />
+      <ResponsiveContainer width={'100%'} height={220}>
+        <Treemap {...config}>
+          <Tooltip content={(properties) => <CustomTooltip {...properties} />} />
+        </Treemap>
+      </ResponsiveContainer>
     </div>
   );
 };

--- a/src/containers/datasets/restoration/loss/tooltip.tsx
+++ b/src/containers/datasets/restoration/loss/tooltip.tsx
@@ -1,0 +1,22 @@
+import { numberFormat } from 'lib/format';
+const CustomTooltip = (data) => {
+  const { payload } = data;
+  if (!payload.length) return null;
+  const legendData = payload[0].payload;
+  const indicator = legendData.indicator.replaceAll('_', ' ');
+
+  return (
+    <div className="space-y-2 rounded-2xl bg-white p-4 text-sm shadow-lg">
+      <p className="first-letter:uppercase">{indicator}</p>
+      <div className="flex items-center space-x-2 whitespace-nowrap">
+        <div className="h-3 w-0.5" style={{ backgroundColor: legendData.color }} />
+        <p className="font-bold">{legendData.label}</p>
+      </div>
+      <p className="pl-3 text-xs">
+        {numberFormat(legendData.value)} {legendData.unit}
+      </p>{' '}
+    </div>
+  );
+};
+
+export default CustomTooltip;

--- a/src/containers/datasets/restoration/loss/tooltip.tsx
+++ b/src/containers/datasets/restoration/loss/tooltip.tsx
@@ -8,8 +8,8 @@ const CustomTooltip = (data) => {
   return (
     <div className="space-y-2 rounded-2xl bg-white p-4 text-sm shadow-lg">
       <p className="first-letter:uppercase">{indicator}</p>
-      <div className="flex items-center space-x-2 whitespace-nowrap">
-        <div className="h-3 w-0.5" style={{ backgroundColor: legendData.color }} />
+      <div className="flex max-w-[180px] items-start space-x-2">
+        <div className="h-4 w-0.5 " style={{ backgroundColor: legendData.color }} />
         <p className="font-bold">{legendData.label}</p>
       </div>
       <p className="pl-3 text-xs">

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -80,7 +80,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
           <div style={style} ref={registerChild}>
             <button
               type="button"
-              className="flex h-full w-full flex-1 items-end justify-between pb-2"
+              className="flex h-full w-full flex-1 items-center justify-between px-4 py-1 hover:rounded-2xl  hover:bg-brand-800 hover:bg-opacity-10"
               onClick={() => {
                 handleLocation(locationsToDisplay[index]);
               }}


### PR DESCRIPTION
## Tooltip in restoration loss widget

### Overview

This PR:
- adds a tooltip por treemap chart in the restoration loss widget
<img width="274" alt="Screenshot 2023-06-08 at 11 57 10" src="https://github.com/Vizzuality/mangrove-atlas/assets/33252015/bf0b00dc-17e2-4eeb-909e-93186dddedbb">

- adds hovering styles to locations list
<img width="533" alt="Screenshot 2023-06-08 at 11 59 30" src="https://github.com/Vizzuality/mangrove-atlas/assets/33252015/7500fb39-a5ef-41f7-93eb-d6eb5c9fe224">

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-589?atlOrigin=eyJpIjoiYzBhYWI5OWFkNDIyNDVkNWFlNzVhYzRkNGEwM2MwNzAiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
