### PR TITLE
fixes fitBounds crashes

### DIFF
--- a/src/components/map/component.tsx
+++ b/src/components/map/component.tsx
@@ -63,13 +63,18 @@ export const CustomMap: FC<CustomMapProps> = ({
     // enabling fly mode avoids the map to be interrupted during the bounds transition
     setFlying(true);
 
-    mapRef?.fitBounds(
-      [
-        [bbox[0], bbox[1]],
-        [bbox[2], bbox[3]],
-      ],
-      options
-    );
+    try {
+      mapRef?.fitBounds(
+        [
+          [bbox[0], bbox[1]],
+          [bbox[2], bbox[3]],
+        ],
+        options
+      );
+    } catch (e) {
+      setFlying(false);
+      console.error(e);
+    }
   }, [bounds, mapRef]);
 
   const handleMapMove = useCallback(

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -105,8 +105,9 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   const handleViewState = useCallback(() => {
     if (map) {
       setURLBounds(map.getBounds().toArray());
+      setLocationBounds(null);
     }
-  }, [map, setURLBounds]);
+  }, [map, setURLBounds, setLocationBounds]);
 
   const initialViewState: MapboxProps['initialViewState'] = useMemo(
     () => ({
@@ -122,14 +123,15 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
 
   const bounds = useMemo<CustomMapProps['bounds']>(() => {
     if (!locationBounds) return null;
+
     return {
       bbox: locationBounds,
       options: {
         padding: {
-          top: 0,
-          right: 0,
-          bottom: 0,
-          left: screenWidth >= breakpoints.md ? 620 : 0,
+          top: 50,
+          right: 20,
+          bottom: 50,
+          left: screenWidth >= breakpoints.lg ? 620 + 20 : 20,
         },
       },
     } satisfies CustomMapProps['bounds'];


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Fixes `fitBounds` crashes when the user changes to certain locations, switches to fullscreen and other cases.

Also, adjusts bounds options to be more similar to production.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

https://vizzuality.atlassian.net/browse/GMW-605
https://vizzuality.atlassian.net/browse/GMW-606

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
