### PR TITLE
(fix): leave last widget expanded

### DIFF
--- a/src/containers/sidebar/category/index.tsx
+++ b/src/containers/sidebar/category/index.tsx
@@ -1,21 +1,27 @@
-import { useCallback, useState, MouseEvent } from 'react';
+import { useCallback, useState, MouseEvent, useMemo, useEffect } from 'react';
 
 import cn from 'lib/classnames';
 
 import { drawingToolAtom } from 'store/drawing-tool';
 import { activeCategoryAtom } from 'store/sidebar';
+import { widgetsCollapsedAtom } from 'store/widgets';
 
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useRecoilState } from 'recoil';
 
 import { CATEGORY_OPTIONS } from 'containers/sidebar/constants';
+import { useWidgets } from 'containers/widgets/hooks';
 
 import Icon from 'components/icon';
 
 const Category = () => {
+  const widgets = useWidgets();
   const [isOpen, setIsOpen] = useState(false);
   const [drawingToolState, setDrawingToolState] = useRecoilState(drawingToolAtom);
   const [category, setCategory] = useRecoilState(activeCategoryAtom);
+  const [widgetsCollapsed, setWidgetsCollapsed] = useRecoilState(widgetsCollapsedAtom);
+
+  const lastWidgetSlug = useMemo(() => widgets.at(-1).slug, [widgets]);
 
   const { showWidget: isDrawingToolWidgetVisible } = drawingToolState;
 
@@ -26,6 +32,17 @@ const Category = () => {
   const closeMenu = useCallback(() => {
     setIsOpen(false);
   }, []);
+
+  useEffect(() => {
+    const updateWidgetsCollapsed = Object.keys(widgetsCollapsed).reduce((acc, key) => {
+      acc[key] = true;
+      return acc;
+    }, {});
+
+    updateWidgetsCollapsed[lastWidgetSlug] = false;
+    setWidgetsCollapsed(updateWidgetsCollapsed);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [category]);
 
   const handleCategory = useCallback(
     (evt: MouseEvent<HTMLButtonElement>) => {

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import cn from 'lib/classnames';
 
@@ -23,6 +23,8 @@ const WidgetsContainer: React.FC = () => {
 
   const [widgetsCollapsed, setWidgetsCollapsed] = useRecoilState(widgetsCollapsedAtom);
 
+  const lastWidgetSlug = useMemo(() => widgets.at(-1).slug, [widgets]);
+
   const widgetsCollapsedChecker = Object.values(widgetsCollapsed).includes(true);
 
   const handleWidgetsCollapsed = useCallback(() => {
@@ -31,8 +33,10 @@ const WidgetsContainer: React.FC = () => {
       return acc;
     }, {});
 
+    updateWidgetsCollapsed[lastWidgetSlug] = false;
+
     setWidgetsCollapsed(updateWidgetsCollapsed);
-  }, [widgetsCollapsed, widgetsCollapsedChecker, setWidgetsCollapsed]);
+  }, [widgetsCollapsed, widgetsCollapsedChecker, setWidgetsCollapsed, lastWidgetSlug]);
 
   return (
     <WidgetsLayout>

--- a/src/store/widgets/index.ts
+++ b/src/store/widgets/index.ts
@@ -6,8 +6,6 @@ import widgets from 'containers/widgets/constants';
 
 import { WidgetSlugType } from 'types/widget';
 
-const widgetsNotCollapsed = ['mangrove_drivers_change', 'mangrove_drawing_tool'];
-
 export const activeWidgetsAtom = atom<WidgetSlugType[]>({
   key: 'active',
   default: ['mangrove_habitat_extent'],
@@ -26,11 +24,9 @@ export const widgetYearAtom = atom<number>({
 
 export const widgetsCollapsedAtom = atom({
   key: 'widgets-collapsed',
-  default: widgets
-    .filter(({ slug }) => !widgetsNotCollapsed.includes(slug))
-    .reduce((previousObject, currentObject) => {
-      return Object.assign(previousObject, {
-        [currentObject.slug]: false,
-      });
-    }, {}),
+  default: widgets.reduce((previousObject, currentObject) => {
+    return Object.assign(previousObject, {
+      [currentObject.slug]: false,
+    });
+  }, {}),
 });


### PR DESCRIPTION
##  Leave last widget open

### Overview

This PR includes the feat that leaves last widget always expanded.

### Testing instructions

The last widget should always be open, even when changing categories in the menu, but should be available to collapse individually.

### Feature relevant tickets

???