### PR TITLE
sort items in legend and tooltip accordingly to stack bars

### DIFF
--- a/src/containers/datasets/emissions-mitigation/legend.tsx
+++ b/src/containers/datasets/emissions-mitigation/legend.tsx
@@ -1,3 +1,5 @@
+import orderBy from 'lodash-es/orderBy';
+
 import cn from 'lib/classnames';
 
 type Item = {
@@ -17,9 +19,10 @@ type LegendTypes = {
 };
 
 const Legend = ({ items, onClick, filteredIndicators, setFilteredIndicators }: LegendTypes) => {
+  const sortedItems = orderBy(items, ['category', 'order'], ['asc', 'desc']);
   return (
     <div className="ml-6 flex w-full max-w-[40%] flex-col text-black/85">
-      {items.map(({ color, label }) => (
+      {sortedItems.map(({ color, label }) => (
         <button
           type="button"
           key={label}

--- a/src/containers/datasets/emissions-mitigation/tooltip.tsx
+++ b/src/containers/datasets/emissions-mitigation/tooltip.tsx
@@ -16,23 +16,14 @@ type TooltipProps = {
 };
 
 const Tooltip: React.FC = ({ active, payload = [] }: TooltipProps) => {
-  const sortedPayload = useMemo(
-    () =>
-      payload.sort((a, b) => {
-        if (Number(a.dataKey) >= Number(b.dataKey)) return -1;
-        if (Number(a.dataKey) < Number(b.dataKey)) return 1;
-        return 0;
-      }),
-    [payload]
-  );
-
   if (!active) return null;
 
   return (
     <div className="space-y-2 rounded-2xl bg-white py-2 px-6 font-sans text-sm shadow-lg">
       <p className="flex justify-center">{payload[0]?.payload?.category}</p>
 
-      {sortedPayload?.map(({ color, name, dataKey }) => (
+      {/* recharts organic order is from bottom to top for the stacked bars and from top to bottom in tooltip, using reverse to show tooltip values from bottom to top */}
+      {payload.reverse()?.map(({ color, name, dataKey }) => (
         <p key={dataKey} className={cn({ 'flex space-x-4': true })}>
           {color && (
             <span

--- a/src/containers/datasets/international-status/widget.tsx
+++ b/src/containers/datasets/international-status/widget.tsx
@@ -14,8 +14,6 @@ const InternationalStatus = () => {
     location,
     pledge_type,
     ndc_target,
-    ndc_reduction_target,
-    target_years,
     ndc_target_url,
     ndc_updated,
     ndc_mitigation,


### PR DESCRIPTION
## Order in stacked bars, tooltip and legend don't match

### Overview

The organic order for recharts in stacked bars is from bottom to top, in the tooltip and legend id from top to bottom.
this PR reorders tooltip and legend so it matches stacked bars order

### Designs
From:
<img width="495" alt="Screenshot 2023-06-09 at 14 15 14" src="https://github.com/Vizzuality/mangrove-atlas/assets/33252015/da7489d7-e3f3-4229-a5aa-20d18f8171e6">
to:
![Screenshot 2023-06-12 at 17 38 08](https://github.com/Vizzuality/mangrove-atlas/assets/33252015/6d8cf66b-14c0-4cab-ac37-f37ff35dd13a)


### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-609?atlOrigin=eyJpIjoiMTkxMWQwNGRlNmM3NGQ5MTgwZmJlMzZlZDEzODczZDUiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
