### PR TITLE
Gmw 714 sharing capabilities

### DIFF
--- a/src/components/widget-controls/index.tsx
+++ b/src/components/widget-controls/index.tsx
@@ -5,7 +5,6 @@ import cn from 'lib/classnames';
 import { drawingToolAtom } from 'store/drawing-tool';
 import { activeLayersAtom } from 'store/layers';
 import { mapSettingsAtom } from 'store/map-settings';
-import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -38,11 +37,10 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const { showWidget } = useRecoilValue(drawingToolAtom);
   const isMapSettingsOpen = useRecoilValue(mapSettingsAtom);
   const screenWidth = useScreenWidth();
-  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
   const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
-  const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
+  const activeLayersIds = activeLayers.map((l) => l.id);
+  const isActive = useMemo(() => activeLayersIds.includes(id), [activeLayersIds, id]);
   const widgets = useWidgets();
-
   const download = DOWNLOAD[id] || content?.download;
   const info = INFO[id] || content?.info;
   const layer = LAYERS[id] || content?.layer;
@@ -55,7 +53,7 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
           opacity: string;
         }[]);
     setActiveLayers(layersUpdate);
-  }, [isActive, activeLayers, setActiveLayers]);
+  }, [isActive, activeLayers, setActiveLayers, id]);
 
   const HELPER_ID = id === widgets[0].slug;
 

--- a/src/components/widget-controls/index.tsx
+++ b/src/components/widget-controls/index.tsx
@@ -3,6 +3,7 @@ import { useMemo, useCallback } from 'react';
 import cn from 'lib/classnames';
 
 import { drawingToolAtom } from 'store/drawing-tool';
+import { activeLayersAtom } from 'store/layers';
 import { mapSettingsAtom } from 'store/map-settings';
 import { activeWidgetsAtom } from 'store/widgets';
 
@@ -17,6 +18,7 @@ import { useWidgets } from 'containers/widgets/hooks';
 import { SwitchWrapper, SwitchRoot, SwitchThumb } from 'components/switch';
 import { breakpoints } from 'styles/styles.config';
 import type { WidgetSlugType } from 'types/widget';
+import type { ContextualBasemapsId } from 'types/widget';
 
 import Download from './download';
 import Info from './info';
@@ -37,6 +39,7 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const isMapSettingsOpen = useRecoilValue(mapSettingsAtom);
   const screenWidth = useScreenWidth();
   const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
   const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
   const widgets = useWidgets();
 
@@ -45,9 +48,14 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const layer = LAYERS[id] || content?.layer;
 
   const handleClick = useCallback(() => {
-    const widgetsUpdate = isActive ? activeWidgets.filter((w) => w !== id) : [id, ...activeWidgets];
-    setActiveWidgets(widgetsUpdate);
-  }, [id, isActive, setActiveWidgets, activeWidgets]);
+    const layersUpdate = isActive
+      ? activeLayers.filter((w) => w.id !== id)
+      : ([{ id, opacity: '1' }, ...activeLayers] as {
+          id: WidgetSlugType | ContextualBasemapsId | 'custom-area';
+          opacity: string;
+        }[]);
+    setActiveLayers(layersUpdate);
+  }, [isActive, activeLayers, setActiveLayers]);
 
   const HELPER_ID = id === widgets[0].slug;
 

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -5,9 +5,11 @@ import { useMap } from 'react-map-gl';
 import { useRouter } from 'next/router';
 
 import cn from 'lib/classnames';
+import { orderByAttribute } from 'lib/utils';
 
 import { analysisAtom } from 'store/analysis';
 import { drawingToolAtom } from 'store/drawing-tool';
+import { activeLayersAtom } from 'store/layers';
 import {
   basemapAtom,
   URLboundsAtom,
@@ -87,14 +89,16 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   const [cursor, setCursor] = useRecoilState(mapCursorAtom);
 
   const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
   const [, setAnalysisState] = useRecoilState(analysisAtom);
 
-  const nationalDashboardLayers = activeWidgets.filter((el) =>
-    el?.includes('mangrove_national_dashboard')
+  const nationalDashboardLayers = activeLayers?.filter(
+    (el) => el.id === 'mangrove_national_dashboard'
   );
+
   const activeOrdered = [
     ...nationalDashboardLayers,
-    ...LAYERS_ORDER.filter((el) => activeWidgets.some((f) => f === el)),
+    ...orderByAttribute(LAYERS_ORDER, activeLayers),
   ] as (WidgetSlugType & ContextualBasemapsId & 'custom-area' & NationalDashboardLayer)[];
 
   const [restorationPopUp, setRestorationPopUp] = useState<{
@@ -454,7 +458,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
       <Media greaterThanOrEqual="md">
         <div className="absolute bottom-10 right-10 space-y-1 print:hidden">
           {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
-          <Legend layers={activeOrdered} setActiveWidgets={setActiveWidgets} />
+          <Legend layers={activeOrdered} setActiveLayers={setActiveLayers} />
         </div>
       </Media>
     </div>

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -20,10 +20,10 @@ type NationalDashboardLayer = `mangrove_national_dashboard${string}`;
 
 const Legend = ({
   layers,
-  setActiveWidgets,
+  setActiveLayers,
 }: {
   layers: readonly (WidgetSlugType & ContextualBasemapsId & 'custom-area')[];
-  setActiveWidgets: (
+  setActiveLayers: (
     layers: (WidgetSlugType & ContextualBasemapsId & 'custom-area' & NationalDashboardLayer)[]
   ) => void;
 }) => {
@@ -40,15 +40,15 @@ const Legend = ({
   const settings = useRecoilValue(nationalDashboardSettingsAtom);
   const nationalDashboardLayerName =
     settings && Object.values(settings).filter((s) => s.locationId === locationId)[0]?.name;
-
+  console.log(layers, 'layers');
   const removeLayer = useCallback(
     (layer: string) => {
       const updatedLayers = layers.filter((l) => {
         return l !== layer;
       });
-      setActiveWidgets(updatedLayers);
+      setActiveLayers(updatedLayers);
     },
-    [layers, setActiveWidgets]
+    [layers, setActiveLayers]
   );
 
   const layerName = (label) => {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,0 +1,13 @@
+export const orderByAttribute = (
+  orderedListIds: string[],
+  list: { id: string; opacity: string }[]
+) =>
+  list.sort((a, b) => {
+    const indexA = orderedListIds.indexOf(a.id);
+    const indexB = orderedListIds.indexOf(b.id);
+
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+
+    return indexA - indexB;
+  });

--- a/src/store/layers/index.ts
+++ b/src/store/layers/index.ts
@@ -1,0 +1,23 @@
+import { array, object, string, number } from '@recoiljs/refine';
+import { atom } from 'recoil';
+import { urlSyncEffect } from 'recoil-sync';
+
+import { ContextualBasemapsId, WidgetSlugType } from 'types/widget';
+
+const layerSchema = object({
+  id: string(),
+  opacity: string(),
+});
+
+export const activeLayersAtom = atom<
+  { id: WidgetSlugType | ContextualBasemapsId | 'custom-area'; opacity: string }[]
+>({
+  key: 'layers',
+  default: [{ id: 'mangrove_habitat_extent', opacity: '1' }],
+  effects: [
+    urlSyncEffect({
+      refine: array(layerSchema),
+      history: 'replace',
+    }),
+  ],
+});


### PR DESCRIPTION
## Active layer params added to URL

### Overview

_From now on, the layer and widget can be activated independently. That means the widget and layer should be managed separately stored and updated in the URL accordingly.  This PR adds layers to URL (with opacity but without the possibility of changing it yet), and adds implementation to activate layer from the platform aside the widget _

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-714?atlOrigin=eyJpIjoiOTU4ZjM5NGY3YmU1NDdiZTllMGI0MDE0ZGJhOGJmMmQiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
