### PR TITLE
coastal protection widget

### DIFF
--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -41,7 +41,6 @@ const ChartsMap = new Map([
   ['line', LineChart],
   ['composed', ComposedChart],
 ]);
-
 const Chart = ({ config }) => {
   const {
     data,
@@ -71,13 +70,19 @@ const Chart = ({ config }) => {
     onBrushEnd,
     startIndex,
     endIndex,
+    dataKey,
   } = config;
 
-  const { pies, bars, lines } = chartBase;
+  const { pies, bars, lines, bar } = chartBase;
   const Chart = ChartsMap.get(type);
+
   return (
     <div className="relative h-full w-full">
-      <ResponsiveContainer width="100%" height={height || 250} className="relative w-full flex-1">
+      <ResponsiveContainer
+        width={width || '100%'}
+        height={height || 250}
+        className="relative w-full flex-1"
+      >
         <Chart
           stackOffset={stackOffset}
           height={height}
@@ -147,14 +152,17 @@ const Chart = ({ config }) => {
               {...yAxis}
             />
           )}
+          {bar && <Bar dataKey={dataKey} {...bar} />}
           {bars &&
-            Object.keys(bars).map((key) => (
-              <Bar key={key} dataKey={key} dot={false} {...bars[key]}>
-                {!!bars[key].label && <Label {...bars[key].label} />}
-                {bars[key].itemColor &&
-                  data.map((item) => <Cell key={`c_${item.color}`} fill={item.color} />)}
-              </Bar>
-            ))}
+            Object.keys(bars).map((key) => {
+              return (
+                <Bar key={key} dataKey={key} dot={false} {...bars[key]}>
+                  {!!bars[key].label && <Label {...bars[key].label} />}
+                  {bars[key].itemColor &&
+                    data.map((item) => <Cell key={`c_${item.color}`} fill={item.color} />)}
+                </Bar>
+              );
+            })}
 
           {lines &&
             Object.keys(lines).map((key) => (

--- a/src/containers/datasets/flood-protection/coastal-protection/index.tsx
+++ b/src/containers/datasets/flood-protection/coastal-protection/index.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router';
+
+import cn from 'lib/classnames';
+
+import { useLocation } from 'containers/datasets/locations/hooks';
+import { LocationTypes } from 'containers/datasets/locations/types';
+
+import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+
+const CoastalProtection = () => {
+  const {
+    query: { params: queryParams },
+  } = useRouter();
+  const locationType = queryParams?.[0] as LocationTypes;
+  const id = queryParams?.[1];
+  const {
+    data: { name: location },
+  } = useLocation(locationType, id);
+  return (
+    <div
+      className={cn({
+        [WIDGET_CARD_WRAPPER_STYLE]: true,
+        relative: true,
+      })}
+    >
+      <div className="space-y-4">
+        <p className={WIDGET_SENTENCE_STYLE}>
+          In <span className="font-bold"> {location}</span>, mangroves are protecting the coast
+          against flood caused from different type of storms.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CoastalProtection;

--- a/src/containers/datasets/flood-protection/info.mdx
+++ b/src/containers/datasets/flood-protection/info.mdx
@@ -1,0 +1,19 @@
+import LayoutMdx from 'layouts/mdx';
+
+# Mangrove Coastal Protection
+
+## Overview: 
+Pending
+
+## Reference: 
+Pending
+
+## License: 
+Pending
+    
+
+export default ({ children, ...props }) => (
+  <LayoutMdx {...props}>
+    {children}
+  </LayoutMdx>
+);

--- a/src/containers/datasets/flood-protection/storms/chart.tsx
+++ b/src/containers/datasets/flood-protection/storms/chart.tsx
@@ -6,8 +6,10 @@ import type { Data } from '../types';
 
 const FloodProtectionChart = ({ data }: { data: Data }) => {
   return (
-    <div className="flex w-full items-center justify-between pb-10">
-      <Chart config={data} />
+    <div className="grid w-full flex-1 grid-cols-3 items-center pb-10">
+      <div className="col-span-2">
+        <Chart config={data} />
+      </div>
       <Legend items={data.data} />
     </div>
   );

--- a/src/containers/datasets/flood-protection/storms/chart.tsx
+++ b/src/containers/datasets/flood-protection/storms/chart.tsx
@@ -1,0 +1,16 @@
+import Legend from 'containers/legend';
+
+import Chart from 'components/chart';
+
+import type { Data } from '../types';
+
+const FloodProtectionChart = ({ data }: { data: Data }) => {
+  return (
+    <div className="flex w-full items-center justify-between pb-10">
+      <Chart config={data} />
+      <Legend items={data.data} />
+    </div>
+  );
+};
+
+export default FloodProtectionChart;

--- a/src/containers/datasets/flood-protection/storms/chart.tsx
+++ b/src/containers/datasets/flood-protection/storms/chart.tsx
@@ -4,15 +4,13 @@ import Chart from 'components/chart';
 
 import type { Data } from '../types';
 
-const FloodProtectionChart = ({ data }: { data: Data }) => {
-  return (
-    <div className="grid w-full flex-1 grid-cols-3 items-center pb-10">
-      <div className="col-span-2">
-        <Chart config={data} />
-      </div>
-      <Legend items={data.data} />
+const FloodProtectionChart = ({ data }: { data: Data }) => (
+  <div className="grid w-full flex-1 grid-cols-3 items-center pb-10">
+    <div className="col-span-2">
+      <Chart config={data} />
     </div>
-  );
-};
+    <Legend items={data.data} />
+  </div>
+);
 
 export default FloodProtectionChart;

--- a/src/containers/datasets/flood-protection/storms/constants.ts
+++ b/src/containers/datasets/flood-protection/storms/constants.ts
@@ -1,0 +1,11 @@
+export const LABELS = {
+  annual: 'annual',
+  '25_year': '25-year',
+  '100_year': '100-year',
+};
+
+export const UNITS_LABELS = {
+  people: 'individuals',
+  usd: '$',
+  km2: 'km²',
+};

--- a/src/containers/datasets/flood-protection/storms/constants.ts
+++ b/src/containers/datasets/flood-protection/storms/constants.ts
@@ -1,7 +1,16 @@
 export const LABELS = {
-  annual: 'annual',
-  '25_year': '25-year',
-  '100_year': '100-year',
+  annual: {
+    short: 'annual',
+    large: 'annually',
+  },
+  '25_year': {
+    short: '25-year',
+    large: 'once every 25 years',
+  },
+  '100_year': {
+    short: '100-year',
+    large: 'once every 100 years',
+  },
 };
 
 export const UNITS_LABELS = {

--- a/src/containers/datasets/flood-protection/storms/hooks.tsx
+++ b/src/containers/datasets/flood-protection/storms/hooks.tsx
@@ -1,0 +1,179 @@
+import type { SourceProps, LayerProps } from 'react-map-gl';
+
+import { useRouter } from 'next/router';
+
+import { numberFormat, formatMillion } from 'lib/format';
+
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import chroma from 'chroma-js';
+
+import { useLocation } from 'containers/datasets/locations/hooks';
+import type { LocationTypes } from 'containers/datasets/locations/types';
+
+import API from 'services/api';
+
+import type { Data, DataResponse, FloodProtectionPeriodId } from '../types';
+
+import { LABELS, UNITS_LABELS } from './constants';
+import Tooltip from './tooltip';
+
+type UseParamsOptions = {
+  location_id?: string;
+  indicator: 'area' | 'population' | 'stock';
+};
+
+const fakeData = [
+  {
+    indicator: 'stock',
+    period: 'annual',
+    periodFormatted: 'annual',
+    value: 600,
+    annual: 600,
+    color: 'red',
+  },
+  {
+    indicator: 'stock',
+    period: '25_year',
+    periodFormatted: '25-year',
+    value: 2000,
+    '25-year': 2000,
+    color: 'red',
+  },
+  {
+    indicator: 'stock',
+    period: '100_year',
+    periodFormatted: '100-year',
+    value: 21000,
+    '100-year': 21000,
+    color: 'red',
+  },
+];
+
+const GRADIENTS_BY_INDICATOR = {
+  area: ['#F3E0F7', '#E4C7F1', '#D1AFE8', '#AB91CF', '#9F82CE', '#826DBA', '#63589F'],
+  population: ['#FFC6C4', '#F4A3A8', '#E38191', '#CC607D', '#AD466C', '#8B3058', '#672044'],
+  stock: ['#D1EEEA', '#A8DBD9', '#85C4C9', '#68ABB8', '#4F90A6', '#3B738F', '#2A5674'],
+};
+
+const getColor = (data, selectedPeriod, indicator) => {
+  const indicatorData = data.filter((d) => d.period === selectedPeriod)[0];
+  const { value } = indicatorData;
+  const colorScale = chroma.scale(GRADIENTS_BY_INDICATOR[indicator]).domain([0, 2000]);
+  return colorScale(value);
+};
+
+const getBars = (data, selectedPeriod, metadata, indicator) =>
+  data.map((d) => ({
+    ...d,
+    barSize: 40,
+    fill: d.period === selectedPeriod ? getColor(data, selectedPeriod, indicator) : '#E1E1E1',
+    isAnimationActive: false,
+    value: d.value,
+    period: LABELS[d.period],
+    color: d.period === selectedPeriod ? getColor(data, selectedPeriod, indicator) : '#E1E1E1',
+    [LABELS[d.period]]: d.value,
+    showValue: true,
+    label: d.period,
+    labelFormatted: LABELS[d.period],
+    valueFormatted: d.value > 1000000 ? formatMillion(d.value) : numberFormat(d.value),
+    unit: UNITS_LABELS[metadata.unit],
+  }));
+
+export function useMangrovesFloodProtection(
+  selectedPeriod: FloodProtectionPeriodId,
+  params: UseParamsOptions,
+  queryOptions?: UseQueryOptions<DataResponse, Error, Data>
+) {
+  const {
+    query: { params: queryParams },
+  } = useRouter();
+  const locationType = queryParams?.[0] as LocationTypes;
+  const id = queryParams?.[1];
+  const {
+    data: { name: location, id: currentLocation, location_id },
+  } = useLocation(locationType, id);
+  const fetchMangrovesFloodProtection = () =>
+    API.request({
+      method: 'GET',
+      url: '/widgets/flood_protection',
+      params: {
+        ...(!!location_id ? { location_id: 'worldwide' } : { location_id: currentLocation }),
+        ...params,
+      },
+    }).then((response) => response.data);
+  return useQuery(['flood-protection', params, location_id], fetchMangrovesFloodProtection, {
+    select: (data) => {
+      const ChartData = getBars(fakeData, selectedPeriod, data.metadata, params.indicator);
+      const selectedValue = ChartData.find((d) => d.label === selectedPeriod).value;
+      const TooltipData = {
+        content: (properties) => <Tooltip {...properties} />,
+      };
+      return {
+        data: ChartData,
+        config: {
+          type: 'bar',
+          dataKey: 'value',
+          width: 275,
+          margin: {
+            top: 40,
+            bottom: 0,
+            left: 20,
+            right: 40,
+          },
+          chartBase: {
+            dataKey: 'value',
+            type: 'bar',
+            bar: ChartData,
+          },
+          data: ChartData,
+          xKey: 'periodFormatted',
+          xAxis: {
+            type: 'category',
+            tick: {
+              fontSize: 12,
+              lineHeight: 20,
+              fill: 'rgba(0, 0, 0, 0.54)',
+            },
+          },
+          yAxis: {
+            label: (props) => {
+              return (
+                <g>
+                  <text
+                    x={10}
+                    y={15}
+                    textAnchor="start"
+                    fontSize={12}
+                    fontWeight={700}
+                    fill="rgba(0, 0, 0, 0.85)"
+                  >
+                    {UNITS_LABELS[data.metadata.unit]}
+                  </text>
+                </g>
+              );
+            },
+            tick: {
+              fontSize: 12,
+              fill: 'rgba(0,0,0,0.54)',
+            },
+            tickNumber: 5,
+            width: 30,
+            interval: 0,
+            orientation: 'left',
+          },
+          tooltip: TooltipData,
+          cartesianGrid: {
+            vertical: false,
+            strokeDasharray: '5 15',
+          },
+        },
+        selectedValue,
+        ...data.metadata,
+        min: 600,
+        max: 21000,
+        location,
+      };
+    },
+    ...queryOptions,
+  });
+}

--- a/src/containers/datasets/flood-protection/storms/hooks.tsx
+++ b/src/containers/datasets/flood-protection/storms/hooks.tsx
@@ -44,7 +44,7 @@ const getFormattedValue = (value: number, indicator: FloodProtectionIndicatorId)
     const roundedValue = Math.round(value);
     return roundedValue > 1000000 ? formatMillion(roundedValue) : roundedValue;
   }
-  return value > 1000000 ? formatMillion(value) : numberFormat(value);
+  return value > 1000000 ? formatMillion(value) : value % 2 === 0 ? value : numberFormat(value);
 };
 
 const getBars = (data, selectedPeriod, metadata, indicator) => {
@@ -55,12 +55,12 @@ const getBars = (data, selectedPeriod, metadata, indicator) => {
     fill: d.period === selectedPeriod ? color : '#E1E1E1',
     isAnimationActive: false,
     value: d.value,
-    period: LABELS[d.period],
+    period: LABELS[d.period].short,
     color: d.period === selectedPeriod ? color : '#E1E1E1',
     [LABELS[d.period]]: d.value,
     showValue: true,
     label: d.period,
-    labelFormatted: LABELS[d.period],
+    labelFormatted: LABELS[d.period].short,
     valueFormatted: getFormattedValue(d.value, indicator),
     unit: UNITS_LABELS[metadata.unit],
   }));
@@ -91,12 +91,12 @@ export function useMangrovesFloodProtection(
   return useQuery(['flood-protection', params, location_id], fetchMangrovesFloodProtection, {
     select: (data) => {
       const ChartData = getBars(data.data, selectedPeriod, data.metadata, params.indicator);
-      const selectedValue = ChartData.find((d) => d.label === selectedPeriod).valueFormatted;
+      const selectedValue = ChartData.find((d) => d.label === selectedPeriod).value;
       const TooltipData = {
         content: (properties) => <Tooltip {...properties} />,
       };
-      const min = getFormattedValue(data.metadata.min, params.indicator);
-      const max = getFormattedValue(data.metadata.max, params.indicator);
+      const min = data.metadata.min;
+      const max = data.metadata.max;
       return {
         data: ChartData,
         config: {
@@ -106,7 +106,7 @@ export function useMangrovesFloodProtection(
           margin: {
             top: 40,
             bottom: 0,
-            left: 20,
+            left: 25,
             right: 40,
           },
           chartBase: {
@@ -162,6 +162,7 @@ export function useMangrovesFloodProtection(
         min,
         max,
         location,
+        getFormattedValue,
       };
     },
     ...queryOptions,

--- a/src/containers/datasets/flood-protection/storms/layers/area.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/area.tsx
@@ -1,0 +1,81 @@
+import { Source, Layer } from 'react-map-gl';
+import type { SourceProps, LayerProps } from 'react-map-gl';
+
+import { floodPeriodAtom } from 'store/widgets/flood-protection';
+
+import { useRecoilValue } from 'recoil';
+export function useSource(): SourceProps {
+  return {
+    id: 'Coastal_protection_area',
+    type: 'vector',
+    url: 'mapbox://globalmangrovewatch.1j82fo12',
+  };
+}
+
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
+  const min = 0;
+  const max = 11303;
+  const period = useRecoilValue(floodPeriodAtom);
+
+  return [
+    {
+      id,
+      'source-layer': 'coastal_protection_map',
+      filter: ['has', `${period}_area`],
+      type: 'fill',
+      paint: {
+        'fill-color': [
+          'interpolate',
+          ['linear'],
+          ['get', `${period}_area`],
+          min,
+          '#F3E0F7',
+          max,
+          '#63589F',
+        ],
+        'fill-outline-color': [
+          'interpolate',
+          ['linear'],
+          ['get', `${period}_area`],
+          min,
+          '#F3E0F7',
+          max,
+          '#63589F',
+        ],
+      },
+    },
+    {
+      id: `${id}-line`,
+      'source-layer': 'coastal_protection_map',
+      filter: ['has', `${period}_area`],
+      type: 'line',
+      paint: {
+        'line-color': [
+          'interpolate',
+          ['linear'],
+          ['get', `${period}_area`],
+          min,
+          '#F3E0F7',
+          max,
+          '#63589F',
+        ],
+      },
+    },
+  ];
+}
+
+const MangrovesFloodProtectionLayer = ({ beforeId, id }: LayerProps) => {
+  const SOURCE = useSource();
+  const LAYERS = useLayers({ id });
+
+  if (!SOURCE || !LAYERS) return null;
+  return (
+    <Source {...SOURCE}>
+      {LAYERS.map((LAYER) => (
+        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
+      ))}
+    </Source>
+  );
+};
+
+export default MangrovesFloodProtectionLayer;

--- a/src/containers/datasets/flood-protection/storms/layers/area.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/area.tsx
@@ -38,6 +38,7 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
           max,
           '#63589F',
         ],
+        'fill-opacity': 0.7,
         'fill-outline-color': [
           'interpolate',
           ['linear'],

--- a/src/containers/datasets/flood-protection/storms/layers/area.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/area.tsx
@@ -1,9 +1,11 @@
 import { Source, Layer } from 'react-map-gl';
 import type { SourceProps, LayerProps } from 'react-map-gl';
 
-import { floodPeriodAtom } from 'store/widgets/flood-protection';
+import { floodAreaPeriodAtom } from 'store/widgets/flood-protection';
 
 import { useRecoilValue } from 'recoil';
+
+import { useMangrovesFloodProtection } from '../hooks';
 export function useSource(): SourceProps {
   return {
     id: 'Coastal_protection_area',
@@ -13,10 +15,13 @@ export function useSource(): SourceProps {
 }
 
 export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
-  const min = 0;
-  const max = 11303;
-  const period = useRecoilValue(floodPeriodAtom);
+  const period = useRecoilValue(floodAreaPeriodAtom);
+  const { data } = useMangrovesFloodProtection(period, {
+    indicator: 'area',
+  });
 
+  if (!data || !data?.data?.length) return null;
+  const { max, min } = data;
   return [
     {
       id,

--- a/src/containers/datasets/flood-protection/storms/layers/population.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/population.tsx
@@ -1,9 +1,11 @@
 import { Source, Layer } from 'react-map-gl';
 import type { SourceProps, LayerProps } from 'react-map-gl';
 
-import { floodPeriodAtom } from 'store/widgets/flood-protection';
+import { floodPopulationPeriodAtom } from 'store/widgets/flood-protection';
 
 import { useRecoilValue } from 'recoil';
+
+import { useMangrovesFloodProtection } from '../hooks';
 
 export function useSource(): SourceProps {
   return {
@@ -14,9 +16,13 @@ export function useSource(): SourceProps {
 }
 
 export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
-  const min = 0;
-  const max = 8400000;
-  const period = useRecoilValue(floodPeriodAtom);
+  const period = useRecoilValue(floodPopulationPeriodAtom);
+  const { data } = useMangrovesFloodProtection(period, {
+    indicator: 'population',
+  });
+
+  if (!data || !data?.data?.length) return null;
+  const { max, min } = data;
   return [
     {
       id,

--- a/src/containers/datasets/flood-protection/storms/layers/population.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/population.tsx
@@ -1,0 +1,54 @@
+import { Source, Layer } from 'react-map-gl';
+import type { SourceProps, LayerProps } from 'react-map-gl';
+
+import { floodPeriodAtom } from 'store/widgets/flood-protection';
+
+import { useRecoilValue } from 'recoil';
+
+export function useSource(): SourceProps {
+  return {
+    id: 'Coastal_protection_population',
+    type: 'vector',
+    url: 'mapbox://globalmangrovewatch.1j82fo12',
+  };
+}
+
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
+  const min = 0;
+  const max = 8400000;
+  const period = useRecoilValue(floodPeriodAtom);
+  return [
+    {
+      id,
+      'source-layer': 'coastal_protection_map',
+      filter: ['has', `${period}_population`],
+      type: 'fill',
+      paint: {
+        'fill-color': [
+          'interpolate',
+          ['linear'],
+          ['get', `${period}_population`],
+          min,
+          '#FFC6C4',
+          max,
+          '#672044',
+        ],
+      },
+    },
+  ];
+}
+
+const MangrovesFloodProtectionPopulationLayer = ({ beforeId, id }: LayerProps) => {
+  const SOURCE = useSource();
+  const LAYERS = useLayers({ id });
+  if (!SOURCE || !LAYERS) return null;
+  return (
+    <Source {...SOURCE}>
+      {LAYERS.map((LAYER) => (
+        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
+      ))}
+    </Source>
+  );
+};
+
+export default MangrovesFloodProtectionPopulationLayer;

--- a/src/containers/datasets/flood-protection/storms/layers/population.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/population.tsx
@@ -39,6 +39,7 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
           max,
           '#672044',
         ],
+        'fill-opacity': 0.6,
       },
     },
   ];

--- a/src/containers/datasets/flood-protection/storms/layers/stock.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/stock.tsx
@@ -1,0 +1,56 @@
+import { Source, Layer } from 'react-map-gl';
+import type { SourceProps, LayerProps } from 'react-map-gl';
+
+import { floodPeriodAtom } from 'store/widgets/flood-protection';
+
+import { useRecoilValue } from 'recoil';
+
+export function useSource(): SourceProps {
+  return {
+    id: 'Coastal_protection_stock',
+    type: 'vector',
+    url: 'mapbox://globalmangrovewatch.1j82fo12',
+  };
+}
+
+export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
+  const min = 0;
+  const max = 11300000;
+  const period = useRecoilValue(floodPeriodAtom);
+  return [
+    {
+      id,
+      'source-layer': 'coastal_protection_map',
+      filter: ['has', `${period}_stock`],
+      type: 'fill',
+      paint: {
+        'fill-color': [
+          'interpolate',
+          ['linear'],
+          ['get', `${period}_stock`],
+          min,
+          '#D1EEEA',
+          max,
+          '#2A5674',
+        ],
+      },
+    },
+  ];
+}
+
+const MangrovesFloodProtectionStockLayer = ({ beforeId, id }: LayerProps) => {
+  const SOURCE = useSource();
+  const LAYERS = useLayers({ id });
+
+  if (!SOURCE || !LAYERS) return null;
+
+  return (
+    <Source {...SOURCE}>
+      {LAYERS.map((LAYER) => (
+        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
+      ))}
+    </Source>
+  );
+};
+
+export default MangrovesFloodProtectionStockLayer;

--- a/src/containers/datasets/flood-protection/storms/layers/stock.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/stock.tsx
@@ -39,6 +39,7 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
           max,
           '#2A5674',
         ],
+        'fill-opacity': 0.8,
       },
     },
   ];

--- a/src/containers/datasets/flood-protection/storms/layers/stock.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/stock.tsx
@@ -1,9 +1,11 @@
 import { Source, Layer } from 'react-map-gl';
 import type { SourceProps, LayerProps } from 'react-map-gl';
 
-import { floodPeriodAtom } from 'store/widgets/flood-protection';
+import { floodStockPeriodAtom } from 'store/widgets/flood-protection';
 
 import { useRecoilValue } from 'recoil';
+
+import { useMangrovesFloodProtection } from '../hooks';
 
 export function useSource(): SourceProps {
   return {
@@ -14,9 +16,13 @@ export function useSource(): SourceProps {
 }
 
 export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
-  const min = 0;
-  const max = 11300000;
-  const period = useRecoilValue(floodPeriodAtom);
+  const period = useRecoilValue(floodStockPeriodAtom);
+  const { data } = useMangrovesFloodProtection(period, {
+    indicator: 'stock',
+  });
+
+  if (!data || !data?.data?.length) return null;
+  const { max, min } = data;
   return [
     {
       id,

--- a/src/containers/datasets/flood-protection/storms/tooltip.tsx
+++ b/src/containers/datasets/flood-protection/storms/tooltip.tsx
@@ -1,6 +1,7 @@
 const CustomTooltip = ({ active, payload }) => {
   if (!active) return null;
   const { unit, valueFormatted, labelFormatted } = payload?.[0]?.payload;
+
   return (
     <div className="space-y-2 rounded-2xl bg-white p-4 text-sm shadow-lg">
       <div className="flex items-center space-x-2 whitespace-nowrap">

--- a/src/containers/datasets/flood-protection/storms/tooltip.tsx
+++ b/src/containers/datasets/flood-protection/storms/tooltip.tsx
@@ -1,0 +1,16 @@
+const CustomTooltip = ({ active, payload }) => {
+  if (!active) return null;
+  const { unit, valueFormatted, label } = payload?.[0]?.payload;
+  return (
+    <div className="space-y-2 rounded-2xl bg-white p-4 text-sm shadow-lg">
+      <div className="flex items-center space-x-2 whitespace-nowrap">
+        <p>{label}</p>
+      </div>
+      <p className="whitespace-nowrap font-bold">
+        {valueFormatted} {unit}
+      </p>
+    </div>
+  );
+};
+
+export default CustomTooltip;

--- a/src/containers/datasets/flood-protection/storms/tooltip.tsx
+++ b/src/containers/datasets/flood-protection/storms/tooltip.tsx
@@ -1,10 +1,10 @@
 const CustomTooltip = ({ active, payload }) => {
   if (!active) return null;
-  const { unit, valueFormatted, label } = payload?.[0]?.payload;
+  const { unit, valueFormatted, labelFormatted } = payload?.[0]?.payload;
   return (
     <div className="space-y-2 rounded-2xl bg-white p-4 text-sm shadow-lg">
       <div className="flex items-center space-x-2 whitespace-nowrap">
-        <p>{label}</p>
+        <p>{labelFormatted}</p>
       </div>
       <p className="whitespace-nowrap font-bold">
         {valueFormatted} {unit}

--- a/src/containers/datasets/flood-protection/storms/widget.tsx
+++ b/src/containers/datasets/flood-protection/storms/widget.tsx
@@ -107,7 +107,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
   const maxValue = getFormattedValue(max, indicator);
   const minValue = getFormattedValue(min, indicator);
   const trianglePositionPerc = (selectedValue * 100) / max; // substract icon size
-  const trianglePosition = (lineChartWidth * trianglePositionPerc) / 100;
+  const trianglePosition = lineChartWidth * trianglePositionPerc;
   const value = getFormattedValue(selectedValue, indicator);
 
   const getBackground = (indicator) => {
@@ -233,7 +233,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
                 <Icon
                   icon={TRIANGLE_SVG}
                   className="absolute -top-7 h-5 w-5"
-                  style={{ left: trianglePosition * 100 }}
+                  style={{ left: trianglePosition }}
                 />
               )}
             </div>

--- a/src/containers/datasets/flood-protection/storms/widget.tsx
+++ b/src/containers/datasets/flood-protection/storms/widget.tsx
@@ -9,7 +9,7 @@ import {
   floodStockPeriodAtom,
 } from 'store/widgets/flood-protection';
 
-import { set } from 'date-fns';
+import { SelectValue } from '@radix-ui/react-select';
 import { useRecoilState } from 'recoil';
 
 import Icon from 'components/icon';
@@ -102,10 +102,13 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
 
   if (!data || !data?.data?.length) return null;
 
-  const { periods, max, min, selectedValue, location } = data;
+  const { periods, max, min, selectedValue, location, getFormattedValue } = data;
   const isWorldwide = location === 'Worldwide';
-  const trianglePositionPerc = (Number(selectedValue) * 100) / max; // substract icon size
+  const maxValue = getFormattedValue(max, indicator);
+  const minValue = getFormattedValue(min, indicator);
+  const trianglePositionPerc = (selectedValue * 100) / max; // substract icon size
   const trianglePosition = (lineChartWidth * trianglePositionPerc) / 100;
+  const value = getFormattedValue(selectedValue, indicator);
 
   const getBackground = (indicator) => {
     let background;
@@ -148,11 +151,11 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
           </header>
           <p className={WIDGET_SENTENCE_STYLE}>
             In <span className="font-bold first-letter:uppercase"> {data.location}</span>, mangroves
-            protect against intense storms that occur once every{' '}
+            protect against <span className="font-bold">intense</span> storms that occur{' '}
             <Tooltip>
               <TooltipTrigger asChild>
                 <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
-                  {LABELS[selectedPeriod]}
+                  {LABELS[selectedPeriod].large}
                   <Icon
                     icon={ARROW_SVG}
                     className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 print:hidden"
@@ -179,7 +182,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
                           onClick={() => handlePeriod(period)}
                           disabled={period === selectedPeriod}
                         >
-                          {LABELS[period]}
+                          {LABELS[period].short}
                         </button>
                       </li>
                     ))}
@@ -189,19 +192,23 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
                 </TooltipContent>
               </TooltipPortal>
             </Tooltip>{' '}
-            {indicator === 'area' && 'an area of' && (
-              <span className="font-bold">
-                {selectedValue} km<sup>2</sup>.
+            {indicator === 'area' && (
+              <span>
+                an area of
+                <span className="font-bold">
+                  {' '}
+                  {value} km<sup>2</sup>.
+                </span>
               </span>
             )}
             {indicator === 'population' && (
               <span>
-                to <span className="font-bold">{selectedValue}</span> individuals
+                to <span className="font-bold">{value}</span> individuals
               </span>
             )}
             {indicator === 'stock' && (
               <span>
-                built capital worth <span className="font-bold">$ {selectedValue}</span>.
+                built capital worth <span className="font-bold">$ {value}</span>.
               </span>
             )}
           </p>
@@ -231,7 +238,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
               )}
             </div>
             <div className="flex w-full justify-between text-sm text-black/85">
-              {[min, max].map((l) => (
+              {[minValue, maxValue].map((l) => (
                 <p key={l}>{l}</p>
               ))}
             </div>

--- a/src/containers/datasets/flood-protection/storms/widget.tsx
+++ b/src/containers/datasets/flood-protection/storms/widget.tsx
@@ -233,7 +233,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
                 <Icon
                   icon={TRIANGLE_SVG}
                   className="absolute -top-7 h-5 w-5"
-                  style={{ left: !!trianglePosition && trianglePosition }}
+                  style={{ left: trianglePosition * 100 }}
                 />
               )}
             </div>

--- a/src/containers/datasets/flood-protection/storms/widget.tsx
+++ b/src/containers/datasets/flood-protection/storms/widget.tsx
@@ -1,0 +1,201 @@
+import { useMemo, createRef, useState, useLayoutEffect } from 'react';
+
+import cn from 'lib/classnames';
+
+import { activeWidgetsAtom } from 'store/widgets';
+import { floodPeriodAtom } from 'store/widgets/flood-protection';
+
+import { useRecoilState } from 'recoil';
+
+import Icon from 'components/icon';
+import Loading from 'components/loading';
+import { SwitchRoot, SwitchThumb, SwitchWrapper } from 'components/switch';
+import {
+  Tooltip,
+  TooltipArrow,
+  TooltipContent,
+  TooltipPortal,
+  TooltipTrigger,
+} from 'components/tooltip';
+import {
+  WIDGET_CARD_WRAPPER_STYLE,
+  WIDGET_SENTENCE_STYLE,
+  WIDGET_SUBTITLE_STYLE,
+  WIDGET_SELECT_STYLES,
+} from 'styles/widgets';
+import { WidgetSlugType } from 'types/widget';
+
+import ARROW_SVG from 'svgs/ui/arrow.svg?sprite';
+import TRIANGLE_SVG from 'svgs/ui/triangle.svg?sprite';
+
+import type { FloodProtectionIndicatorId } from '../types';
+
+import FloodProtectionChart from './chart';
+import { LABELS, UNITS_LABELS } from './constants';
+import { useMangrovesFloodProtection } from './hooks';
+
+const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId }) => {
+  const [lineChartWidth, setLineChartWidth] = useState(0);
+
+  const [selectedPeriod, setPeriod] = useRecoilState(floodPeriodAtom);
+  const { isFetched, isFetching, data } = useMangrovesFloodProtection(selectedPeriod, {
+    indicator,
+  });
+
+  const id = `mangrove_coastal_protection_${indicator}` satisfies WidgetSlugType;
+
+  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
+
+  const handleClick = () => {
+    const widgetsUpdate = isActive ? activeWidgets.filter((w) => w !== id) : [...activeWidgets, id];
+    setActiveWidgets(widgetsUpdate);
+  };
+
+  const ref = createRef<HTMLDivElement>();
+  // fires synchronously after all DOM mutations.
+  useLayoutEffect(() => {
+    if (ref && ref.current && ref.current.offsetWidth) {
+      setLineChartWidth(ref?.current?.offsetWidth);
+    }
+  }, [ref.current]);
+  if (!data || !data?.data?.length) return null;
+  const { periods, max, min, selectedValue, location } = data;
+  const isWorldwide = location === 'Worldwide';
+  const trianglePosition = (selectedValue * lineChartWidth) / max - 11; // substract icon size
+  const getBackground = (indicator) => {
+    let background;
+    switch (true) {
+      case indicator === 'area':
+        background =
+          'linear-gradient(90deg, #F3E0F7 0%, #E4C7F1 17%, #D1AFE8 33%, #AB91CF 50%, #9F82CE 67%, #826DBA 83%, #63589F 100%)';
+        break;
+      case indicator === 'population':
+        background =
+          'linear-gradient(90deg, #FFC6C4 0%, #F4A3A8 17%, #E38191 33%, #CC607D 50%, #AD466C 67%, #8B3058 83%, #672044 100%)';
+        break;
+      case indicator === 'stock':
+        background =
+          'linear-gradient(90deg, #D1EEEA 0%, #A8DBD9 17%, #85C4C9 33%, #68ABB8 50%, #4F90A6 67%, #3B738F 83%, #2A5674 100%)';
+        break;
+      default:
+        background = '#ECECEF';
+        break;
+    }
+    return background;
+  };
+  return (
+    <div className={`${WIDGET_CARD_WRAPPER_STYLE} relative`}>
+      <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
+      {!isFetching && (
+        <div className="absolute top-0 -left-10 -right-10 border-2 border-b border-brand-800/30" />
+      )}
+      {isFetched && data && (
+        <div className="space-y-4">
+          <header className="flex justify-between">
+            <h3 className={WIDGET_SUBTITLE_STYLE}>{indicator}</h3>
+            <div className="flex items-start space-x-2">
+              <SwitchWrapper id="planet_medres_visual_monthly">
+                <SwitchRoot onClick={handleClick} defaultChecked={isActive} checked={isActive}>
+                  <SwitchThumb />
+                </SwitchRoot>
+              </SwitchWrapper>
+            </div>
+          </header>
+          <p className={WIDGET_SENTENCE_STYLE}>
+            In <span className="font-bold first-letter:uppercase"> {data.location}</span>, mangroves
+            protect against intense storms that occur once every{' '}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                  {LABELS[selectedPeriod]}
+                  <Icon
+                    icon={ARROW_SVG}
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 print:hidden"
+                  />
+                </span>
+              </TooltipTrigger>
+
+              <TooltipPortal>
+                <TooltipContent
+                  side="bottom"
+                  align="center"
+                  className="rounded-3xl bg-white  text-black/85 shadow-soft"
+                >
+                  <ul className={cn({ 'max-h-56 space-y-2 overflow-y-auto scrollbar-hide': true })}>
+                    {periods?.map((period) => (
+                      <li key={period}>
+                        <button
+                          className={cn({
+                            'font-bold ': true,
+                            'hover:text-brand-800': period !== selectedPeriod,
+                            'opacity-50': period > selectedPeriod,
+                          })}
+                          type="button"
+                          onClick={() => setPeriod(period)}
+                          disabled={period === selectedPeriod}
+                        >
+                          {LABELS[period]}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <TooltipArrow className=" fill-white" width={10} height={5} />
+                </TooltipContent>
+              </TooltipPortal>
+            </Tooltip>{' '}
+            {indicator === 'area' && 'an area of' && (
+              <span className="font-bold">
+                {selectedValue} km<sup>2</sup>.
+              </span>
+            )}
+            {indicator === 'population' && (
+              <span>
+                to <span className="font-bold">{selectedValue}</span> individuals
+              </span>
+            )}
+            {indicator === 'stock' && (
+              <span>
+                built capital worth <span className="font-bold">$ {selectedValue}</span>.
+              </span>
+            )}
+          </p>
+          <div className="flex flex-1 flex-col items-center space-y-2">
+            <FloodProtectionChart data={data.config} />
+          </div>
+          <div className="relative flex flex-1 flex-col font-sans text-sm text-black/85 ">
+            <p className="w-full text-end text-sm">{UNITS_LABELS[data.unit]}</p>
+
+            <div
+              ref={ref}
+              className={cn({
+                'relative h-7 w-full': true,
+                'my-2.5': isWorldwide,
+                'mt-8 mb-2.5': !isWorldwide,
+              })}
+              style={{
+                background: getBackground(indicator),
+              }}
+            >
+              {!isWorldwide && (
+                <Icon
+                  icon={TRIANGLE_SVG}
+                  className="absolute -top-7 h-5 w-5"
+                  style={{ left: !!trianglePosition && trianglePosition }}
+                />
+              )}
+            </div>
+            <div className="flex w-full justify-between text-sm text-black/85">
+              {[min, max].map((l) => (
+                <p key={l}>{l}</p>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FloodProtection;

--- a/src/containers/datasets/flood-protection/storms/widget.tsx
+++ b/src/containers/datasets/flood-protection/storms/widget.tsx
@@ -107,7 +107,7 @@ const FloodProtection = ({ indicator }: { indicator: FloodProtectionIndicatorId 
   const maxValue = getFormattedValue(max, indicator);
   const minValue = getFormattedValue(min, indicator);
   const trianglePositionPerc = (selectedValue * 100) / max; // substract icon size
-  const trianglePosition = lineChartWidth * trianglePositionPerc;
+  const trianglePosition = (lineChartWidth * trianglePositionPerc) / 100;
   const value = getFormattedValue(selectedValue, indicator);
 
   const getBackground = (indicator) => {

--- a/src/containers/datasets/flood-protection/types.d.ts
+++ b/src/containers/datasets/flood-protection/types.d.ts
@@ -1,0 +1,28 @@
+export type Metadata = {
+  location_id: string;
+  min: string;
+  max: string;
+  periods: ['annual', '25_year', '100_year'];
+  unit: 'usd' | 'people' | 'km2';
+};
+
+export type ChartData = {
+  indicator: 'area' | 'people' | 'stock';
+  value: number;
+  period: 'annual' | '25_year' | '100_year';
+};
+
+export type Data = {
+  data: ChartData[];
+  chartData: ChartData[];
+  location: string;
+} & Metadata &
+  Chartdata;
+
+export type DataResponse = {
+  data: ChartData[];
+  metadata: Metadata;
+};
+
+export type FloodProtectionIndicatorId = 'area' | 'population' | 'stock';
+export type FloodProtectionPeriodId = 'annual' | '25_years' | '100_years';

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -1,0 +1,18 @@
+import CoastalProtection from './coastal-protection';
+import FloodProtection from './storms/widget';
+import { FloodProtectionIndicatorId } from './types';
+
+const FLOOD_PROTECTION_INDICATORS: FloodProtectionIndicatorId[] = ['area', 'population', 'stock'];
+
+const MangrovesFloodProtection = () => {
+  return (
+    <div className="space-y-4">
+      <CoastalProtection />
+      {FLOOD_PROTECTION_INDICATORS.map((indicator) => (
+        <FloodProtection key={indicator} indicator={indicator} />
+      ))}
+    </div>
+  );
+};
+
+export default MangrovesFloodProtection;

--- a/src/containers/datasets/index.tsx
+++ b/src/containers/datasets/index.tsx
@@ -29,6 +29,11 @@ import DriversChangeWidget from 'containers/datasets/drivers-change/widget';
 import EmissionsMitigationInfo from 'containers/datasets/emissions-mitigation/info.mdx';
 import EmissionsMitigationWidget from 'containers/datasets/emissions-mitigation/widget';
 import FisheriesWidget from 'containers/datasets/fisheries/widget';
+import FloodProtectionInfo from 'containers/datasets/flood-protection/info.mdx';
+import FloodProtectionAreaLayer from 'containers/datasets/flood-protection/storms/layers/area';
+import FloodProtectionPopulationLayer from 'containers/datasets/flood-protection/storms/layers/population';
+import FloodProtectionStockLayer from 'containers/datasets/flood-protection/storms/layers/stock';
+import FloodProtectionWidget from 'containers/datasets/flood-protection/widget';
 import HabitatChangeInfo from 'containers/datasets/habitat-change/info.mdx';
 import HabitatChangeWidget from 'containers/datasets/habitat-change/widget';
 import HabitatExtentDownload from 'containers/datasets/habitat-extent/download';
@@ -88,10 +93,11 @@ export const WIDGETS = {
   mangrove_restoration: RestorationWidget,
   mangrove_drawing_tool: DrawingToolWidget,
   mangrove_national_dashboard: NationalDashboardWidget,
+  mangrove_flood_protection: FloodProtectionWidget,
   mangrove_layer_name_second: LayerNameContentSecond,
   mangrove_contextual_basemaps: BasemapsContextualMapSettings,
   mangrove_fisheries: FisheriesWidget,
-} satisfies Record<WidgetSlugType, () => JSX.Element>;
+} satisfies Partial<Record<WidgetSlugType, () => JSX.Element>>;
 
 export const LAYERS = {
   mangrove_habitat_extent: HabitatExtentLayer,
@@ -111,6 +117,9 @@ export const LAYERS = {
   mangrove_layer_name_second: LayerNameLayerSecond,
   mangrove_restoration_sites: RestorationSitesLayer,
   mangrove_national_dashboard: NationalDashboardLayer,
+  mangrove_coastal_protection_area: FloodProtectionAreaLayer,
+  mangrove_coastal_protection_population: FloodProtectionPopulationLayer,
+  mangrove_coastal_protection_stock: FloodProtectionStockLayer,
 };
 
 export const INFO = {
@@ -132,6 +141,7 @@ export const INFO = {
   mangrove_layer_name_second: LayerNameInfoSecond,
   mangrove_restoration_sites: RestorationSitesInfo,
   mangrove_national_dashboard: NationalDashboardInfo,
+  mangrove_flood_protection: FloodProtectionInfo,
 };
 
 export const DOWNLOAD = {

--- a/src/containers/datasets/national-dashboard/hooks.tsx
+++ b/src/containers/datasets/national-dashboard/hooks.tsx
@@ -12,7 +12,6 @@ import API from 'services/api';
 import type { Data, DataResponse } from './types';
 
 // widget data
-
 type UseParamsOptions = {
   slug: 'fisheries' | 'restoration-value';
 };

--- a/src/containers/datasets/restoration/loss/widget.tsx
+++ b/src/containers/datasets/restoration/loss/widget.tsx
@@ -4,7 +4,11 @@ import { numberFormat } from 'lib/format';
 import { TreemapNode } from 'recharts/types/util/types';
 
 import Loading from 'components/loading';
-import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+import {
+  WIDGET_CARD_WRAPPER_STYLE,
+  WIDGET_SENTENCE_STYLE,
+  WIDGET_SUBTITLE_STYLE,
+} from 'styles/widgets';
 
 import LossChart from './chart';
 import { useMangroveDegradationAndLoss } from './hooks';
@@ -82,7 +86,7 @@ const LossWidget = () => {
       <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && data && (
         <div className="space-y-4">
-          <h3 className="text-xs">MANGROVE LOSS</h3>
+          <h3 className={WIDGET_SUBTITLE_STYLE}>MANGROVE LOSS</h3>
           <p className={WIDGET_SENTENCE_STYLE}>
             The main restorable loss driver in
             <span className="font-bold"> {data?.location}</span> is{' '}

--- a/src/containers/datasets/restoration/overview/mean-restoration/widget.tsx
+++ b/src/containers/datasets/restoration/overview/mean-restoration/widget.tsx
@@ -3,7 +3,11 @@ import cn from 'lib/classnames';
 import { useMangroveRestoration } from 'containers/datasets/restoration/overview/hooks';
 
 import Loading from 'components/loading';
-import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+import {
+  WIDGET_CARD_WRAPPER_STYLE,
+  WIDGET_SENTENCE_STYLE,
+  WIDGET_SUBTITLE_STYLE,
+} from 'styles/widgets';
 
 import OverviewChart from './chart';
 
@@ -21,7 +25,7 @@ const MeanRestoration = () => {
       <Loading visible={isLoading || isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && !isError && data && (
         <div className="space-y-4">
-          <h3 className="text-xs">OVERVIEW</h3>
+          <h3 className={WIDGET_SUBTITLE_STYLE}>OVERVIEW</h3>
           <p className={WIDGET_SENTENCE_STYLE}>
             The mean restoration potential score for{' '}
             <span className="font-bold"> {data.location}</span> is{' '}

--- a/src/containers/datasets/restoration/overview/restorable-areas/widget.tsx
+++ b/src/containers/datasets/restoration/overview/restorable-areas/widget.tsx
@@ -3,7 +3,11 @@ import cn from 'lib/classnames';
 import { useMangroveRestoration } from 'containers/datasets/restoration/overview/hooks';
 
 import Loading from 'components/loading';
-import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+import {
+  WIDGET_CARD_WRAPPER_STYLE,
+  WIDGET_SENTENCE_STYLE,
+  WIDGET_SUBTITLE_STYLE,
+} from 'styles/widgets';
 
 import RestorableAreasChart from './chart';
 const RestorableAreas = () => {
@@ -19,7 +23,7 @@ const RestorableAreas = () => {
       <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && !isLoading && (
         <div className="space-y-4">
-          <h3 className="text-xs">RESTORABLE MANGROVE AREA</h3>
+          <h3 className={WIDGET_SUBTITLE_STYLE}>RESTORABLE MANGROVE AREA</h3>
           <p className={WIDGET_SENTENCE_STYLE}>
             <span className="font-bold first-letter:uppercase"> {data.location}</span> restorable
             mangrove areas represent{' '}

--- a/src/containers/datasets/restoration/restoration-value/widget.tsx
+++ b/src/containers/datasets/restoration/restoration-value/widget.tsx
@@ -1,5 +1,9 @@
 import Loading from 'components/loading';
-import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+import {
+  WIDGET_CARD_WRAPPER_STYLE,
+  WIDGET_SENTENCE_STYLE,
+  WIDGET_SUBTITLE_STYLE,
+} from 'styles/widgets';
 
 import RestorationValueChart from './chart';
 import { useMangroveEcosystemServices } from './hooks';
@@ -15,7 +19,7 @@ const RestorationValue = () => {
       <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && data && (
         <div className="space-y-4">
-          <h3 className="text-xs">RESTORATION VALUE</h3>
+          <h3 className={WIDGET_SUBTITLE_STYLE}>RESTORATION VALUE</h3>
           <p className={WIDGET_SENTENCE_STYLE}>
             The restoration of mangroves in{' '}
             <span className="font-bold first-letter:uppercase"> {data.location}</span> would

--- a/src/containers/layers/constants.tsx
+++ b/src/containers/layers/constants.tsx
@@ -1,14 +1,14 @@
 export const LAYERS = [
   {
-    name: 'Coastal protection area',
+    name: 'Coastal protection: area',
     id: 'mangrove_coastal_protection_area',
   },
   {
-    name: 'Coastal protection population',
+    name: 'Coastal protection: population',
     id: 'mangrove_coastal_protection_population',
   },
   {
-    name: 'Coastal protection stock',
+    name: 'Coastal protection: stock',
     id: 'mangrove_coastal_protection_stock',
   },
   {

--- a/src/containers/layers/constants.tsx
+++ b/src/containers/layers/constants.tsx
@@ -1,5 +1,17 @@
 export const LAYERS = [
   {
+    name: 'Coastal protection area',
+    id: 'mangrove_coastal_protection_area',
+  },
+  {
+    name: 'Coastal protection population',
+    id: 'mangrove_coastal_protection_population',
+  },
+  {
+    name: 'Coastal protection stock',
+    id: 'mangrove_coastal_protection_stock',
+  },
+  {
     name: 'Mangrove Blue Carbon',
     id: 'mangrove_blue_carbon',
   },

--- a/src/containers/legend/index.tsx
+++ b/src/containers/legend/index.tsx
@@ -35,26 +35,29 @@ const Legend = ({ title, subtitle, items, variant = 'vertical' }: LegendTypes) =
         </h2>
       )}
       {items.map(
-        ({ showValue = true, color, label, labelFormatted, valueFormatted, value, unit }) => (
-          <div key={label} className={cn({ 'flex items-start': true })}>
-            <div
-              style={{ backgroundColor: color }}
-              className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
-            />
-            <div className="flex flex-col items-start text-sm">
-              <p className={cn({ 'font-bold': !showValue })}>{labelFormatted || label}</p>
-              <div className="flex space-x-2 whitespace-nowrap">
-                {showValue && unit && (unit === '$' || unit === 'usd') && (
-                  <p className="font-bold">{unit}</p>
-                )}
-                {showValue && <p className="font-bold">{valueFormatted || value}</p>}
-                {showValue && unit && unit !== '$' && unit === 'usd' && (
-                  <p className="font-bold">{unit}</p>
-                )}
+        ({ showValue = true, color, label, labelFormatted, valueFormatted, value, unit }) => {
+          console.log(unit);
+          return (
+            <div key={label} className={cn({ 'flex items-start': true })}>
+              <div
+                style={{ backgroundColor: color }}
+                className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+              />
+              <div className="flex flex-col items-start text-sm">
+                <p className={cn({ 'font-bold': !showValue })}>{labelFormatted || label}</p>
+                <div className="flex space-x-2 whitespace-nowrap">
+                  {showValue && unit && (unit === '$' || unit === 'usd') && (
+                    <p className="font-bold">{unit}</p>
+                  )}
+                  {showValue && <p className="font-bold">{valueFormatted || value}</p>}
+                  {showValue && unit && unit !== '$' && unit !== 'usd' && (
+                    <p className="font-bold">{unit}</p>
+                  )}
+                </div>
               </div>
             </div>
-          </div>
-        )
+          );
+        }
       )}
     </div>
   );

--- a/src/containers/legend/index.tsx
+++ b/src/containers/legend/index.tsx
@@ -4,6 +4,7 @@ type Item = {
   showValue?: boolean;
   color: string;
   label: string;
+  labelFormatted?: string;
   value?: number;
   unit?: string;
   valueFormatted?: string;
@@ -17,7 +18,7 @@ type LegendTypes = {
   unit?: string;
 };
 
-const Legend = ({ title, subtitle, items, variant = 'vertical', unit }: LegendTypes) => {
+const Legend = ({ title, subtitle, items, variant = 'vertical' }: LegendTypes) => {
   return (
     <div
       className={cn({
@@ -33,21 +34,28 @@ const Legend = ({ title, subtitle, items, variant = 'vertical', unit }: LegendTy
           {subtitle}
         </h2>
       )}
-      {items.map(({ showValue = true, color, label, valueFormatted, value, unit }) => (
-        <div key={label} className={cn({ 'flex items-start': true })}>
-          <div
-            style={{ backgroundColor: color }}
-            className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
-          />
-          <div className="flex flex-col items-start text-sm">
-            <p className="font-bold">{label}</p>
-            <div className="flex space-x-2 whitespace-nowrap">
-              {showValue && <p>{valueFormatted || value}</p>}
-              {showValue && unit && <p>{unit}</p>}
+      {items.map(
+        ({ showValue = true, color, label, labelFormatted, valueFormatted, value, unit }) => (
+          <div key={label} className={cn({ 'flex items-start': true })}>
+            <div
+              style={{ backgroundColor: color }}
+              className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+            />
+            <div className="flex flex-col items-start text-sm">
+              <p className={cn({ 'font-bold': !showValue })}>{labelFormatted || label}</p>
+              <div className="flex space-x-2 whitespace-nowrap">
+                {showValue && unit && (unit === '$' || unit === 'usd') && (
+                  <p className="font-bold">{unit}</p>
+                )}
+                {showValue && <p className="font-bold">{valueFormatted || value}</p>}
+                {showValue && unit && unit !== '$' && unit === 'usd' && (
+                  <p className="font-bold">{unit}</p>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      ))}
+        )
+      )}
     </div>
   );
 };

--- a/src/containers/legend/index.tsx
+++ b/src/containers/legend/index.tsx
@@ -36,7 +36,6 @@ const Legend = ({ title, subtitle, items, variant = 'vertical' }: LegendTypes) =
       )}
       {items.map(
         ({ showValue = true, color, label, labelFormatted, valueFormatted, value, unit }) => {
-          console.log(unit);
           return (
             <div key={label} className={cn({ 'flex items-start': true })}>
               <div

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import Helper from 'containers/guide/helper';
-import widgets from 'containers/widgets/constants';
+import { LAYERS } from 'containers/layers/constants';
 
 import Icon from 'components/icon';
 import { WidgetSlugType } from 'types/widget';
@@ -25,8 +25,8 @@ const Legend = ({
     [layers, setActiveWidgets]
   );
 
-  const widgetName = (label) => {
-    return widgets.find((w) => w.slug === label)?.name;
+  const layerName = (label) => {
+    return LAYERS.find((w) => w.id === label)?.name;
   };
 
   const HELPER_ID = 'mangrove_habitat_extent';
@@ -44,8 +44,8 @@ const Legend = ({
             tooltipPosition={{ top: 80, left: 0 }}
             message="List of legends seen on the map. You can close them directly here"
           >
-            <div className="flex h-11 items-center justify-between rounded-md bg-white px-6 py-3 text-sm shadow-medium">
-              <p className="text-xs font-semibold uppercase">{widgetName(l)}</p>
+            <div className="flex h-11 min-w-[270px] items-center justify-between rounded-md bg-white px-6 py-3 text-sm shadow-medium">
+              <p className="text-xs font-semibold uppercase">{layerName(l)}</p>
               <button onClick={() => removeLayer(l)}>
                 <Icon icon={REMOVE_SVG} className="h-5 w-5" />
               </button>

--- a/src/containers/widgets/constants.ts
+++ b/src/containers/widgets/constants.ts
@@ -131,6 +131,17 @@ const widgets = [
   //   layersIds: [''],
   // },
   {
+    name: 'Coastal protection',
+    slug: 'mangrove_flood_protection',
+    locationType: ['custom-area', 'wdpa', 'country', 'worldwide'],
+    categoryIds: ['all_datasets', 'distribution_and_change'],
+    layersIds: [
+      'mangrove_coastal_protection_area',
+      'mangrove_coastal_protection_population',
+      'mangrove_coastal_protection_stock',
+    ],
+  },
+  {
     name: 'Draw or upload an area',
     slug: 'mangrove_drawing_tool',
     locationType: ['custom-area', 'wdpa', 'country', 'worldwide'],

--- a/src/containers/widgets/constants.ts
+++ b/src/containers/widgets/constants.ts
@@ -133,7 +133,7 @@ const widgets = [
   {
     name: 'Coastal protection',
     slug: 'mangrove_flood_protection',
-    locationType: ['custom-area', 'wdpa', 'country', 'worldwide'],
+    locationType: ['custom-area', 'wdpa', 'country'],
     categoryIds: ['all_datasets', 'distribution_and_change'],
     layersIds: [
       'mangrove_coastal_protection_area',

--- a/src/lib/format/index.ts
+++ b/src/lib/format/index.ts
@@ -4,5 +4,5 @@ export const numberFormat = format(',.2f');
 export const percentFormat = format('.2%');
 export const smallNumberFormat = format('.4f');
 export const formatAxis = format(',.0d');
-export const formatMillion = formatPrefix(',.2', 1e6);
+export const formatMillion = formatPrefix(',.0', 1e6);
 export const significantDigitsFormat = format('.3s');

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -77,7 +77,6 @@ const MyApp = ({ Component, pageProps }: AppProps<PageProps>) => {
           }
         `}
       </style>
-
       <RecoilRoot>
         <RecoilURLSyncNext
           location={{ part: 'queryParams' }}

--- a/src/store/widgets/flood-protection.ts
+++ b/src/store/widgets/flood-protection.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+import { FloodProtectionPeriodId } from 'containers/datasets/flood-protection/types';
+
+export const floodPeriodAtom = atom<FloodProtectionPeriodId>({
+  key: 'flood-protection-period',
+  default: 'annual',
+});

--- a/src/store/widgets/flood-protection.ts
+++ b/src/store/widgets/flood-protection.ts
@@ -2,7 +2,17 @@ import { atom } from 'recoil';
 
 import { FloodProtectionPeriodId } from 'containers/datasets/flood-protection/types';
 
-export const floodPeriodAtom = atom<FloodProtectionPeriodId>({
-  key: 'flood-protection-period',
+export const floodAreaPeriodAtom = atom<FloodProtectionPeriodId>({
+  key: 'flood-area-protection-period',
+  default: 'annual',
+});
+
+export const floodPopulationPeriodAtom = atom<FloodProtectionPeriodId>({
+  key: 'flood-population-protection-period',
+  default: 'annual',
+});
+
+export const floodStockPeriodAtom = atom<FloodProtectionPeriodId>({
+  key: 'flood-stock-protection-period',
   default: 'annual',
 });

--- a/src/types/widget.ts
+++ b/src/types/widget.ts
@@ -35,6 +35,10 @@ export type WidgetSlugType =
   | 'mangrove_fisheries'
   | 'mangrove_layer_name_second'
   | 'mangrove_contextual_basemaps'
+  | 'mangrove_flood_protection'
+  | 'mangrove_coastal_protection_area'
+  | 'mangrove_coastal_protection_population'
+  | 'mangrove_coastal_protection_stock'
   | 'mangrove_drawing_tool';
 
 export type AnalysisWidgetSlug =


### PR DESCRIPTION
## COASTAL PROTECTION (flood protection widget)

### Overview

This PR adds a flood protection widget .

### Designs

[_Link to the related design prototypes (if applicable)_](https://www.figma.com/file/GJCx8yGfx6JERPuxlpG3nK/Mangrove-Watch-%5BInternal%5D?node-id=3041%3A31385&mode=dev)

### Testing instructions

This widget is not at a worldwide level. Some examples where you can find it is Tanzania, and Haiti (do some spot checks to other locations)

### Feature relevant tickets

[_Link to the related task manager tickets_](https://vizzuality.atlassian.net/browse/GMW-633?atlOrigin=eyJpIjoiZjdlZGQxZTg2NDhhNGFiMzgxMWU4ZjRkYmZjYWVkMzEiLCJwIjoiaiJ9)


---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
