### PR TITLE
(fix): restoration popup [GMW-601]

### DIFF
--- a/src/components/popup/index.tsx
+++ b/src/components/popup/index.tsx
@@ -31,6 +31,7 @@ const Popup = ({
       longitude={longitude || null}
       latitude={latitude || null}
       onClose={onClose}
+      closeOnClick={false}
       className="c-restoration-popup"
     >
       {children}

--- a/src/containers/datasets/carbon-market-potential/widget.tsx
+++ b/src/containers/datasets/carbon-market-potential/widget.tsx
@@ -60,7 +60,7 @@ const CarbonMarketPotentialWidget = () => {
                 <TooltipContent
                   side="bottom"
                   align="center"
-                  className="rounded-[20x] bg-white  text-black/85 shadow-soft"
+                  className="rounded-[20px] bg-white  text-black/85 shadow-soft"
                 >
                   <ul className={cn({ 'max-h-56 space-y-2 overflow-y-auto scrollbar-hide': true })}>
                     {labels?.map((l) => (

--- a/src/containers/datasets/restoration/layer.tsx
+++ b/src/containers/datasets/restoration/layer.tsx
@@ -1,13 +1,24 @@
+import { useEffect } from 'react';
+
 import { Source, Layer } from 'react-map-gl';
 
 import type { LayerProps } from 'types/layers';
 
 import { useLayers, useSource } from './hooks';
 
-const MangrovesLayer = ({ beforeId, id }: LayerProps) => {
+const MangrovesLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
   const SOURCE = useSource();
   const LAYERS = useLayers({ id });
+
+  useEffect(() => {
+    const ids = LAYERS.map((layer) => layer.id);
+
+    onAdd(ids);
+    return () => onRemove(ids);
+  }, []);
+
   if (!SOURCE || !LAYERS) return null;
+
   return (
     <Source {...SOURCE}>
       {LAYERS.map((LAYER) => (

--- a/src/containers/datasets/restoration/layer.tsx
+++ b/src/containers/datasets/restoration/layer.tsx
@@ -12,9 +12,9 @@ const MangrovesLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
 
   useEffect(() => {
     const ids = LAYERS.map((layer) => layer.id);
-
     onAdd(ids);
     return () => onRemove(ids);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (!SOURCE || !LAYERS) return null;

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -8,7 +8,7 @@ import cn from 'lib/classnames';
 
 import { analysisAtom } from 'store/analysis';
 import { drawingToolAtom } from 'store/drawing-tool';
-import { basemapAtom, URLboundsAtom, locationBoundsAtom } from 'store/map';
+import { basemapAtom, URLboundsAtom, locationBoundsAtom, interactiveLayerIdsAtom } from 'store/map';
 import { activeWidgetsAtom } from 'store/widgets';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -54,10 +54,9 @@ export const DEFAULT_PROPS = {
   maxZoom: 20,
 };
 
-const interactiveLayerIds = ['mangrove_restoration-layer'];
-
 const MapContainer = ({ mapId }: { mapId: string }) => {
   const basemap = useRecoilValue(basemapAtom);
+  const interactiveLayerIds = useRecoilValue(interactiveLayerIdsAtom);
   const [{ enabled: isDrawingToolEnabled, uploadedGeojson, customGeojson }, setDrawingToolState] =
     useRecoilState(drawingToolAtom);
   const [locationBounds, setLocationBounds] = useRecoilState(locationBoundsAtom);

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -54,7 +54,7 @@ export const DEFAULT_PROPS = {
   maxZoom: 20,
 };
 
-const interactiveLayerIds = ['mangrove_restoration'];
+const interactiveLayerIds = ['mangrove_restoration-layer'];
 
 const MapContainer = ({ mapId }: { mapId: string }) => {
   const basemap = useRecoilValue(basemapAtom);
@@ -180,7 +180,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
 
   const onClickHandler = (e) => {
     const restorationData = e?.features.find(
-      ({ layer }) => layer.id === 'mangrove_restoration'
+      ({ layer }) => layer.id === 'mangrove_restoration-layer'
     )?.properties;
 
     if (restorationData) {

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -177,6 +177,17 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
     [setDrawingToolState]
   );
 
+  const removePopup = () => {
+    setRestorationPopUp({
+      popup: [],
+      popupInfo: null,
+      popUpPosition: {
+        x: null,
+        y: null,
+      },
+    });
+  };
+
   const onClickHandler = (e) => {
     const restorationData = e?.features.find(
       ({ layer }) => layer.id === 'mangrove_restoration-layer'
@@ -193,17 +204,9 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
         },
       });
     }
-  };
-
-  const removePopup = () => {
-    setRestorationPopUp({
-      popup: [],
-      popupInfo: null,
-      popUpPosition: {
-        x: null,
-        y: null,
-      },
-    });
+    if (!restorationData) {
+      removePopup();
+    }
   };
 
   return (

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -189,8 +189,8 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   };
 
   const onClickHandler = (e) => {
-    const restorationData = e?.features.find(
-      ({ layer }) => layer.id === 'mangrove_restoration-layer'
+    const restorationData = e?.features.find(({ layer }) =>
+      interactiveLayerIds.includes(layer.id)
     )?.properties;
 
     if (restorationData) {

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 
+import { interactiveIdsAtom } from 'store/map';
 import { activeWidgetsAtom } from 'store/widgets';
 
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { LAYERS } from 'containers/datasets';
 
@@ -17,6 +18,7 @@ const EXCLUDED_DATA_LAYERS: WidgetSlugType[] = [
 
 const LayerManagerContainer = () => {
   const layers = useRecoilValue(activeWidgetsAtom);
+  const [interactiveIds, setInteractiveIds] = useRecoilState(interactiveIdsAtom);
   const LAYERS_FILTERED = useMemo(
     () => [
       ...layers
@@ -27,6 +29,15 @@ const LayerManagerContainer = () => {
     ],
     [layers]
   );
+  const handleAdd = (styleIds) => {
+    const updatedIds = [...interactiveIds, styleIds];
+    setInteractiveIds(updatedIds);
+  };
+
+  const handleRemove = (styleIds) => {
+    const updatedIds = interactiveIds.filter((id) => id === styleIds);
+    setInteractiveIds(updatedIds);
+  };
 
   return (
     <>
@@ -34,7 +45,15 @@ const LayerManagerContainer = () => {
         const LayerComponent = LAYERS[layer];
         const beforeId = i === 0 ? 'custom-layers' : `${LAYERS_FILTERED[i - 1]}-layer`;
 
-        return <LayerComponent key={layer} id={`${layer}-layer`} beforeId={beforeId} />;
+        return (
+          <LayerComponent
+            key={layer}
+            id={`${layer}-layer`}
+            beforeId={beforeId}
+            onAdd={handleAdd}
+            onRemove={handleRemove}
+          />
+        );
       })}
 
       {/* Countries layer */}

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { interactiveIdsAtom } from 'store/map';
+import { interactiveLayerIdsAtom } from 'store/map';
 import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -18,7 +18,7 @@ const EXCLUDED_DATA_LAYERS: WidgetSlugType[] = [
 
 const LayerManagerContainer = () => {
   const layers = useRecoilValue(activeWidgetsAtom);
-  const [interactiveIds, setInteractiveIds] = useRecoilState(interactiveIdsAtom);
+  const [interactiveLayerIds, setInteractiveLayerIds] = useRecoilState(interactiveLayerIdsAtom);
   const LAYERS_FILTERED = useMemo(
     () => [
       ...layers
@@ -29,14 +29,15 @@ const LayerManagerContainer = () => {
     ],
     [layers]
   );
-  const handleAdd = (styleIds) => {
-    const updatedIds = [...interactiveIds, styleIds];
-    setInteractiveIds(updatedIds);
+
+  const handleAdd = ([styleIds]) => {
+    const updatedIds = [...interactiveLayerIds, styleIds];
+    setInteractiveLayerIds(updatedIds);
   };
 
-  const handleRemove = (styleIds) => {
-    const updatedIds = interactiveIds.filter((id) => id === styleIds);
-    setInteractiveIds(updatedIds);
+  const handleRemove = ([styleIds]) => {
+    const updatedIds = interactiveLayerIds.filter((id) => id === styleIds);
+    setInteractiveLayerIds(updatedIds);
   };
 
   return (

--- a/src/store/map/index.ts
+++ b/src/store/map/index.ts
@@ -30,7 +30,7 @@ export const locationBoundsAtom = atom<[number, number, number, number]>({
   default: null,
 });
 
-export const interactiveIdsAtom = atom<string[]>({
+export const interactiveLayerIdsAtom = atom<string[]>({
   key: 'interactiveIds',
   default: [],
 });

--- a/src/store/map/index.ts
+++ b/src/store/map/index.ts
@@ -29,3 +29,8 @@ export const locationBoundsAtom = atom<[number, number, number, number]>({
   key: 'locationBounds',
   default: null,
 });
+
+export const interactiveIdsAtom = atom<string[]>({
+  key: 'interactiveIds',
+  default: [],
+});

--- a/src/types/layers.ts
+++ b/src/types/layers.ts
@@ -10,6 +10,8 @@ import { Layer } from '@deck.gl/core/typed';
 export type LayerProps = {
   id?: string;
   beforeId?: string;
+  onAdd?: (ids: string[]) => void;
+  onRemove?: (ids: string[]) => void;
   zIndex?: number;
   // settings?: Partial<S>;
 };


### PR DESCRIPTION
## Restoration popup

### Overview

This PR fixes popup displaying on map and manage interactive layers from layer manager, saving a global state with ids from each layer, to avoid hardcoded ids.

### Feature relevant tickets

[GMW-601](https://vizzuality.atlassian.net/browse/GMW-601)
