### PR TITLE
emissions mitigation category colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "axios": "1.3.4",
     "chroma-js": "^2.4.2",
     "classnames": "^2.3.2",
-    "clsx": "1.2.1",
     "cmdk": "0.2.0",
     "cypress": "12.7.0",
     "d3-format": "3.1.0",
@@ -106,9 +105,6 @@
     "svgo": "3.0.2",
     "svgo-loader": "3.0.3",
     "typescript": "4.9.4"
-  },
-  "resolutions": {
-    "webpack": "^5"
   },
   "husky": {
     "pre-commit": "yarn lint"

--- a/src/containers/datasets/emissions-mitigation/hooks.tsx
+++ b/src/containers/datasets/emissions-mitigation/hooks.tsx
@@ -20,8 +20,18 @@ import type { DataResponse, UseParamsOptions, emissionsMitigationData, Data } fr
 
 interface DataBar {
   category: DataResponse['data'][0]['category'];
+  indicator: DataResponse['data'][0]['category'];
   [key: string]: number | DataResponse['data'][0]['category'];
 }
+const COLORS = {
+  'reduce mangrove loss': '#79D09A',
+  'mangrove restoration': '#3EA3A1',
+  'reforestation (tropics)': '#FBD07E',
+  'reduce peatland degradation and conversion': '#FF98B1',
+  'reduce deforestation': '#C57CF2',
+  'grassland and savanna fire mgmt': '#74C5FF',
+  'forest management (global)': '#7287F9',
+};
 
 const getData = (data) => {
   const dataByCategory = groupBy(data, 'category');
@@ -140,8 +150,9 @@ export function useMangroveEmissionsMitigation(
     const orderedData = orderBy(data?.data, ['category'], ['asc']);
     const indicators =
       orderedData?.map((d, i) => ({
-        [d.indicator]: COLOR_RAMP[i],
+        [d.indicator]: COLORS[d.indicator.toLowerCase()] || COLOR_RAMP[i],
         category: d.category,
+        color: COLORS[d.indicator.toLowerCase()] || COLOR_RAMP[i],
         order: `${i}-${d.category}`,
       })) || ([] satisfies Data[]);
 

--- a/src/containers/datasets/emissions-mitigation/tooltip.tsx
+++ b/src/containers/datasets/emissions-mitigation/tooltip.tsx
@@ -10,6 +10,7 @@ type TooltipProps = {
     payload?: {
       category: string;
     };
+    value: number;
   }[];
   active: boolean;
   title: string;
@@ -23,17 +24,18 @@ const Tooltip: React.FC = ({ active, payload = [] }: TooltipProps) => {
       <p className="flex justify-center">{payload[0]?.payload?.category}</p>
 
       {/* recharts organic order is from bottom to top for the stacked bars and from top to bottom in tooltip, using reverse to show tooltip values from bottom to top */}
-      {payload.reverse()?.map(({ color, name, dataKey }) => (
-        <p key={dataKey} className={cn({ 'flex space-x-4': true })}>
-          {color && (
+      {payload.reverse()?.map(({ color, name, dataKey, value }) => (
+        <p key={dataKey} className={cn({ 'flex justify-between space-x-4': true })}>
+          <span className="flex flex-1 space-x-2">
             <span
               className={cn({
                 'mt-0.5 h-4 w-2 shrink-0 rounded-full': true,
               })}
               style={{ backgroundColor: color }}
             />
-          )}
-          {<span className="font-bold">{name}</span>}
+            {<span className="whitespace-nowrap font-bold">{name}</span>}
+          </span>
+          {<span>{value}</span>}
         </p>
       ))}
     </div>

--- a/src/containers/sidebar/category/index.tsx
+++ b/src/containers/sidebar/category/index.tsx
@@ -39,7 +39,7 @@ const Category = () => {
       return acc;
     }, {});
 
-    updateWidgetsCollapsed[lastWidgetSlug] = false;
+    updateWidgetsCollapsed[lastWidgetSlug || 'mangrove_drawing_tool'] = false;
     setWidgetsCollapsed(updateWidgetsCollapsed);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [category]);

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -32,6 +32,7 @@ const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps): n
     const updatedWidgetsCollapsed = {
       ...widgetsCollapsed,
       [id]: !widgetsCollapsed[id],
+      ['mangrove_drawing_tool']: false,
     };
     setWidgetsCollapsed(updatedWidgetsCollapsed);
   }, [id, widgetsCollapsed, setWidgetsCollapsed]);

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -34,6 +34,7 @@ const WidgetsContainer: React.FC = () => {
     }, {});
 
     updateWidgetsCollapsed[lastWidgetSlug] = false;
+    updateWidgetsCollapsed['mangrove_drawing_tool'] = false;
 
     setWidgetsCollapsed(updateWidgetsCollapsed);
   }, [widgetsCollapsed, widgetsCollapsedChecker, setWidgetsCollapsed, lastWidgetSlug]);

--- a/src/store/widgets/index.ts
+++ b/src/store/widgets/index.ts
@@ -26,7 +26,9 @@ export const widgetsCollapsedAtom = atom({
   key: 'widgets-collapsed',
   default: widgets.reduce((previousObject, currentObject) => {
     return Object.assign(previousObject, {
+      ...previousObject,
       [currentObject.slug]: false,
+      mangrove_drawing_tool: false,
     });
   }, {}),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,7 +3460,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clsx@npm:1.2.1, clsx@npm:^1.0.4":
+"clsx@npm:^1.0.4":
   version: 1.2.1
   resolution: "clsx@npm:1.2.1"
   checksum: 30befca8019b2eb7dbad38cff6266cf543091dae2825c856a62a8ccf2c3ab9c2907c4d12b288b73101196767f66812365400a227581484a05f968b0307cfaf12
@@ -7154,7 +7154,6 @@ __metadata:
     axios: 1.3.4
     chroma-js: ^2.4.2
     classnames: ^2.3.2
-    clsx: 1.2.1
     cmdk: 0.2.0
     cypress: 12.7.0
     d3-format: 3.1.0


### PR DESCRIPTION
## SEmission mitigation tooltip and colors

### Overview

This PR: 
- Adds absolute values to the tooltip
- Associates categories to a specific color. e are assuming we are not going to get any more categories than the ones declared. However,  it adds a  color_ramp as a backup just in case
- Forbids drawing tool to collapse
- Removes unused dependencies

### Designs

_[Link to the related design prototypes ](https://www.figma.com/file/GJCx8yGfx6JERPuxlpG3nK/Mangrove-Watch-%5BInternal%5D?type=design&node-id=1045-3626&t=YpkVHtHpMJnwLtCK-0)_

### Testing instructions

Scroll to the Emissions mitigation widget (all categories) and change location to see if colors persist regardless of the number of categories

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-609?atlOrigin=eyJpIjoiYWE0MjVmODJmNDUyNDAwZGE4MjgyZjZhODlhZjJhN2UiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
