### PR TITLE
(fix): drawing tool close flow [GMW-634]

### DIFF
--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -66,7 +66,7 @@ const DialogClose = ({ onClose = () => null }: { onClose?: () => void }) => (
   <DialogPrimitive.Close asChild>
     <button
       type="button"
-      className="absolute top-7 right-6 z-50 flex h-11 w-10 cursor-pointer items-center justify-end rounded-r-[10px] bg-white hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 md:top-7 md:-right-10 md:border"
+      className="absolute top-7 right-6 z-40 flex h-11 w-10 cursor-pointer items-center justify-end rounded-r-[10px] bg-white hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 md:top-7 md:-right-10 md:border"
       onClick={onClose}
     >
       <Icon icon={CLOSE_SVG} className="mr-2.5 h-7 w-7 md:h-5 md:w-5" />
@@ -113,6 +113,7 @@ const DialogDescription = React.forwardRef<
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 export {
   Dialog,
+  DialogPortal,
   DialogTrigger,
   DialogContent,
   DialogHeader,

--- a/src/containers/alert/index.tsx
+++ b/src/containers/alert/index.tsx
@@ -10,7 +10,7 @@ import { locationsModalAtom } from 'store/locations';
 import { printModeState } from 'store/print-mode';
 import { placeSectionAtom } from 'store/sidebar';
 
-import { useRecoilState, useRecoilValue, useResetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { Dialog, DialogPortal, DialogContent } from 'components/dialog';
 import Icon from 'components/icon';
@@ -22,11 +22,11 @@ const MANGROVES_SKIP_ANALYSIS_ALERT = 'MANGROVES_SKIP_ANALYSIS_ALERT';
 const AnalysisAlert = () => {
   const { asPath, replace } = useRouter();
 
-  const [isAnalysisAlertOpen, setAnalysisAlert] = useRecoilState(analysisAlertAtom);
-  const [placeSection, savePlaceSection] = useRecoilState(placeSectionAtom);
-  const [locationsModalIsOpen, setLocationsModalIsOpen] = useRecoilState(locationsModalAtom);
-  const [skipAnalysisAlert, setSkipAnalysisAlert] = useRecoilState(skipAnalysisAlertAtom);
+  const placeSection = useRecoilValue(placeSectionAtom);
   const isPrintingMode = useRecoilValue(printModeState);
+  const setLocationsModalIsOpen = useSetRecoilState(locationsModalAtom);
+  const [isAnalysisAlertOpen, setAnalysisAlert] = useRecoilState(analysisAlertAtom);
+  const [skipAnalysisAlert, setSkipAnalysisAlert] = useRecoilState(skipAnalysisAlertAtom);
   const resetAnalysisState = useResetRecoilState(analysisAtom);
   const resetDrawingState = useResetRecoilState(drawingToolAtom);
 
@@ -44,6 +44,7 @@ const AnalysisAlert = () => {
     resetDrawingState();
     resetAnalysisState();
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     replace(`/?${queryParams}`, null);
 
     map.flyTo({
@@ -64,6 +65,7 @@ const AnalysisAlert = () => {
     resetDrawingState();
     resetAnalysisState();
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     replace(`/?${queryParams}`, null);
 
     setAnalysisAlert(false);
@@ -80,7 +82,7 @@ const AnalysisAlert = () => {
 
   const handleCheckbox = useCallback(() => {
     setSkipAnalysisAlert(!skipAnalysisAlert);
-  }, [skipAnalysisAlert]);
+  }, [skipAnalysisAlert, setSkipAnalysisAlert]);
 
   return (
     <>

--- a/src/containers/alert/index.tsx
+++ b/src/containers/alert/index.tsx
@@ -1,0 +1,142 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { useMap } from 'react-map-gl';
+
+import { useRouter } from 'next/router';
+
+import { analysisAtom } from 'store/analysis';
+import { drawingToolAtom } from 'store/drawing-tool';
+import { printModeState } from 'store/print-mode';
+
+import { useResetRecoilState, useRecoilValue } from 'recoil';
+
+import { Dialog, DialogPortal, DialogContent } from 'components/dialog';
+import Icon from 'components/icon';
+
+import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
+
+const MANGROVES_SKIP_ANALYSIS_ALERT = 'MANGROVES_SKIP_ANALYSIS_ALERT';
+
+const AnalysisAlert = ({
+  setLocationsModalIsOpen,
+  placeOption,
+}: {
+  setLocationsModalIsOpen: (boolean) => void;
+  placeOption: string;
+}) => {
+  const resetAnalysisState = useResetRecoilState(analysisAtom);
+  const resetDrawingState = useResetRecoilState(drawingToolAtom);
+  const isPrintingMode = useRecoilValue(printModeState);
+  const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
+  const [isAnalysisAlertOpen, setAnalysisAlert] = useState(false);
+  const [skipAnalysisAlert, setSkipAnalysisAlert] = useState(false);
+
+  const { [`default-desktop-${isPrintingId}`]: map } = useMap();
+  const { asPath, replace } = useRouter();
+
+  const queryParams = useMemo(() => asPath.split('?')[1], [asPath]);
+
+  const handleWorldwideView = useCallback(() => {
+    resetDrawingState();
+    resetAnalysisState();
+
+    replace(`/?${queryParams}`, null);
+
+    map.flyTo({
+      center: [0, 20],
+      zoom: 2,
+    });
+  }, [replace, map, queryParams, resetAnalysisState, resetDrawingState]);
+
+  const closeAnalysisAlertModal = useCallback(() => {
+    setAnalysisAlert(false);
+  }, [setAnalysisAlert]);
+
+  const handleCancelResetPage = useCallback(() => {
+    closeAnalysisAlertModal();
+    setLocationsModalIsOpen(false);
+  }, [closeAnalysisAlertModal]);
+
+  const handleCheckbox = useCallback(() => {
+    setSkipAnalysisAlert(!skipAnalysisAlert);
+  }, [skipAnalysisAlert]);
+
+  const handleResetPage = useCallback(() => {
+    if (skipAnalysisAlert) {
+      window.localStorage.setItem(MANGROVES_SKIP_ANALYSIS_ALERT, String(skipAnalysisAlert));
+    }
+
+    if (placeOption === 'worldwide') {
+      handleWorldwideView();
+    }
+
+    resetDrawingState();
+    resetAnalysisState();
+
+    replace(`/?${queryParams}`, null);
+
+    closeAnalysisAlertModal();
+  }, [
+    queryParams,
+    skipAnalysisAlert,
+    placeOption,
+    replace,
+    closeAnalysisAlertModal,
+    resetDrawingState,
+    resetAnalysisState,
+    handleWorldwideView,
+  ]);
+
+  useEffect(() => {
+    setSkipAnalysisAlert(window.localStorage.getItem(MANGROVES_SKIP_ANALYSIS_ALERT) === 'true');
+  }, []);
+
+  return (
+    <Dialog open={isAnalysisAlertOpen}>
+      <DialogPortal className="z-50">
+        <DialogContent
+          className="space-y-5 rounded-3xl p-10 md:left-auto"
+          onEscapeKeyDown={closeAnalysisAlertModal}
+        >
+          <div className="space-y-5">
+            <div className="flex justify-end">
+              <button type="button" onClick={closeAnalysisAlertModal}>
+                <Icon icon={CLOSE_SVG} className="h-8 w-8" />
+              </button>
+            </div>
+            <h3 className="text-3xl">Reset the page and delete area</h3>
+            <div className="space-y-2">
+              <p>
+                If you reset the page,{' '}
+                <span className="font-semibold">your custom area will be deleted</span>. Are you
+                sure that you want to reset the page?
+              </p>
+              <div className="flex items-center space-x-2">
+                <input type="checkbox" name="do-not-ask" onChange={handleCheckbox} />
+                <label htmlFor="modal">Don&apos;t ask me again.</label>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center justify-center space-x-5">
+            <button
+              type="button"
+              onClick={handleCancelResetPage}
+              className="rounded-2xl border-2 border-brand-800/20 px-6 py-[1px] text-sm text-brand-800"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleResetPage}
+              className="rounded-2xl bg-brand-800 px-6 py-[2px] text-sm text-white"
+            >
+              Reset page
+            </button>
+          </div>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+};
+
+export default AnalysisAlert;

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -148,7 +148,7 @@ export function useMangroveNetChange(
       : isFetched && !data?.data?.length;
 
   return useMemo(() => {
-    const years = data.metadata?.year.sort();
+    const years = data?.metadata?.year.sort();
     const unit = selectedUnit || data.metadata?.units.net_change;
     const currentStartYear = startYear || years?.[0];
     const currentEndYear = endYear || years?.[years?.length - 1];

--- a/src/containers/location-title/index.tsx
+++ b/src/containers/location-title/index.tsx
@@ -4,6 +4,10 @@ import { useRouter } from 'next/router';
 
 import cn from 'lib/classnames';
 
+import { analysisAlertAtom, analysisAtom } from 'store/analysis';
+
+import { useRecoilState } from 'recoil';
+
 import { useLocation } from 'containers/datasets/locations/hooks';
 import type { LocationTypes } from 'containers/datasets/locations/types';
 import LocationDialogContent from 'containers/location-dialog-content';
@@ -21,18 +25,22 @@ const LocationTitle = () => {
   } = useLocation(locationType, id, {
     enabled: (!!locationType && !!id) || locationType !== 'custom-area',
   });
-  const [isOpen, setIsOpen] = useState<boolean>(false);
 
+  const [isAnalysisAlertOpen, setAnalysisAlert] = useRecoilState(analysisAlertAtom);
+  const [{ enabled: isAnalysisEnabled }] = useRecoilState(analysisAtom);
+
+  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [width, setWidth] = useState<number>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
 
   const openMenu = useCallback(() => {
     if (!isOpen) setIsOpen(true);
-  }, [isOpen]);
+    if (isAnalysisEnabled) setAnalysisAlert(true);
+  }, [isOpen, isAnalysisEnabled, setAnalysisAlert]);
 
   const closeMenu = useCallback(() => {
-    setIsOpen(false);
-  }, []);
+    if (!isAnalysisAlertOpen) setIsOpen(false);
+  }, [isAnalysisAlertOpen]);
 
   const locationName = useMemo(() => {
     if (locationType === 'custom-area') {

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -73,7 +73,7 @@ const Place = () => {
       center: [0, 20],
       zoom: 2,
     });
-  }, [map, resetAnalysisState, resetDrawingState, resetMapSettingsState]);
+  }, [map, resetAnalysisState, resetDrawingState, replace, queryParams]);
 
   const handleDrawingToolView = useCallback(() => {
     setDrawingToolState((drawingToolState) => ({
@@ -96,43 +96,13 @@ const Place = () => {
     replace,
     queryParams,
     savePlaceSection,
+    resetMapSettingsState,
   ]);
 
   const openAnalysisAlertModal = useCallback(() => {
     setAnalysisAlert(true);
     openLocationsModal();
   }, [setAnalysisAlert, openLocationsModal]);
-
-  const closeAnalysisAlertModal = useCallback(() => {
-    setAnalysisAlert(false);
-  }, [setAnalysisAlert]);
-
-  const handleResetPage = useCallback(() => {
-    if (skipAnalysisAlert) {
-      window.localStorage.setItem(MANGROVES_SKIP_ANALYSIS_ALERT, String(skipAnalysisAlert));
-    }
-
-    if (placeSection === 'worldwide') {
-      handleWorldwideView();
-    }
-
-    resetDrawingState();
-    resetAnalysisState();
-    resetMapSettingsState();
-
-    replace(`/?${queryParams}`, null);
-
-    closeAnalysisAlertModal();
-  }, [
-    queryParams,
-    skipAnalysisAlert,
-    placeSection,
-    replace,
-    closeAnalysisAlertModal,
-    resetDrawingState,
-    resetAnalysisState,
-    handleWorldwideView,
-  ]);
 
   useEffect(() => {
     setSkipAnalysisAlert(window.localStorage.getItem(MANGROVES_SKIP_ANALYSIS_ALERT) === 'true');

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 
 import cn from 'lib/classnames';
 
-import { analysisAtom } from 'store/analysis';
+import { analysisAlertAtom, analysisAtom } from 'store/analysis';
 import { drawingToolAtom } from 'store/drawing-tool';
 import { mapCursorAtom } from 'store/map';
 import { mapSettingsAtom } from 'store/map-settings';
@@ -32,6 +32,7 @@ const MANGROVES_SKIP_ANALYSIS_ALERT = 'MANGROVES_SKIP_ANALYSIS_ALERT';
 const Place = () => {
   const [{ enabled: isAnalysisEnabled }] = useRecoilState(analysisAtom);
   const [placeSection, savePlaceSection] = useRecoilState(placeSectionAtom);
+  const [isAnalysisAlertOpen, setAnalysisAlert] = useRecoilState(analysisAlertAtom);
   const setDrawingToolState = useSetRecoilState(drawingToolAtom);
   const resetAnalysisState = useResetRecoilState(analysisAtom);
   const resetDrawingState = useResetRecoilState(drawingToolAtom);
@@ -40,7 +41,7 @@ const Place = () => {
   const isPrintingMode = useRecoilValue(printModeState);
   const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
   const [locationsModalIsOpen, setLocationsModalIsOpen] = useState(false);
-  const [isAnalysisAlertOpen, setAnalysisAlert] = useState(false);
+
   const [skipAnalysisAlert, setSkipAnalysisAlert] = useState(false);
 
   const { [`default-desktop-${isPrintingId}`]: map } = useMap();

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -65,8 +65,9 @@ const Place = () => {
   const handleWorldwideView = useCallback(() => {
     resetDrawingState();
     resetAnalysisState();
-    resetMapSettingsState();
-    handleResetPage();
+
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    replace(`/?${queryParams}`, null);
 
     map.flyTo({
       center: [0, 20],
@@ -86,6 +87,7 @@ const Place = () => {
     resetMapCursor();
     savePlaceSection('area');
 
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     replace(`/custom-area${queryParams ? `?${queryParams}` : ''}`, null);
   }, [
     setDrawingToolState,

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -55,9 +55,8 @@ const Place = () => {
   const closeMenu = useCallback(() => {
     if (!isAnalysisAlertOpen) {
       setLocationsModalIsOpen(false);
+      savePlaceOption(null);
     }
-
-    savePlaceOption(null);
   }, [isAnalysisAlertOpen]);
 
   const handleWorldwideView = useCallback(() => {
@@ -161,7 +160,7 @@ const Place = () => {
             })}
           />
         </button>
-        <Dialog open={locationsModalIsOpen}>
+        <Dialog open={placeOption === 'search' && locationsModalIsOpen}>
           <DialogTrigger asChild>
             <button
               onClick={handleOnClickSearch}

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -11,6 +11,7 @@ import { drawingToolAtom } from 'store/drawing-tool';
 import { mapCursorAtom } from 'store/map';
 import { mapSettingsAtom } from 'store/map-settings';
 import { printModeState } from 'store/print-mode';
+import { placeSectionAtom } from 'store/sidebar';
 
 import { useRecoilState, useSetRecoilState, useResetRecoilState, useRecoilValue } from 'recoil';
 
@@ -30,6 +31,7 @@ const MANGROVES_SKIP_ANALYSIS_ALERT = 'MANGROVES_SKIP_ANALYSIS_ALERT';
 
 const Place = () => {
   const [{ enabled: isAnalysisEnabled }] = useRecoilState(analysisAtom);
+  const [placeSection, savePlaceSection] = useRecoilState(placeSectionAtom);
   const setDrawingToolState = useSetRecoilState(drawingToolAtom);
   const resetAnalysisState = useResetRecoilState(analysisAtom);
   const resetDrawingState = useResetRecoilState(drawingToolAtom);
@@ -40,7 +42,6 @@ const Place = () => {
   const [locationsModalIsOpen, setLocationsModalIsOpen] = useState(false);
   const [isAnalysisAlertOpen, setAnalysisAlert] = useState(false);
   const [skipAnalysisAlert, setSkipAnalysisAlert] = useState(false);
-  const [placeOption, savePlaceOption] = useState('worldwide');
 
   const { [`default-desktop-${isPrintingId}`]: map } = useMap();
   const resetMapSettingsState = useResetRecoilState(mapSettingsAtom);
@@ -55,7 +56,7 @@ const Place = () => {
   const closeMenu = useCallback(() => {
     if (!isAnalysisAlertOpen) {
       setLocationsModalIsOpen(false);
-      savePlaceOption(null);
+      savePlaceSection(null);
     }
   }, [isAnalysisAlertOpen]);
 
@@ -81,7 +82,7 @@ const Place = () => {
     resetAnalysisState();
     resetMapSettingsState();
     resetMapCursor();
-    savePlaceOption('area');
+    savePlaceSection('area');
 
     replace(`/custom-area${queryParams ? `?${queryParams}` : ''}`, null);
   }, [setDrawingToolState, resetAnalysisState, resetMapCursor, replace, queryParams]);
@@ -109,7 +110,7 @@ const Place = () => {
       window.localStorage.setItem(MANGROVES_SKIP_ANALYSIS_ALERT, String(skipAnalysisAlert));
     }
 
-    if (placeOption === 'worldwide') {
+    if (placeSection === 'worldwide') {
       handleWorldwideView();
     }
 
@@ -123,7 +124,7 @@ const Place = () => {
   }, [
     queryParams,
     skipAnalysisAlert,
-    placeOption,
+    placeSection,
     replace,
     closeAnalysisAlertModal,
     resetDrawingState,
@@ -141,7 +142,7 @@ const Place = () => {
     } else {
       handleWorldwideView();
     }
-    savePlaceOption('worldwide');
+    savePlaceSection('worldwide');
   }, [handleWorldwideView, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
 
   const handleOnClickSearch = useCallback(() => {
@@ -150,7 +151,7 @@ const Place = () => {
     } else {
       openLocationsModal();
     }
-    savePlaceOption('search');
+    savePlaceSection('search');
   }, [openLocationsModal, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
 
   return (
@@ -166,12 +167,12 @@ const Place = () => {
             icon={GLOBE_SVG}
             className={cn({
               'h-9 w-9 rounded-full p-1': true,
-              'bg-brand-800 fill-current text-white': placeOption === 'worldwide',
-              'fill-current text-brand-800': placeOption !== 'worldwide',
+              'bg-brand-800 fill-current text-white': placeSection === 'worldwide',
+              'fill-current text-brand-800': placeSection !== 'worldwide',
             })}
           />
         </button>
-        <Dialog open={placeOption === 'search' && locationsModalIsOpen}>
+        <Dialog open={placeSection === 'search' && locationsModalIsOpen}>
           <DialogTrigger asChild>
             <button
               onClick={handleOnClickSearch}
@@ -181,8 +182,8 @@ const Place = () => {
                 icon={GLASS_SVG}
                 className={cn({
                   'h-9 w-9 rounded-full p-1': true,
-                  'bg-brand-800 fill-current text-white': placeOption === 'search',
-                  'fill-current text-brand-800': placeOption !== 'search',
+                  'bg-brand-800 fill-current text-white': placeSection === 'search',
+                  'fill-current text-brand-800': placeSection !== 'search',
                 })}
               />
             </button>
@@ -201,8 +202,8 @@ const Place = () => {
             icon={AREA_SVG}
             className={cn({
               'h-9 w-9 rounded-full p-1': true,
-              'bg-brand-800 fill-current text-white': placeOption === 'area',
-              'fill-current text-brand-800': placeOption !== 'area',
+              'bg-brand-800 fill-current text-white': placeSection === 'area',
+              'fill-current text-brand-800': placeSection !== 'area',
             })}
           />
         </button>

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -109,6 +109,10 @@ const Place = () => {
       window.localStorage.setItem(MANGROVES_SKIP_ANALYSIS_ALERT, String(skipAnalysisAlert));
     }
 
+    if (placeOption === 'worldwide') {
+      handleWorldwideView();
+    }
+
     resetDrawingState();
     resetAnalysisState();
     resetMapSettingsState();
@@ -119,10 +123,12 @@ const Place = () => {
   }, [
     queryParams,
     skipAnalysisAlert,
+    placeOption,
     replace,
     closeAnalysisAlertModal,
     resetDrawingState,
     resetAnalysisState,
+    handleWorldwideView,
   ]);
 
   useEffect(() => {

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -95,6 +95,11 @@ const Place = () => {
     setAnalysisAlert(false);
   }, [setAnalysisAlert]);
 
+  const handleCancelResetPage = useCallback(() => {
+    closeAnalysisAlertModal();
+    setLocationsModalIsOpen(false);
+  }, [closeAnalysisAlertModal]);
+
   const handleCheckbox = useCallback(() => {
     setSkipAnalysisAlert(!skipAnalysisAlert);
   }, [skipAnalysisAlert]);
@@ -224,7 +229,7 @@ const Place = () => {
             <div className="flex items-center justify-center space-x-5">
               <button
                 type="button"
-                onClick={closeAnalysisAlertModal}
+                onClick={handleCancelResetPage}
                 className="rounded-2xl border-2 border-brand-800/20 px-6 py-[1px] text-sm text-brand-800"
               >
                 Cancel

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
 import { useMap } from 'react-map-gl';
 
@@ -16,15 +16,15 @@ import { placeSectionAtom } from 'store/sidebar';
 
 import { useRecoilState, useSetRecoilState, useResetRecoilState, useRecoilValue } from 'recoil';
 
+import AnalysisAlert from 'containers/alert';
 import LocationDialogContent from 'containers/location-dialog-content';
 
-import { Dialog, DialogPortal, DialogContent, DialogTrigger } from 'components/dialog';
+import { Dialog, DialogTrigger } from 'components/dialog';
 import Icon from 'components/icon';
 
 import AREA_SVG from 'svgs/sidebar/area.svg?sprite';
 import GLASS_SVG from 'svgs/sidebar/glass.svg?sprite';
 import GLOBE_SVG from 'svgs/sidebar/globe.svg?sprite';
-import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
 
 import { STYLES } from '../constants';
 
@@ -53,14 +53,14 @@ const Place = () => {
 
   const openLocationsModal = useCallback(() => {
     if (!locationsModalIsOpen) setLocationsModalIsOpen(true);
-  }, [locationsModalIsOpen]);
+  }, [locationsModalIsOpen, setLocationsModalIsOpen]);
 
   const closeMenu = useCallback(() => {
     if (!isAnalysisAlertOpen) {
       setLocationsModalIsOpen(false);
       savePlaceSection(null);
     }
-  }, [isAnalysisAlertOpen]);
+  }, [isAnalysisAlertOpen, setLocationsModalIsOpen, savePlaceSection]);
 
   const handleWorldwideView = useCallback(() => {
     resetDrawingState();
@@ -87,7 +87,14 @@ const Place = () => {
     savePlaceSection('area');
 
     replace(`/custom-area${queryParams ? `?${queryParams}` : ''}`, null);
-  }, [setDrawingToolState, resetAnalysisState, resetMapCursor, replace, queryParams]);
+  }, [
+    setDrawingToolState,
+    resetAnalysisState,
+    resetMapCursor,
+    replace,
+    queryParams,
+    savePlaceSection,
+  ]);
 
   const openAnalysisAlertModal = useCallback(() => {
     setAnalysisAlert(true);
@@ -97,15 +104,6 @@ const Place = () => {
   const closeAnalysisAlertModal = useCallback(() => {
     setAnalysisAlert(false);
   }, [setAnalysisAlert]);
-
-  const handleCancelResetPage = useCallback(() => {
-    closeAnalysisAlertModal();
-    setLocationsModalIsOpen(false);
-  }, [closeAnalysisAlertModal]);
-
-  const handleCheckbox = useCallback(() => {
-    setSkipAnalysisAlert(!skipAnalysisAlert);
-  }, [skipAnalysisAlert]);
 
   const handleResetPage = useCallback(() => {
     if (skipAnalysisAlert) {
@@ -136,7 +134,7 @@ const Place = () => {
 
   useEffect(() => {
     setSkipAnalysisAlert(window.localStorage.getItem(MANGROVES_SKIP_ANALYSIS_ALERT) === 'true');
-  }, []);
+  }, [setSkipAnalysisAlert]);
 
   const handleOnClickWorldwide = useCallback(() => {
     if (isAnalysisEnabled && !skipAnalysisAlert) {
@@ -145,7 +143,13 @@ const Place = () => {
       handleWorldwideView();
     }
     savePlaceSection('worldwide');
-  }, [handleWorldwideView, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
+  }, [
+    handleWorldwideView,
+    isAnalysisEnabled,
+    skipAnalysisAlert,
+    openAnalysisAlertModal,
+    savePlaceSection,
+  ]);
 
   const handleOnClickSearch = useCallback(() => {
     if (isAnalysisEnabled && !skipAnalysisAlert) {
@@ -154,7 +158,13 @@ const Place = () => {
       openLocationsModal();
     }
     savePlaceSection('search');
-  }, [openLocationsModal, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
+  }, [
+    openLocationsModal,
+    isAnalysisEnabled,
+    skipAnalysisAlert,
+    openAnalysisAlertModal,
+    savePlaceSection,
+  ]);
 
   return (
     <div className="flex flex-col space-y-2 text-center">
@@ -210,50 +220,7 @@ const Place = () => {
           />
         </button>
       </div>
-      <Dialog open={isAnalysisAlertOpen}>
-        <DialogPortal className="z-50">
-          <DialogContent
-            className="space-y-5 rounded-3xl p-10 md:left-auto"
-            onEscapeKeyDown={closeAnalysisAlertModal}
-          >
-            <div className="space-y-5">
-              <div className="flex justify-end">
-                <button type="button" onClick={closeAnalysisAlertModal}>
-                  <Icon icon={CLOSE_SVG} className="h-8 w-8" />
-                </button>
-              </div>
-              <h3 className="text-3xl">Reset the page and delete area</h3>
-              <div className="space-y-2">
-                <p>
-                  If you reset the page,{' '}
-                  <span className="font-semibold">your custom area will be deleted</span>. Are you
-                  sure that you want to reset the page?
-                </p>
-                <div className="flex items-center space-x-2">
-                  <input type="checkbox" name="do-not-ask" onChange={handleCheckbox} />
-                  <label htmlFor="modal">Don&apos;t ask me again.</label>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center justify-center space-x-5">
-              <button
-                type="button"
-                onClick={handleCancelResetPage}
-                className="rounded-2xl border-2 border-brand-800/20 px-6 py-[1px] text-sm text-brand-800"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleResetPage}
-                className="rounded-2xl bg-brand-800 px-6 py-[2px] text-sm text-white"
-              >
-                Reset page
-              </button>
-            </div>
-          </DialogContent>
-        </DialogPortal>
-      </Dialog>
+      <AnalysisAlert />
     </div>
   );
 };

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -16,7 +16,7 @@ import { useRecoilState, useSetRecoilState, useResetRecoilState, useRecoilValue 
 
 import LocationDialogContent from 'containers/location-dialog-content';
 
-import { Dialog, DialogContent, DialogTrigger } from 'components/dialog';
+import { Dialog, DialogPortal, DialogContent, DialogTrigger } from 'components/dialog';
 import Icon from 'components/icon';
 
 import AREA_SVG from 'svgs/sidebar/area.svg?sprite';
@@ -37,7 +37,7 @@ const Place = () => {
 
   const isPrintingMode = useRecoilValue(printModeState);
   const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
-  const [isOpen, setIsOpen] = useState(false);
+  const [locationsModalIsOpen, setLocationsModalIsOpen] = useState(false);
   const [isAnalysisAlertOpen, setAnalysisAlert] = useState(false);
   const [skipAnalysisAlert, setSkipAnalysisAlert] = useState(false);
   const [placeOption, savePlaceOption] = useState('worldwide');
@@ -48,14 +48,17 @@ const Place = () => {
 
   const queryParams = useMemo(() => asPath.split('?')[1], [asPath]);
 
-  const openMenu = useCallback(() => {
-    if (!isOpen) setIsOpen(true);
-  }, [isOpen]);
+  const openLocationsModal = useCallback(() => {
+    if (!locationsModalIsOpen) setLocationsModalIsOpen(true);
+  }, [locationsModalIsOpen]);
 
   const closeMenu = useCallback(() => {
-    setIsOpen(false);
+    if (!isAnalysisAlertOpen) {
+      setLocationsModalIsOpen(false);
+    }
+
     savePlaceOption(null);
-  }, []);
+  }, [isAnalysisAlertOpen]);
 
   const handleWorldwideView = useCallback(() => {
     resetDrawingState();
@@ -86,7 +89,8 @@ const Place = () => {
 
   const openAnalysisAlertModal = useCallback(() => {
     setAnalysisAlert(true);
-  }, [setAnalysisAlert]);
+    openLocationsModal();
+  }, [setAnalysisAlert, openLocationsModal]);
 
   const closeAnalysisAlertModal = useCallback(() => {
     setAnalysisAlert(false);
@@ -134,10 +138,10 @@ const Place = () => {
     if (isAnalysisEnabled && !skipAnalysisAlert) {
       openAnalysisAlertModal();
     } else {
-      openMenu();
+      openLocationsModal();
     }
     savePlaceOption('search');
-  }, [openMenu, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
+  }, [openLocationsModal, isAnalysisEnabled, skipAnalysisAlert, openAnalysisAlertModal]);
 
   return (
     <div className="flex flex-col space-y-2 text-center">
@@ -157,7 +161,7 @@ const Place = () => {
             })}
           />
         </button>
-        <Dialog open={isOpen}>
+        <Dialog open={locationsModalIsOpen}>
           <DialogTrigger asChild>
             <button
               onClick={handleOnClickSearch}
@@ -194,47 +198,48 @@ const Place = () => {
         </button>
       </div>
       <Dialog open={isAnalysisAlertOpen}>
-        <DialogContent
-          className="space-y-5 rounded-3xl p-10 md:left-auto"
-          onEscapeKeyDown={closeAnalysisAlertModal}
-          onInteractOutside={closeAnalysisAlertModal}
-        >
-          <div className="space-y-5">
-            <div className="flex justify-end">
-              <button type="button" onClick={closeAnalysisAlertModal}>
-                <Icon icon={CLOSE_SVG} className="h-8 w-8" />
-              </button>
-            </div>
-            <h3 className="text-3xl">Reset the page and delete area</h3>
-            <div className="space-y-2">
-              <p>
-                If you reset the page,{' '}
-                <span className="font-semibold">your custom area will be deleted</span>. Are you
-                sure that you want to reset the page?
-              </p>
-              <div className="flex items-center space-x-2">
-                <input type="checkbox" name="do-not-ask" onChange={handleCheckbox} />
-                <label htmlFor="modal">Don&apos;t ask me again.</label>
+        <DialogPortal className="z-50">
+          <DialogContent
+            className="space-y-5 rounded-3xl p-10 md:left-auto"
+            onEscapeKeyDown={closeAnalysisAlertModal}
+          >
+            <div className="space-y-5">
+              <div className="flex justify-end">
+                <button type="button" onClick={closeAnalysisAlertModal}>
+                  <Icon icon={CLOSE_SVG} className="h-8 w-8" />
+                </button>
+              </div>
+              <h3 className="text-3xl">Reset the page and delete area</h3>
+              <div className="space-y-2">
+                <p>
+                  If you reset the page,{' '}
+                  <span className="font-semibold">your custom area will be deleted</span>. Are you
+                  sure that you want to reset the page?
+                </p>
+                <div className="flex items-center space-x-2">
+                  <input type="checkbox" name="do-not-ask" onChange={handleCheckbox} />
+                  <label htmlFor="modal">Don&apos;t ask me again.</label>
+                </div>
               </div>
             </div>
-          </div>
-          <div className="flex items-center justify-center space-x-5">
-            <button
-              type="button"
-              onClick={closeAnalysisAlertModal}
-              className="rounded-2xl border-2 border-brand-800/20 px-6 py-[1px] text-sm text-brand-800"
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              onClick={handleResetPage}
-              className="rounded-2xl bg-brand-800 px-6 py-[2px] text-sm text-white"
-            >
-              Reset page
-            </button>
-          </div>
-        </DialogContent>
+            <div className="flex items-center justify-center space-x-5">
+              <button
+                type="button"
+                onClick={closeAnalysisAlertModal}
+                className="rounded-2xl border-2 border-brand-800/20 px-6 py-[1px] text-sm text-brand-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleResetPage}
+                className="rounded-2xl bg-brand-800 px-6 py-[2px] text-sm text-white"
+              >
+                Reset page
+              </button>
+            </div>
+          </DialogContent>
+        </DialogPortal>
       </Dialog>
     </div>
   );

--- a/src/containers/sidebar/place/index.tsx
+++ b/src/containers/sidebar/place/index.tsx
@@ -6,8 +6,9 @@ import { useRouter } from 'next/router';
 
 import cn from 'lib/classnames';
 
-import { analysisAlertAtom, analysisAtom } from 'store/analysis';
+import { analysisAlertAtom, analysisAtom, skipAnalysisAlertAtom } from 'store/analysis';
 import { drawingToolAtom } from 'store/drawing-tool';
+import { locationsModalAtom } from 'store/locations';
 import { mapCursorAtom } from 'store/map';
 import { mapSettingsAtom } from 'store/map-settings';
 import { printModeState } from 'store/print-mode';
@@ -32,7 +33,10 @@ const MANGROVES_SKIP_ANALYSIS_ALERT = 'MANGROVES_SKIP_ANALYSIS_ALERT';
 const Place = () => {
   const [{ enabled: isAnalysisEnabled }] = useRecoilState(analysisAtom);
   const [placeSection, savePlaceSection] = useRecoilState(placeSectionAtom);
+  const [locationsModalIsOpen, setLocationsModalIsOpen] = useRecoilState(locationsModalAtom);
   const [isAnalysisAlertOpen, setAnalysisAlert] = useRecoilState(analysisAlertAtom);
+  const [skipAnalysisAlert, setSkipAnalysisAlert] = useRecoilState(skipAnalysisAlertAtom);
+
   const setDrawingToolState = useSetRecoilState(drawingToolAtom);
   const resetAnalysisState = useResetRecoilState(analysisAtom);
   const resetDrawingState = useResetRecoilState(drawingToolAtom);
@@ -40,9 +44,6 @@ const Place = () => {
 
   const isPrintingMode = useRecoilValue(printModeState);
   const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
-  const [locationsModalIsOpen, setLocationsModalIsOpen] = useState(false);
-
-  const [skipAnalysisAlert, setSkipAnalysisAlert] = useState(false);
 
   const { [`default-desktop-${isPrintingId}`]: map } = useMap();
   const resetMapSettingsState = useResetRecoilState(mapSettingsAtom);

--- a/src/pages/[[...params]].tsx
+++ b/src/pages/[[...params]].tsx
@@ -74,6 +74,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   }
 
   if (queryClient.getQueryState(['locations'])?.status !== 'success') {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
     queryClient.prefetchQuery({
       queryKey: ['locations'],
       queryFn: fetchLocations,

--- a/src/store/analysis/index.ts
+++ b/src/store/analysis/index.ts
@@ -9,3 +9,8 @@ export const analysisAtom = atom<{
     enabled: false,
   },
 });
+
+export const analysisAlertAtom = atom<boolean>({
+  key: 'analysis-alert',
+  default: false,
+});

--- a/src/store/analysis/index.ts
+++ b/src/store/analysis/index.ts
@@ -14,3 +14,8 @@ export const analysisAlertAtom = atom<boolean>({
   key: 'analysis-alert',
   default: false,
 });
+
+export const skipAnalysisAlertAtom = atom<boolean>({
+  key: 'skip-analysis-alert',
+  default: false,
+});

--- a/src/store/locations/index.ts
+++ b/src/store/locations/index.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const locationsModalAtom = atom<boolean>({
+  key: 'locations-modal',
+  default: false,
+});

--- a/src/store/sidebar/index.ts
+++ b/src/store/sidebar/index.ts
@@ -16,3 +16,8 @@ export const mapViewAtom = atom<boolean>({
   key: 'map-view',
   default: true,
 });
+
+export const placeSectionAtom = atom<'worldwide' | 'search' | 'area'>({
+  key: 'place-section',
+  default: 'worldwide',
+});


### PR DESCRIPTION
## Drawing tool reset flow

### Testing instructions

- [x] When user exits the drawing tool, by clicking on the magnifying glass they should see the page reset modal and the locations modal below.
- [x] When user moves from the drawing tool to Worldwide, the locations modal shouldn't appear.
- [x] When user moves from the drawing tool to Locations, both modals appear (locations and reset page). If they click cancel, the locations modal should close as well.
- [x] When user clicks on worldwide and the alert modal opens and they resets the page, the map should fly to worldwide.
- [x] When you open the locations modal from the Location title instead of from the sidebar, the alerts modal should show and reproduce search icon click flow logic.

### Feature relevant tickets

[GMW-634](https://vizzuality.atlassian.net/browse/GMW-634)


[GMW-634]: https://vizzuality.atlassian.net/browse/GMW-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ