### PR TITLE
worldwide total species from API

### DIFF
--- a/src/containers/datasets/species-distribution/hooks.tsx
+++ b/src/containers/datasets/species-distribution/hooks.tsx
@@ -39,16 +39,6 @@ export function useMangroveSpecies(
       ...queryOptions,
     }).then((response: AxiosResponse<DataResponse>) => response.data);
 
-  const fetchMangroveSpeciesWorlwide = () =>
-    API.request({
-      method: 'GET',
-      url: '/widgets/biodiversity',
-      params: {
-        ...params,
-      },
-      ...queryOptions,
-    }).then((response: AxiosResponse<DataResponse>) => response.data);
-
   const query = useQuery(['biodiversity', params, location_id], fetchMangroveSpecies, {
     placeholderData: {
       metadata: null,
@@ -58,28 +48,14 @@ export function useMangroveSpecies(
     },
     ...queryOptions,
   });
-  const worldwideQuery = useQuery(
-    ['biodiversity-worlwdide', params],
-    fetchMangroveSpeciesWorlwide,
-    {
-      placeholderData: {
-        metadata: null,
-        data: {
-          total: null,
-        },
-      },
-      ...queryOptions,
-    }
-  );
 
   const { data } = query;
-  const { data: worldwideData } = worldwideQuery;
 
   const noData = !data?.data?.total;
 
   return useMemo(() => {
     const total = data?.data?.total;
-    const worldwideTotal = worldwideData.data.total;
+    const worldwideTotal = data?.metadata?.worldwide_total;
     const legend = [1, Math.ceil(worldwideTotal / 2), worldwideTotal];
     return {
       noData,

--- a/src/containers/datasets/species-distribution/types.d.ts
+++ b/src/containers/datasets/species-distribution/types.d.ts
@@ -24,6 +24,7 @@ type Data = { total: number; threatened: number; categories: Categories; species
 type Metadata = {
   note: 'nº of species';
   unit: null | string;
+  worldwide_total: number;
 };
 export type DataResponse = {
   data: Data;


### PR DESCRIPTION
## Worldwide total of species 

### Overview

This PR removes an extra API call to get the total of species worldwide and uses a new attribute provided by the API in the same call

### Testing instructions

Check if the species distribution widget updates accordingly when the user changes a location

![Screenshot 2023-06-14 at 08 58 42](https://github.com/Vizzuality/mangrove-atlas/assets/33252015/6c283215-b7de-48e7-8613-1d8f0688397d)

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-450?atlOrigin=eyJpIjoiMWI4NjEzNTZkYjhjNDc0YTk3NTEzOWU5ZjljYTYxNzQiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
