### PR TITLE
critical fetch on server is now lighter

### DIFF
--- a/src/components/highlighted-places/index.tsx
+++ b/src/components/highlighted-places/index.tsx
@@ -10,13 +10,14 @@ import {
   useLocation,
   HIGHLIGHTED_PLACES,
 } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 const HighlightedPlaces = () => {
   const { data } = useHighlightedPlaces();
   const {
     query: { params },
   } = useRouter();
-  const locationType = params?.[0];
+  const locationType = params?.[0] as LocationTypes;
   const id = params?.[1];
 
   const {

--- a/src/components/location-title/index.tsx
+++ b/src/components/location-title/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import cn from 'lib/classnames';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 import LocationsList from 'containers/locations-list';
 
 import { Dialog, DialogContent, DialogClose, DialogTrigger } from 'components/dialog';
@@ -13,7 +14,7 @@ const LocationTitle = () => {
   const {
     query: { params },
   } = useRouter();
-  const locationType = params?.[0];
+  const locationType = params?.[0] as LocationTypes;
   const id = params?.[1];
   const {
     data: { name },

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -14,6 +14,7 @@ import { CartesianViewBox } from 'recharts/types/util/types';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API_cloud_functions from 'services/cloud-functions';
 
@@ -131,7 +132,7 @@ export function useAlerts<T>(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { location_id },
@@ -430,7 +431,7 @@ export function useSources(): SourceProps[] {
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { location_id },

--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -17,6 +17,7 @@ import { useRecoilValue } from 'recoil';
 import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -49,7 +50,7 @@ export function useMangroveBiomass(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -19,6 +19,7 @@ import { useRecoilValue } from 'recoil';
 import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -46,7 +47,7 @@ export function useMangroveBlueCarbon(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
 
   const {

--- a/src/containers/datasets/carbon-market-potential/hooks.tsx
+++ b/src/containers/datasets/carbon-market-potential/hooks.tsx
@@ -9,6 +9,7 @@ import { numberFormat } from 'lib/format';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API from 'services/api';
 
@@ -54,7 +55,7 @@ export function useCarbonMarketPotential(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/drivers-change/hooks.tsx
+++ b/src/containers/datasets/drivers-change/hooks.tsx
@@ -16,6 +16,7 @@ import type {
   ColorKeysTypes,
 } from 'containers/datasets/drivers-change/types';
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API from 'services/api';
 
@@ -33,7 +34,7 @@ export function useMangroveDriversChange(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation },

--- a/src/containers/datasets/emissions-mitigation/hooks.tsx
+++ b/src/containers/datasets/emissions-mitigation/hooks.tsx
@@ -12,6 +12,7 @@ import chroma from 'chroma-js';
 import type { CartesianViewBox } from 'recharts/types/util/types';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API from 'services/api';
 
@@ -106,7 +107,7 @@ export function useMangroveEmissionsMitigation(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -16,6 +16,7 @@ import { useRecoilValue } from 'recoil';
 import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import CustomTooltip from 'components/chart/tooltip';
 import type { UseParamsOptions } from 'types/widget';
@@ -37,7 +38,7 @@ export function useMangroveHabitatExtent(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -18,6 +18,7 @@ import { useRecoilValue } from 'recoil';
 import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -81,7 +82,7 @@ export function useMangroveHeight(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/international-status/hooks.tsx
+++ b/src/containers/datasets/international-status/hooks.tsx
@@ -7,10 +7,10 @@ import { numberFormat } from 'lib/format';
 import { widgetYearAtom } from 'store/widgets';
 
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { AxiosResponse } from 'axios';
 import { useRecoilValue } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -27,7 +27,7 @@ export function useMangroveInternationalStatus(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/locations/types.d.ts
+++ b/src/containers/datasets/locations/types.d.ts
@@ -1,6 +1,6 @@
 import { GeoJSONSourceRaw } from 'react-map-gl';
 
-export type LocationTypes = Readonly<'custom-area', 'wdpa', 'country' | 'worldwide'>;
+export type LocationTypes = Readonly<'custom-area' | 'wdpa' | 'country' | 'worldwide'>;
 export interface Location {
   name: string;
   location_type: LocationTypes;

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -18,6 +18,7 @@ import { useRecoilValue } from 'recoil';
 import type { AnalysisResponse } from 'hooks/analysis';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import CustomTooltip from 'components/chart/tooltip';
 
@@ -91,7 +92,7 @@ export function useMangroveNetChange(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/protection/hooks.tsx
+++ b/src/containers/datasets/protection/hooks.tsx
@@ -10,6 +10,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { PolarViewBox } from 'recharts/types/util/types';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -64,7 +65,7 @@ export function useMangroveProtectedAreas(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/restoration-sites/hooks.tsx
+++ b/src/containers/datasets/restoration-sites/hooks.tsx
@@ -11,6 +11,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -26,7 +27,7 @@ export function useMangroveRestorationSites(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },
@@ -65,7 +66,7 @@ export function useMangroveRestorationSitesFilters(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { id: currentLocation, location_id },

--- a/src/containers/datasets/restoration/fisheries/hooks.tsx
+++ b/src/containers/datasets/restoration/fisheries/hooks.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 type UseParamsOptions = {
   slug: 'fisheries' | 'restoration-value';
@@ -25,7 +26,7 @@ export function useMangroveEcosystemServices(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { id: currentLocation, location_id },

--- a/src/containers/datasets/restoration/loss/hooks.tsx
+++ b/src/containers/datasets/restoration/loss/hooks.tsx
@@ -6,6 +6,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import chroma from 'chroma-js';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -59,7 +60,7 @@ export function useMangroveDegradationAndLoss(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/restoration/overview/hooks.tsx
+++ b/src/containers/datasets/restoration/overview/hooks.tsx
@@ -7,6 +7,7 @@ import { numberFormat } from 'lib/format';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -22,7 +23,7 @@ export function useMangroveRestoration(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/restoration/restoration-value/hooks.tsx
+++ b/src/containers/datasets/restoration/restoration-value/hooks.tsx
@@ -3,12 +3,11 @@ import { useRouter } from 'next/router';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API from 'services/api';
 
 import type { Data, DataResponse } from './types';
-
-// widget data
 
 type UseParamsOptions = {
   slug: 'fisheries' | 'restoration-value';
@@ -21,7 +20,7 @@ export function useMangroveEcosystemServices(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/species-distribution/hooks.tsx
+++ b/src/containers/datasets/species-distribution/hooks.tsx
@@ -8,6 +8,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -23,7 +24,7 @@ export function useMangroveSpecies(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/datasets/species-location/hooks.tsx
+++ b/src/containers/datasets/species-location/hooks.tsx
@@ -11,6 +11,7 @@ import type { QueryObserverOptions } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
 import { useLocations, useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import API from 'services/api';
 
@@ -35,7 +36,7 @@ export function useMangroveSpeciesLocation<T>(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { id: currentLocation, location_id },

--- a/src/containers/datasets/species-threatened/hooks.tsx
+++ b/src/containers/datasets/species-threatened/hooks.tsx
@@ -8,6 +8,7 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 import type { UseParamsOptions } from 'types/widget';
 
@@ -76,7 +77,7 @@ export function useMangroveSpecies(
   const {
     query: { params: queryParams },
   } = useRouter();
-  const locationType = queryParams?.[0];
+  const locationType = queryParams?.[0] as LocationTypes;
   const id = queryParams?.[1];
   const {
     data: { name: location, id: currentLocation, location_id },

--- a/src/containers/locations-list/mobile/highlighted-places/index.tsx
+++ b/src/containers/locations-list/mobile/highlighted-places/index.tsx
@@ -10,13 +10,14 @@ import {
   useLocation,
   HIGHLIGHTED_PLACES,
 } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
 
 const HighlightedPlacesMobile = () => {
   const { data } = useHighlightedPlaces();
   const {
     query: { params },
   } = useRouter();
-  const locationType = params?.[0];
+  const locationType = params?.[0] as LocationTypes;
   const id = params?.[1];
 
   const {


### PR DESCRIPTION
## Substitute this line for a meaningful title for your changes

### Overview

Instead of fetching `/locations` to determine the routes available in the application, now we check if the provided location is available in the API (`/location/{id}`), saving the 1.6MB request and blocking the server longer than desired.

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_Link to the related task manager tickets_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
