### PR TITLE
mangrove protection: fixes layer color ramp

### DIFF
--- a/src/containers/datasets/protection/hooks.tsx
+++ b/src/containers/datasets/protection/hooks.tsx
@@ -6,11 +6,8 @@ import { useRouter } from 'next/router';
 
 import { numberFormat } from 'lib/format';
 
-import { widgetYearAtom } from 'store/widgets';
-
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { PolarViewBox } from 'recharts/types/util/types';
-import { useRecoilValue } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
 
@@ -62,7 +59,6 @@ export function useMangroveProtectedAreas(
   params?: UseParamsOptions,
   queryOptions?: UseQueryOptions<DataResponse, Error, ProtectionType>
 ) {
-  const currentYear = useRecoilValue(widgetYearAtom);
   const units = ['ha', 'km²'];
 
   const {
@@ -116,7 +112,7 @@ export function useMangroveProtectedAreas(
         label: key,
         color: COLORS[key],
       })),
-    [location, unit, currentYear]
+    []
   );
   return useQuery(['protected-areas', restParams, location_id], fetchMangroveProtectedAreas, {
     select: (data) => ({
@@ -124,8 +120,6 @@ export function useMangroveProtectedAreas(
       ...data?.metadata,
       units,
       location,
-      protectedPercentage: numberFormat((data.protected_area * 100) / data.total_area),
-      nonProtectedPercentage: numberFormat(100 - (data.protected_area * 100) / data.total_area),
       protectedArea:
         unit === 'ha'
           ? numberFormat(data?.data[0]?.protected_area)
@@ -212,33 +206,29 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
       type: 'fill',
       paint: {
         'fill-color': [
-          'interpolate',
-          ['linear'],
+          'step',
           ['get', 'pct_protected'],
-          0,
-          '#CF597E',
+          '#cf597e',
+          0.2,
+          '#eeb479',
           0.4,
-          '#EEB479',
+          '#e9e29c',
           0.6,
-          '#E9E29C',
+          '#9ccb86',
           0.8,
-          '#9CCB86',
-          1,
           '#009392',
         ],
         'fill-outline-color': [
-          'interpolate',
-          ['linear'],
+          'step',
           ['get', 'pct_protected'],
-          0,
-          '#CF597E',
+          '#cf597e',
+          0.2,
+          '#eeb479',
           0.4,
-          '#EEB479',
+          '#e9e29c',
           0.6,
-          '#E9E29C',
+          '#9ccb86',
           0.8,
-          '#9CCB86',
-          1,
           '#009392',
         ],
         'fill-opacity': 0.7,

--- a/src/containers/datasets/protection/widget.tsx
+++ b/src/containers/datasets/protection/widget.tsx
@@ -20,7 +20,9 @@ import { useMangroveProtectedAreas } from './hooks';
 const Protection = () => {
   const [selectedUnit, setUnit] = useState('ha');
   const { data, isFetched, isFetching } = useMangroveProtectedAreas({ unit: selectedUnit });
-  if (!data?.length) return null;
+
+  if (!Object.keys(data || {}).length) return null;
+
   return (
     <div className={WIDGET_CARD_WRAPER_STYLE}>
       <Loading visible={isFetching && !isFetched} iconClassName="flex w-10 h-10 m-auto my-10" />


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

![image](https://github.com/Vizzuality/mangrove-atlas/assets/999124/8c00a2fe-6ccc-493e-ab76-c2ee4758470e)

Changes layer color ramp to not interpolate between colours.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/GMW-453

---

## Checklist before submitting

- [x] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
