### PR TITLE
(fix): add unit to legend in carbon market widget [GMW-608]

### DIFF
--- a/src/containers/datasets/carbon-market-potential/hooks.tsx
+++ b/src/containers/datasets/carbon-market-potential/hooks.tsx
@@ -100,7 +100,7 @@ export function useCarbonMarketPotential(
       return {
         category: labelDisplayed,
         label: d.label,
-        value: d.value,
+        value: `${d.value} ${unit}`,
         color: COLORS[d.category],
         description: d.description,
         percentage: d.percentage,


### PR DESCRIPTION
## Add unit to legend in carbon market widget 

### Feature relevant tickets

[GMW-608](https://vizzuality.atlassian.net/browse/GMW-608)


[GMW-608]: https://vizzuality.atlassian.net/browse/GMW-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ