### PR TITLE
[FE](fix): non accents sensitive on search location [GMW-706]

### DIFF
--- a/src/hooks/search/index.ts
+++ b/src/hooks/search/index.ts
@@ -11,6 +11,7 @@ export const useSearch = <T = unknown>(items: T[], search: string, fields: strin
       keys: fields,
       shouldSort: true,
       includeMatches: true,
+      threshold: 0.3,
       location: 0,
       distance: 300,
       minMatchCharLength: 1,

--- a/src/hooks/search/index.ts
+++ b/src/hooks/search/index.ts
@@ -3,21 +3,14 @@ import { useMemo } from 'react';
 import diacritics from 'diacritics';
 import Fuse from 'fuse.js';
 
-type ItemWithAccents<T> = T & { name: string };
-
 export const useSearch = <T = unknown>(items: T[], search: string, fields: string[]) => {
-  const itemsNamesWithoutAccents: ItemWithAccents<T>[] = items.map((item: ItemWithAccents<T>) => ({
-    ...item,
-    name: item.name ? item.name.normalize('NFD').replace(/[\u0300-\u036F]/g, '') : '',
-  }));
   const fuse =
     search &&
     search.length &&
-    (new Fuse(itemsNamesWithoutAccents, {
+    (new Fuse(items, {
       keys: fields,
       shouldSort: true,
       includeMatches: true,
-      threshold: 0.1,
       location: 0,
       distance: 300,
       minMatchCharLength: 1,
@@ -25,6 +18,7 @@ export const useSearch = <T = unknown>(items: T[], search: string, fields: strin
 
   return useMemo(
     () => fuse && fuse.search(diacritics.remove(search)).map((d) => d.item),
+
     [search, fuse]
   ) satisfies T[];
 };

--- a/src/hooks/search/index.ts
+++ b/src/hooks/search/index.ts
@@ -1,12 +1,19 @@
 import { useMemo } from 'react';
+
 import diacritics from 'diacritics';
 import Fuse from 'fuse.js';
 
+type ItemWithAccents<T> = T & { name: string };
+
 export const useSearch = <T = unknown>(items: T[], search: string, fields: string[]) => {
+  const itemsNamesWithoutAccents: ItemWithAccents<T>[] = items.map((item: ItemWithAccents<T>) => ({
+    ...item,
+    name: item.name ? item.name.normalize('NFD').replace(/[\u0300-\u036F]/g, '') : '',
+  }));
   const fuse =
     search &&
     search.length &&
-    (new Fuse(items, {
+    (new Fuse(itemsNamesWithoutAccents, {
       keys: fields,
       shouldSort: true,
       includeMatches: true,


### PR DESCRIPTION
## Non accents sensitive on search location

### Overview

Removing threshold and set it to default (0.6) to avoid perfect matches. 

### Testing instructions

If you search for mexico without or with accent you should see:

![Screenshot 2023-12-20 at 12 23 00](https://github.com/Vizzuality/mangrove-atlas/assets/51995866/1edf8dbf-6c6e-4f38-a744-23d3be4f15a2)


### Feature relevant tickets

[GMW-706](https://vizzuality.atlassian.net/browse/GMW-706)


[GMW-706]: https://vizzuality.atlassian.net/browse/GMW-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ