### PR TITLE
(fix): last widget collapse + restoration sites bubbles + close location list[GMW-596]

### DIFF
--- a/src/components/highlighted-places/index.tsx
+++ b/src/components/highlighted-places/index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'containers/datasets/locations/hooks';
 import type { LocationTypes } from 'containers/datasets/locations/types';
 
-const HighlightedPlaces = () => {
+const HighlightedPlaces = ({ onSelectLocation }: { onSelectLocation: () => void }) => {
   const { data } = useHighlightedPlaces();
   const {
     query: { params },
@@ -23,6 +23,7 @@ const HighlightedPlaces = () => {
   const {
     data: { location_id },
   } = useLocation(locationType, id);
+
   const isHighlightedPlace = Object.values(HIGHLIGHTED_PLACES).includes(location_id);
 
   return (
@@ -35,29 +36,31 @@ const HighlightedPlaces = () => {
               href={`/${d.location_type}/${d.location_id}`}
               className="flex flex-1"
             >
-              <div
+              <button
                 className={cn({
                   'flex h-60 flex-1 rounded-3xl bg-cover bg-center': true,
                   'bg-rufiji': HIGHLIGHTED_PLACES['rufiji'] === d.location_id,
                   'bg-saloum': HIGHLIGHTED_PLACES['saloum'] === d.location_id,
                 })}
+                onClick={onSelectLocation}
               >
                 <h3 className="m-auto flex h-full items-end justify-center pb-4 text-end font-sans text-sm font-bold text-white">
                   {d.name}
                 </h3>
-              </div>
+              </button>
             </Link>
           );
       })}
       {isHighlightedPlace && (
         <Link href="/" className="flex flex-1">
-          <div
+          <button
             className={`flex h-60 flex-1 rounded-3xl bg-[url('/images/highlighted-places/worldwide.jpg')] bg-cover bg-center`}
+            onClick={onSelectLocation}
           >
             <h3 className="m-auto flex h-full items-end justify-center pb-4 text-end font-sans text-sm font-bold text-white">
               Worldwide
             </h3>
-          </div>
+          </button>
         </Link>
       )}
     </div>

--- a/src/containers/datasets/restoration-sites/hooks.tsx
+++ b/src/containers/datasets/restoration-sites/hooks.tsx
@@ -156,6 +156,7 @@ export function useLayer({ id }: { id: LayerProps['id'] }): LayerProps[] {
         'text-field': ['get', 'point_count_abbreviated'],
         'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
         'text-size': 16,
+        'text-allow-overlap': true,
       },
       paint: {
         'text-color': '#fff',

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -58,7 +58,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
 
       if (location.bounds) setLocationBounds(turfBbox(location.bounds) as typeof locationBounds);
 
-      if (onSelectLocation) onSelectLocation();
+      onSelectLocation();
     },
     [replace, asPath, setLocationBounds, onSelectLocation]
   );
@@ -100,10 +100,10 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
 
   return (
     <div className="space-y-4 overflow-hidden pt-8 after:bg-gradient-to-b after:from-white/20 after:to-white/100 after:content-[''] md:pt-0">
-      <div className="relative box-border w-full px-2 pt-0.5 md:px-0">
+      <div className="relative box-border w-full px-1 pt-0.5">
         <input
           type="search"
-          className="relative mx-1 box-border w-full border-2 border-transparent bg-transparent text-3xl text-black/85 caret-brand-800 opacity-50 focus:rounded focus:border-b-2  focus:border-grey-75 focus:outline-none focus:ring-transparent"
+          className="relative box-border w-full border-2 border-transparent bg-transparent text-3xl text-black/85 caret-brand-800 opacity-50 focus:rounded focus:border-b-2 focus:border-grey-75 focus:outline-none focus:ring-transparent"
           placeholder="Type name..."
           value={searchValue}
           onChange={(e) => setSearchValue(e.currentTarget.value)}

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -123,7 +123,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
         <HighlightedPlacesMobile />
       </Media>
       <Media greaterThanOrEqual="md">
-        <HighlightedPlaces />
+        <HighlightedPlaces onSelectLocation={onSelectLocation} />
       </Media>
       <div className="relative h-full">
         <AutoSizer>

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -110,6 +110,10 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
 
   const { [mapId]: map } = useMap();
 
+  if (map?.isStyleLoaded()) {
+    console.log('map', map.getStyle());
+  }
+
   const {
     query: { params },
     push,

--- a/src/containers/map/component.tsx
+++ b/src/containers/map/component.tsx
@@ -110,10 +110,6 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
 
   const { [mapId]: map } = useMap();
 
-  if (map?.isStyleLoaded()) {
-    console.log('map', map.getStyle());
-  }
-
   const {
     query: { params },
     push,

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -12,13 +12,16 @@ import { WidgetSlugType } from 'types/widget';
 
 const ProtectedAreasLayer = LAYERS['protected-areas'];
 const CountryBoundariesLayer = LAYERS['country-boundaries'];
+const RestorationSitesLayer = LAYERS['mangrove_restoration_sites'];
 
 const EXCLUDED_DATA_LAYERS: WidgetSlugType[] = [
   'mangrove_habitat_extent',
+  'mangrove_restoration_sites',
 ] satisfies WidgetSlugType[];
 
 const LayerManagerContainer = () => {
   const layers = useRecoilValue(activeWidgetsAtom);
+
   const [, setInteractiveLayerIds] = useRecoilState(interactiveLayerIdsAtom);
   const LAYERS_FILTERED = useMemo(
     () => [
@@ -64,7 +67,6 @@ const LayerManagerContainer = () => {
         );
       })}
 
-      {/* Countries layer */}
       {
         <CountryBoundariesLayer
           id="country-boundaries-layer"
@@ -73,8 +75,12 @@ const LayerManagerContainer = () => {
           onRemove={handleRemove}
         />
       }
-      {/* Protected areas layer */}
+
       {<ProtectedAreasLayer id="protected-areas-layer" beforeId="Country" />}
+
+      {layers.includes('mangrove_restoration_sites') && (
+        <RestorationSitesLayer id="mangrove-restoration-sites-layer" />
+      )}
     </>
   );
 };

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -71,7 +71,7 @@ const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps): n
           <header className="flex items-center justify-between">
             <h2
               onClick={handleWidgetCollapsed}
-              className="flex-1 cursor-pointer py-5 text-xs font-bold uppercase -tracking-tighter text-black/85"
+              className="flex-1 cursor-pointer py-5 text-xs font-bold uppercase -tracking-tighter text-black/85 group-last-of-type:pointer-events-none"
             >
               {title}
             </h2>

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -57,7 +57,7 @@ const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps): n
         exit="expanded"
         transition={{ type: 'spring', bounce: 0, duration: 0.8 }}
         className={cn({
-          'md:h-fit-content ml-[3%] w-[94%] rounded-2xl border border-[#DADED0] bg-white px-1 py-1 shadow-widget md:ml-0 md:w-[540px]':
+          'md:h-fit-content group ml-[3%] w-[94%] rounded-2xl border border-[#DADED0] bg-white px-1 py-1 shadow-widget md:ml-0 md:w-[540px]':
             true,
           [className]: !!className,
         })}
@@ -79,6 +79,7 @@ const WidgetWrapper: React.FC<WidgetLayoutProps> = (props: WidgetLayoutProps): n
           </header>
           <div
             className={cn({
+              'group-last-of-type:block': true,
               hidden: widgetsCollapsed[id],
               block: !widgetsCollapsed[id],
             })}

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -116,6 +116,7 @@ const WidgetsContainer: React.FC = () => {
       </div>
 
       {widgets.length === 0 && <NoData />}
+
       {!!widgets.length ? (
         <div className="flex w-full py-4 print:hidden">
           <button

--- a/src/layouts/mobile/index.tsx
+++ b/src/layouts/mobile/index.tsx
@@ -13,7 +13,7 @@ import LOGO_MOBILE_SVG from 'svgs/logo-mobile.svg?sprite';
 const MobileLayout = () => {
   const mapView = useRecoilValue(mapViewAtom);
   return (
-    <div className="h-full bg-red-400 print:bg-transparent">
+    <div className="h-full print:bg-transparent">
       <div className="fixed top-0 -left-0.5 z-40 h-24 w-full bg-[url('/images/mobile-header.svg')] bg-contain bg-no-repeat">
         <Icon icon={LOGO_MOBILE_SVG} className="ml-4 mt-1.5 h-10 w-24" />
       </div>

--- a/src/layouts/widgets/index.tsx
+++ b/src/layouts/widgets/index.tsx
@@ -6,7 +6,7 @@ const WidgetsLayout = (props: PropsWithChildren) => {
   const { children } = props;
 
   return (
-    <div className="h-full bg-red-400 py-20 scrollbar-hide md:absolute md:top-0 md:left-16 md:w-[550px] md:overflow-y-auto md:bg-transparent print:bg-transparent">
+    <div className="h-full  py-20 scrollbar-hide md:absolute md:top-0 md:left-16 md:w-[550px] md:overflow-y-auto md:bg-transparent print:bg-transparent">
       <LocationTitle />
       {children}
     </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -114,7 +114,7 @@ body {
 
 .txlive-langselector-list {
   @apply !bottom-auto !left-0 !right-auto !top-0 !bg-white !rounded-b-3xl !text-brand-800 ;
-}  
+}
 
 .txlive-langselector-marker {
   @apply !absolute !right-6 !rotate-180;


### PR DESCRIPTION
## Last widget collapse + restoration sites bubbles + close location list

### Overview

This PR includes followed fixes:

- Blocks the possibility of collapsing the last widget (please test in cases where there is no data).
- Sets the restoration sites layer first and makes the counter visible at all zoom levels.
- Close the locations modal when an area is chosen.

### Feature relevant tickets

[GMW-596](https://vizzuality.atlassian.net/browse/GMW-596)


[GMW-596]: https://vizzuality.atlassian.net/browse/GMW-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ