### PR TITLE
(fix): recover language selector

### DIFF
--- a/src/containers/translate-scripts/index.tsx
+++ b/src/containers/translate-scripts/index.tsx
@@ -1,8 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import Script from 'next/script';
 
+import { printModeState } from 'store/print-mode';
+
+import { useRecoilValue } from 'recoil';
+
 const TranslateScripts = () => {
+  const isPrintingMode = useRecoilValue(printModeState);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (isPrintingMode) {
+        const langSelector = document.querySelector('#tx-live-lang-container');
+        langSelector?.classList.add('hidden-langselector');
+      }
+      if (!isPrintingMode) {
+        const langSelector = document.querySelector('#tx-live-lang-container');
+        langSelector?.classList.remove('hidden-langselector');
+      }
+    }
+  }, [isPrintingMode]);
+
   return (
     <>
       <Script

--- a/src/containers/translate-scripts/index.tsx
+++ b/src/containers/translate-scripts/index.tsx
@@ -11,12 +11,11 @@ const TranslateScripts = () => {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      if (isPrintingMode) {
-        const langSelector = document.querySelector('#tx-live-lang-container');
+      const langSelector = document.querySelector('#tx-live-lang-container');
+      if (isPrintingMode) 
         langSelector?.classList.add('hidden-langselector');
       }
       if (!isPrintingMode) {
-        const langSelector = document.querySelector('#tx-live-lang-container');
         langSelector?.classList.remove('hidden-langselector');
       }
     }

--- a/src/containers/translate-scripts/index.tsx
+++ b/src/containers/translate-scripts/index.tsx
@@ -2,20 +2,13 @@ import React from 'react';
 
 import Script from 'next/script';
 
-import { printModeState } from 'store/print-mode';
-
-import { useRecoilValue } from 'recoil';
-
 const TranslateScripts = () => {
-  const isPrintingMode = useRecoilValue(printModeState);
-
   return (
-    !isPrintingMode && (
-      <>
-        <Script
-          id="transifex-live-settings"
-          dangerouslySetInnerHTML={{
-            __html: `
+    <>
+      <Script
+        id="transifex-live-settings"
+        dangerouslySetInnerHTML={{
+          __html: `
           window.liveSettings = {
             api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}',
             detectlang: true,
@@ -24,11 +17,10 @@ const TranslateScripts = () => {
             manual_init: false,
             translate_urls: false,
           }`,
-          }}
-        />
-        <Script id="transifex-live" src="//cdn.transifex.com/live.js" />
-      </>
-    )
+        }}
+      />
+      <Script id="transifex-live" src="//cdn.transifex.com/live.js" />
+    </>
   );
 };
 

--- a/src/containers/translate-scripts/index.tsx
+++ b/src/containers/translate-scripts/index.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
 import Script from 'next/script';
+
+import { printModeState } from 'store/print-mode';
+
+import { useRecoilValue } from 'recoil';
+
 const TranslateScripts = () => {
+  const isPrintingMode = useRecoilValue(printModeState);
+
   return (
-    <>
-      <Script
-        id="transifex-live-settings"
-        dangerouslySetInnerHTML={{
-          __html: `
+    !isPrintingMode && (
+      <>
+        <Script
+          id="transifex-live-settings"
+          dangerouslySetInnerHTML={{
+            __html: `
           window.liveSettings = {
             api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}',
             detectlang: true,
@@ -16,10 +24,11 @@ const TranslateScripts = () => {
             manual_init: false,
             translate_urls: false,
           }`,
-        }}
-      />
-      <Script id="transifex-live" src="//cdn.transifex.com/live.js" />
-    </>
+          }}
+        />
+        <Script id="transifex-live" src="//cdn.transifex.com/live.js" />
+      </>
+    )
   );
 };
 

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -17,6 +19,19 @@ import WidgetsContainer from 'containers/widgets';
 
 const DesktopLayout = () => {
   const isPrintingMode = useRecoilValue(printModeState);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (isPrintingMode) {
+        const langSelector = document.querySelector('#tx-live-lang-container');
+        langSelector?.classList.add('hidden-langselector');
+      }
+      if (!isPrintingMode) {
+        const langSelector = document.querySelector('#tx-live-lang-container');
+        langSelector?.classList.remove('hidden-langselector');
+      }
+    }
+  }, [isPrintingMode]);
 
   const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
   const {

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -40,9 +40,8 @@ const DesktopLayout = () => {
         <meta name="og:type" content="website" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
       </Head>
-      <div className="print:hidden">
-        <TranslateScripts />
-      </div>
+
+      <TranslateScripts />
 
       <div className="relative h-screen w-screen">
         {isPrintingMode && (

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -1,5 +1,3 @@
-import { useEffect } from 'react';
-
 import Head from 'next/head';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -19,19 +17,6 @@ import WidgetsContainer from 'containers/widgets';
 
 const DesktopLayout = () => {
   const isPrintingMode = useRecoilValue(printModeState);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      if (isPrintingMode) {
-        const langSelector = document.querySelector('#tx-live-lang-container');
-        langSelector?.classList.add('hidden-langselector');
-      }
-      if (!isPrintingMode) {
-        const langSelector = document.querySelector('#tx-live-lang-container');
-        langSelector?.classList.remove('hidden-langselector');
-      }
-    }
-  }, [isPrintingMode]);
 
   const isPrintingId = isPrintingMode ? 'print-mode' : 'no-print';
   const {

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -40,7 +40,9 @@ const DesktopLayout = () => {
         <meta name="og:type" content="website" />
         <meta name="viewport" content="width=device-width,initial-scale=1" />
       </Head>
-      <TranslateScripts />
+      <div className="print:hidden">
+        <TranslateScripts />
+      </div>
 
       <div className="relative h-screen w-screen">
         {isPrintingMode && (

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -8,9 +8,9 @@ const Home: React.FC = () => (
       <title>Privacy policy</title>
       <meta name="viewport" content="width=device-width,initial-scale=1" />
     </Head>
-    <div className="print:hidden">
-      <TranslateScripts />
-    </div>
+
+    <TranslateScripts />
+
     <h1>Privacy policy</h1>
   </div>
 );

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -8,7 +8,9 @@ const Home: React.FC = () => (
       <title>Privacy policy</title>
       <meta name="viewport" content="width=device-width,initial-scale=1" />
     </Head>
-    <TranslateScripts />
+    <div className="print:hidden">
+      <TranslateScripts />
+    </div>
     <h1>Privacy policy</h1>
   </div>
 );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -109,7 +109,7 @@ body {
 }
 
 .txlive-langselector {
-  @apply !top-0 !right-28 !bottom-auto !left-auto !bg-brand-800 !rounded-b-3xl !px-5 !uppercase !font-semibold !font-sans !print;
+  @apply !top-0 !right-28 !bottom-auto !left-auto !bg-brand-800 !rounded-b-3xl !px-5 !uppercase !font-semibold !font-sans;
 }
 
 .txlive-langselector-list {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -108,8 +108,13 @@ body {
   border-top-color: #00857F !important;
 }
 
+
 .txlive-langselector {
   @apply !top-0 !right-28 !bottom-auto !left-auto !bg-brand-800 !rounded-b-3xl !px-5 !uppercase !font-semibold !font-sans;
+}
+
+.hidden-langselector {
+  @apply !hidden;
 }
 
 .txlive-langselector-list {


### PR DESCRIPTION
## Recover language selector

### Overview

This PR recover the language selector and hide it from print layout.

### Testing instructions

Test also to print and check you don't have selector inside.

### Feature relevant tickets

[GMW-638](https://vizzuality.atlassian.net/browse/GMW-638)


[GMW-638]: https://vizzuality.atlassian.net/browse/GMW-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ