### PR TITLE
blog images and description

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,16 @@ const nextConfig = {
       },
     ];
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'www.wetlands.org',
+        port: '',
+        pathname: '/wp-content/uploads/**',
+      },
+    ],
+  },
   async rewrites() {
     return [
       // planet APi to get tiles

--- a/src/containers/blog/content/index.tsx
+++ b/src/containers/blog/content/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -10,8 +10,6 @@ import type { Post } from 'hooks/blog/types';
 import PostComponent from 'containers/blog/post';
 
 import { DialogClose } from 'components/dialog';
-
-import placeholderPost from 'images/blog/placeholder-post.png';
 
 export const BlogContent = () => {
   const { data } = useBlogPosts();
@@ -67,11 +65,17 @@ export const BlogContent = () => {
             <Image
               alt={postInfo.title.rendered}
               className="absolute top-0 left-0 h-[240px] w-full rounded-t-[20px] object-cover"
-              src={placeholderPost as StaticImageData}
+              src={postInfo.yoast_head_json.og_image[0].url}
+              width={112}
+              height={240}
             />
             <h3 className="mt-[270px] font-sans text-3xl font-light text-black/85">
               {postInfo.title.rendered}
             </h3>
+            <div
+              className="prose py-4"
+              dangerouslySetInnerHTML={{ __html: postInfo.content.rendered }}
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/containers/blog/post/index.tsx
+++ b/src/containers/blog/post/index.tsx
@@ -1,10 +1,16 @@
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 
 import { usePostTags } from 'hooks/blog';
 
-import placeholderPost from 'images/blog/placeholder-post.png';
-
-export const Post = ({ post }: { post: { id: number; title: { rendered: string } } }) => {
+export const Post = ({
+  post,
+}: {
+  post: {
+    id: number;
+    title: { rendered: string };
+    yoast_head_json: { og_image: { url: string }[] };
+  };
+}) => {
   const { data } = usePostTags({ id: post.id });
 
   return (
@@ -12,7 +18,7 @@ export const Post = ({ post }: { post: { id: number; title: { rendered: string }
       <Image
         alt={post.title.rendered}
         className="h-[114px] w-28 rounded-2xl object-cover"
-        src={placeholderPost as StaticImageData}
+        src={post.yoast_head_json.og_image[0].url}
         width={112}
         height={114}
       />
@@ -22,7 +28,7 @@ export const Post = ({ post }: { post: { id: number; title: { rendered: string }
             return (
               <div
                 key={i}
-                className="itens-center flex w-fit whitespace-nowrap rounded-2xl bg-brand-400 py-1 px-3 text-xs font-semibold uppercase text-white"
+                className="flex w-fit items-center whitespace-nowrap rounded-2xl bg-brand-400 py-1 px-3 text-xs font-semibold uppercase text-white"
               >
                 {tag.name}
               </div>

--- a/src/hooks/blog/types.d.ts
+++ b/src/hooks/blog/types.d.ts
@@ -4,6 +4,14 @@ export type Post = {
   title: {
     rendered: string;
   };
+  yoast_head_json: {
+    og_image: {
+      url: string;
+    }[];
+  };
+  content: {
+    rendered: string;
+  };
 };
 
 export type Tag = {


### PR DESCRIPTION
## Images and description post added

### Overview

_This PR adds images and content to wetland posts._

<img width="696" alt="Screenshot 2023-08-11 at 09 15 48" src="https://github.com/Vizzuality/mangrove-atlas/assets/33252015/2ab0e492-a8da-4932-a503-e7c997e7665f">

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-674?atlOrigin=eyJpIjoiYmM3NWQxMTZmMzkyNDQ2ZmE4ZWFjY2IyM2QyMmNlZjgiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
