### PR TITLE
Feature/clean branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased
 
 ### Changed
 
+- New params to URL. Layer and widget id stored in URL independently
 
 ### Fixed
 

--- a/src/components/collapsible/index.tsx
+++ b/src/components/collapsible/index.tsx
@@ -4,6 +4,7 @@ import * as Collapsible from '@radix-ui/react-collapsible';
 import { ChevronUpIcon } from '@radix-ui/react-icons';
 import cn from 'classnames';
 
+import { LAYERS } from 'containers/layers/constants';
 import widgets from 'containers/widgets/constants';
 
 import Icon from 'components/icon';
@@ -13,10 +14,10 @@ import REMOVE_SVG from 'svgs/ui/close.svg?sprite';
 
 const CollapsibleComponent = ({
   layers,
-  setActiveWidgets,
+  setActiveLayers,
 }: {
   layers: readonly (WidgetSlugType & ContextualBasemapsId & 'custom-area')[];
-  setActiveWidgets: (layers: (WidgetSlugType & ContextualBasemapsId & 'custom-area')[]) => void;
+  setActiveLayers: (layers: (WidgetSlugType & ContextualBasemapsId & 'custom-area')[]) => void;
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -25,13 +26,14 @@ const CollapsibleComponent = ({
       const updatedLayers = layers.filter((l) => {
         return l !== layer;
       });
-      setActiveWidgets(updatedLayers);
+      setActiveLayers(updatedLayers);
     },
-    [layers, setActiveWidgets]
+    [layers, setActiveLayers]
   );
 
-  const widgetName = (label) => {
-    return widgets.find((w) => w.slug === label)?.name;
+  const layerName = (label: { id: string; opacity: string }): string => {
+    const layer = LAYERS.find((w) => w.id === label.id);
+    return layer ? layer.name : '';
   };
 
   return (
@@ -41,7 +43,7 @@ const CollapsibleComponent = ({
           {(!isOpen || !layers.length) && <p className="text-xs font-semibold uppercase">Layer</p>}
           {isOpen && !!layers.length && (
             <div className="flex items-center justify-between">
-              <p className="text-xs font-semibold uppercase">{widgetName(layers[0])}</p>
+              <p className="text-xs font-semibold uppercase">{layerName(layers[0])}</p>
               <button onClick={() => removeLayer(layers[0])} aria-label="remove-layer">
                 <Icon icon={REMOVE_SVG} className="h-4 w-4" description="Cross" />
               </button>
@@ -71,7 +73,7 @@ const CollapsibleComponent = ({
               key={l}
               className="flex h-11 items-center justify-between rounded-md border bg-white px-4 py-3 text-sm shadow-light"
             >
-              <p className="text-xs font-semibold uppercase">{widgetName(l)}</p>
+              <p className="text-xs font-semibold uppercase">{layerName(l)}</p>
               <button aria-label="remove-layer" onClick={() => removeLayer(l)}>
                 <Icon icon={REMOVE_SVG} className="h-4 w-4" description="Cross" />
               </button>

--- a/src/components/widget-controls/index.tsx
+++ b/src/components/widget-controls/index.tsx
@@ -5,7 +5,6 @@ import cn from 'lib/classnames';
 import { drawingToolAtom } from 'store/drawing-tool';
 import { activeLayersAtom } from 'store/layers';
 import { mapSettingsAtom } from 'store/map-settings';
-import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -38,11 +37,10 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const { showWidget } = useRecoilValue(drawingToolAtom);
   const isMapSettingsOpen = useRecoilValue(mapSettingsAtom);
   const screenWidth = useScreenWidth();
-  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
   const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
-  const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
+  const activeLayersIds = activeLayers.map((l) => l.id);
+  const isActive = useMemo(() => activeLayersIds.includes(id), [activeLayersIds, id]);
   const widgets = useWidgets();
-
   const download = DOWNLOAD[id] || content?.download;
   const info = INFO[id] || content?.info;
   const layer = LAYERS[id] || content?.layer;
@@ -55,7 +53,7 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
           opacity: string;
         }[]);
     setActiveLayers(layersUpdate);
-  }, [isActive, activeLayers, setActiveLayers]);
+  }, [isActive, activeLayers, setActiveLayers, id]);
 
   const HELPER_ID = id === widgets[0].slug;
 

--- a/src/components/widget-controls/index.tsx
+++ b/src/components/widget-controls/index.tsx
@@ -3,6 +3,7 @@ import { useMemo, useCallback } from 'react';
 import cn from 'lib/classnames';
 
 import { drawingToolAtom } from 'store/drawing-tool';
+import { activeLayersAtom } from 'store/layers';
 import { mapSettingsAtom } from 'store/map-settings';
 import { activeWidgetsAtom } from 'store/widgets';
 
@@ -17,6 +18,7 @@ import { useWidgets } from 'containers/widgets/hooks';
 import { SwitchWrapper, SwitchRoot, SwitchThumb } from 'components/switch';
 import { breakpoints } from 'styles/styles.config';
 import type { WidgetSlugType } from 'types/widget';
+import type { ContextualBasemapsId } from 'types/widget';
 
 import Download from './download';
 import Info from './info';
@@ -37,6 +39,7 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const isMapSettingsOpen = useRecoilValue(mapSettingsAtom);
   const screenWidth = useScreenWidth();
   const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
   const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
   const widgets = useWidgets();
 
@@ -45,9 +48,14 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const layer = LAYERS[id] || content?.layer;
 
   const handleClick = useCallback(() => {
-    const widgetsUpdate = isActive ? activeWidgets.filter((w) => w !== id) : [id, ...activeWidgets];
-    setActiveWidgets(widgetsUpdate);
-  }, [id, isActive, setActiveWidgets, activeWidgets]);
+    const layersUpdate = isActive
+      ? activeLayers.filter((w) => w.id !== id)
+      : ([{ id, opacity: '1' }, ...activeLayers] as {
+          id: WidgetSlugType | ContextualBasemapsId | 'custom-area';
+          opacity: string;
+        }[]);
+    setActiveLayers(layersUpdate);
+  }, [isActive, activeLayers, setActiveLayers]);
 
   const HELPER_ID = id === widgets[0].slug;
 

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -2,16 +2,16 @@ import { useMemo, useRef, useState, useEffect, useCallback } from 'react';
 
 import cn from 'lib/classnames';
 
-import { activeWidgetsAtom } from 'store/widgets';
+import { activeLayersAtom } from 'store/layers';
 
 import { isEmpty } from 'lodash-es';
 import { useRecoilState } from 'recoil';
 
+import CoastalProtection from 'containers/datasets/flood-protection/coastal-protection';
 import type {
   FloodProtectionPeriodId,
   FloodProtectionIndicatorId,
 } from 'containers/datasets/flood-protection/types';
-import CoastalProtection from 'containers/datasets/flood-protection/coastal-protection';
 
 import Icon from 'components/icon';
 import Loading from 'components/loading';
@@ -24,6 +24,7 @@ import {
   WIDGET_SELECT_STYLES,
 } from 'styles/widgets';
 import { WidgetSlugType } from 'types/widget';
+import type { ContextualBasemapsId } from 'types/widget';
 
 import ARROW_SVG from 'svgs/ui/arrow.svg?sprite';
 import TRIANGLE_SVG from 'svgs/ui/triangle.svg?sprite';
@@ -56,12 +57,18 @@ const FloodProtection = ({
 
   const id = `mangrove_coastal_protection_${indicator}` satisfies WidgetSlugType;
 
-  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
-  const isActive = useMemo(() => activeWidgets.includes(id), [activeWidgets, id]);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
+  const activeLayersIds = activeLayers.map((l) => l.id);
+  const isActive = useMemo(() => activeLayersIds.includes(id), [activeLayersIds, id]);
 
   const handleClick = () => {
-    const widgetsUpdate = isActive ? activeWidgets.filter((w) => w !== id) : [id, ...activeWidgets];
-    setActiveWidgets(widgetsUpdate);
+    const layersUpdate = isActive
+      ? activeLayers.filter((w) => w.id !== id)
+      : ([{ id, opacity: '1' }, ...activeLayers] as {
+          id: WidgetSlugType | ContextualBasemapsId | 'custom-area';
+          opacity: string;
+        }[]);
+    setActiveLayers(layersUpdate);
   };
 
   const ref = useRef<HTMLDivElement>(null);

--- a/src/containers/datasets/national-dashboard/indicator-source/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-source/index.tsx
@@ -5,7 +5,6 @@ import { numberFormat } from 'lib/format';
 
 import { activeLayersAtom } from 'store/layers';
 import { nationalDashboardSettingsAtom } from 'store/national-dashboard';
-import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilState } from 'recoil';
 
@@ -52,7 +51,6 @@ const IndicatorSource = ({
   yearSelected,
   setYearSelected,
 }: IndicatorSourceTypes) => {
-  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
   const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
   const activeLayersIds = activeLayers.map((l) => l.id);
   const [nationalDashboardSettings, setNationalDashboardLayersSettings] = useRecoilState(

--- a/src/containers/datasets/national-dashboard/indicator-source/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-source/index.tsx
@@ -3,6 +3,7 @@ import { useMemo, useCallback, useState, useEffect } from 'react';
 import cn from 'lib/classnames';
 import { numberFormat } from 'lib/format';
 
+import { activeLayersAtom } from 'store/layers';
 import { nationalDashboardSettingsAtom } from 'store/national-dashboard';
 import { activeWidgetsAtom } from 'store/widgets';
 
@@ -52,21 +53,23 @@ const IndicatorSource = ({
   setYearSelected,
 }: IndicatorSourceTypes) => {
   const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
+  const activeLayersIds = activeLayers.map((l) => l.id);
   const [nationalDashboardSettings, setNationalDashboardLayersSettings] = useRecoilState(
     nationalDashboardSettingsAtom
   );
   const [isActiveLayer, setActiveLayer] = useState(false);
 
   const isActive = useMemo(
-    () => activeWidgets.includes('mangrove_national_dashboard_layer') && isActiveLayer,
-    [activeWidgets, dataSource?.layer_link]
+    () => activeLayersIds.includes('mangrove_national_dashboard_layer') && isActiveLayer,
+    [activeLayersIds, isActiveLayer, dataSource?.layer_link]
   );
   const handleClick = useCallback(
     (id) => {
       setActiveLayer(!isActiveLayer);
       const widgetsCheck = isActive
-        ? activeWidgets.filter((w) => w !== id)
-        : [id, ...activeWidgets];
+        ? activeLayers.filter((w) => w.id !== id)
+        : [{ id, opacity: '1' }, ...activeLayers];
 
       setNationalDashboardLayersSettings({
         ...nationalDashboardSettings,
@@ -81,9 +84,9 @@ const IndicatorSource = ({
         },
       });
       const widgetsUpdate = new Set(widgetsCheck);
-      setActiveWidgets([...widgetsUpdate]);
+      setActiveLayers([...widgetsUpdate]);
     },
-    [activeWidgets, yearSelected]
+    [activeLayers, yearSelected]
   );
 
   useEffect(() => {

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -9,7 +9,7 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
 import { LocationTypes } from 'containers/datasets/locations/types';
-import { getWidgetActive } from 'containers/widget/selector';
+import { getLayerActive } from 'containers/widget/selector';
 
 import {
   Command,
@@ -23,6 +23,7 @@ import Loading from 'components/loading';
 import RadioGroupItem from 'components/radio-group/radio-group-item';
 import type { RadioOption } from 'components/radio-group/types';
 import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+import type { WidgetSlugType, ContextualBasemapsId } from 'types/widget';
 
 import { useMangroveSpeciesLocation } from './hooks';
 import type { DataResponse } from './types';
@@ -47,7 +48,7 @@ const SpeciesLocation = () => {
   } = useMangroveSpeciesLocation({
     select: ({ data }) => data,
   });
-  const isWidgetActive = useRecoilValue(getWidgetActive('mangrove_species_location'));
+  const isLayerActive = useRecoilValue(getLayerActive('mangrove_species_location'));
 
   const specieOptions = useMemo(
     () =>
@@ -88,7 +89,7 @@ const SpeciesLocation = () => {
             </p>
           )}
 
-          {isWidgetActive && specieSelected && (
+          {isLayerActive && specieSelected && (
             <div className="mb-8 flex items-center space-x-2">
               <div className="my-0.5 mr-2.5 h-4 w-2 rounded-md border border-brand-800 bg-[url('/images/species-location/small-pattern.svg')] bg-center text-sm" />
               <span className="text-sm font-bold text-black/85">

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -454,7 +454,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
       <Media greaterThanOrEqual="md">
         <div className="absolute bottom-10 right-10 space-y-1 print:hidden">
           {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
-          <Legend layers={activeOrdered} setActiveWidgets={setActiveWidgets} />
+          <Legend />
         </div>
       </Media>
     </div>

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -5,9 +5,11 @@ import { useMap } from 'react-map-gl';
 import { useRouter } from 'next/router';
 
 import cn from 'lib/classnames';
+import { orderByAttribute } from 'lib/utils';
 
 import { analysisAtom } from 'store/analysis';
 import { drawingToolAtom } from 'store/drawing-tool';
+import { activeLayersAtom } from 'store/layers';
 import {
   basemapAtom,
   URLboundsAtom,
@@ -15,7 +17,6 @@ import {
   interactiveLayerIdsAtom,
   mapCursorAtom,
 } from 'store/map';
-import { activeWidgetsAtom } from 'store/widgets';
 
 import { useQueryClient } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
@@ -86,16 +87,18 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   const [URLBounds, setURLBounds] = useRecoilState(URLboundsAtom);
   const [cursor, setCursor] = useRecoilState(mapCursorAtom);
 
-  const [activeWidgets, setActiveWidgets] = useRecoilState(activeWidgetsAtom);
+  const [activeLayers, setActiveLayers] = useRecoilState(activeLayersAtom);
   const [, setAnalysisState] = useRecoilState(analysisAtom);
 
-  const nationalDashboardLayers = activeWidgets.filter((el) =>
-    el?.includes('mangrove_national_dashboard')
+  const nationalDashboardLayers = activeLayers.filter((l) =>
+    l?.id?.includes('mangrove_national_dashboard')
   );
-  const activeOrdered = [
-    ...nationalDashboardLayers,
-    ...LAYERS_ORDER.filter((el) => activeWidgets.some((f) => f === el)),
-  ] as (WidgetSlugType & ContextualBasemapsId & 'custom-area' & NationalDashboardLayer)[];
+  const ordered = orderByAttribute(LAYERS_ORDER, activeLayers);
+
+  const activeOrdered = [...nationalDashboardLayers, ...ordered] as (WidgetSlugType &
+    ContextualBasemapsId &
+    'custom-area' &
+    NationalDashboardLayer)[];
 
   const [restorationPopUp, setRestorationPopUp] = useState<{
     popup: number[];
@@ -448,13 +451,13 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
       </Map>
       <Media lessThan="md">
         <div className="absolute top-20 left-0 z-[80]">
-          <Collapsible layers={activeOrdered} setActiveWidgets={setActiveWidgets} />
+          <Collapsible layers={activeOrdered} setActiveLayers={setActiveLayers} />
         </div>
       </Media>
       <Media greaterThanOrEqual="md">
         <div className="absolute bottom-10 right-10 space-y-1 print:hidden">
           {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
-          <Legend />
+          <Legend layers={activeOrdered} />
         </div>
       </Media>
     </div>

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -16,13 +16,13 @@ import Icon from 'components/icon';
 
 import REMOVE_SVG from 'svgs/ui/close.svg?sprite';
 
-const Legend = () => {
+const Legend = ({ layers }) => {
   const {
     query: { params },
   } = useRouter();
   const locationType = params?.[0] as LocationTypes;
   const id = params?.[1];
-  const [layers, setActiveLayers] = useRecoilState(activeLayersAtom);
+  const [, setActiveLayers] = useRecoilState(activeLayersAtom);
 
   const {
     data: { id: locationId },

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -2,9 +2,10 @@ import { useCallback } from 'react';
 
 import { useRouter } from 'next/router';
 
+import { activeLayersAtom } from 'store/layers';
 import { nationalDashboardSettingsAtom } from 'store/national-dashboard';
 
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 
 import { useLocation } from 'containers/datasets/locations/hooks';
 import type { LocationTypes } from 'containers/datasets/locations/types';
@@ -12,26 +13,16 @@ import Helper from 'containers/guide/helper';
 import { LAYERS } from 'containers/layers/constants';
 
 import Icon from 'components/icon';
-import { ContextualBasemapsId, WidgetSlugType } from 'types/widget';
 
 import REMOVE_SVG from 'svgs/ui/close.svg?sprite';
 
-type NationalDashboardLayer = `mangrove_national_dashboard${string}`;
-
-const Legend = ({
-  layers,
-  setActiveWidgets,
-}: {
-  layers: readonly (WidgetSlugType & ContextualBasemapsId & 'custom-area')[];
-  setActiveWidgets: (
-    layers: (WidgetSlugType & ContextualBasemapsId & 'custom-area' & NationalDashboardLayer)[]
-  ) => void;
-}) => {
+const Legend = () => {
   const {
     query: { params },
   } = useRouter();
   const locationType = params?.[0] as LocationTypes;
   const id = params?.[1];
+  const [layers, setActiveLayers] = useRecoilState(activeLayersAtom);
 
   const {
     data: { id: locationId },
@@ -44,11 +35,11 @@ const Legend = ({
   const removeLayer = useCallback(
     (layer: string) => {
       const updatedLayers = layers.filter((l) => {
-        return l !== layer;
+        return l.id !== layer;
       });
-      setActiveWidgets(updatedLayers);
+      setActiveLayers(updatedLayers);
     },
-    [layers, setActiveWidgets]
+    [layers, setActiveLayers]
   );
 
   const layerName = (label) => {
@@ -61,12 +52,12 @@ const Legend = ({
     <div className="flex flex-col space-y-1 print:hidden">
       {!!layers.length &&
         layers.map((l) => {
-          const layerNameToDisplay = layerName(l);
-          if (layerNameToDisplay === undefined && l !== 'mangrove_national_dashboard_layer')
+          const layerNameToDisplay = layerName(l.id);
+          if (layerNameToDisplay === undefined && l.id !== 'mangrove_national_dashboard_layer')
             return null;
           return (
             <Helper
-              key={l}
+              key={l.id}
               className={{
                 button: l === HELPER_ID ? '-bottom-3.5 -left-1.5 z-[20]' : 'hidden',
                 tooltip: 'w-[236px]',
@@ -74,9 +65,9 @@ const Legend = ({
               tooltipPosition={{ top: 80, left: 0 }}
               message="List of legends seen on the map. You can close them directly here"
             >
-              {l !== 'mangrove_national_dashboard_layer' && (
+              {l.id !== 'mangrove_national_dashboard_layer' && (
                 <div
-                  data-testid={`layer-legend-${l}`}
+                  data-testid={`layer-legend-${l.id}`}
                   className="flex h-11 min-w-[270px] items-center justify-between rounded-md bg-white px-6 py-3 text-sm shadow-medium"
                 >
                   <p className="text-xs font-semibold uppercase">{layerNameToDisplay}</p>
@@ -88,16 +79,20 @@ const Legend = ({
                     tooltipPosition={{ top: 100, left: 150 }}
                     message="layers on the map can be switched off here (same as toggle on widget)"
                   >
-                    <button type="button" onClick={() => removeLayer(l)} aria-label="Remove layer">
+                    <button
+                      type="button"
+                      onClick={() => removeLayer(l.id)}
+                      aria-label="Remove layer"
+                    >
                       <Icon icon={REMOVE_SVG} className="h-5 w-5" description="Remove layer" />
                     </button>
                   </Helper>
                 </div>
               )}
-              {l === 'mangrove_national_dashboard_layer' && nationalDashboardLayerName && (
+              {l.id === 'mangrove_national_dashboard_layer' && nationalDashboardLayerName && (
                 <div className="flex h-11 min-w-[270px] items-center justify-between rounded-md bg-white px-6 py-3 text-sm shadow-medium">
                   <p className="text-xs font-semibold uppercase">{`National Dashboard: ${nationalDashboardLayerName}`}</p>
-                  <button onClick={() => removeLayer(l)}>
+                  <button onClick={() => removeLayer(l.id)}>
                     <Icon icon={REMOVE_SVG} className="h-5 w-5" />
                   </button>
                 </div>

--- a/src/containers/sidebar/mobile/map-toggle/index.tsx
+++ b/src/containers/sidebar/mobile/map-toggle/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import cn from 'lib/classnames';
 
+import { activeLayersAtom } from 'store/layers';
 import { mapViewAtom } from 'store/sidebar';
-import { activeWidgetsAtom } from 'store/widgets';
 
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -12,7 +12,7 @@ import Icon from 'components/icon';
 import CLOSE_SVG from 'svgs/ui/close.svg?sprite';
 
 const MapToggle = () => {
-  const activeWidgets = useRecoilValue(activeWidgetsAtom);
+  const activeLayers = useRecoilValue(activeLayersAtom);
   const [mapView, setMapView] = useRecoilState(mapViewAtom);
 
   return (
@@ -34,7 +34,7 @@ const MapToggle = () => {
             description="Close"
           />
         )}
-        {!mapView && <p className="font-sans text-sm text-white">{activeWidgets.length}</p>}
+        {!mapView && <p className="font-sans text-sm text-white">{activeLayers.length}</p>}
       </button>
       <div className="text-center font-sans text-xxs text-white">Map</div>
     </div>

--- a/src/containers/widget/selector.ts
+++ b/src/containers/widget/selector.ts
@@ -1,8 +1,9 @@
+import { activeLayersAtom } from 'store/layers';
 import { activeWidgetsAtom } from 'store/widgets';
 
 import { selectorFamily } from 'recoil';
 
-import type { WidgetSlugType } from 'types/widget';
+import type { WidgetSlugType, ContextualBasemapsId } from 'types/widget';
 
 export const getWidgetActive = selectorFamily({
   key: 'is-widget-active',
@@ -10,5 +11,19 @@ export const getWidgetActive = selectorFamily({
     (widgetId: WidgetSlugType) =>
     ({ get }) => {
       return get(activeWidgetsAtom).includes(widgetId);
+    },
+});
+
+export const getLayerActive = selectorFamily<
+  boolean,
+  WidgetSlugType | ContextualBasemapsId | 'custom-area'
+>({
+  key: 'is-layer-active',
+  get:
+    (widgetId) =>
+    ({ get }) => {
+      const activeLayers = get(activeLayersAtom);
+      // Check if any object in the array has an id that matches widgetId
+      return activeLayers.some((layer) => layer.id === widgetId);
     },
 });

--- a/src/lib/recoil/devtools.tsx
+++ b/src/lib/recoil/devtools.tsx
@@ -6,8 +6,10 @@ function RecoilDevTools() {
   const snapshot = useRecoilSnapshot();
 
   useEffect(() => {
+    // eslint-disable-next-line no-console
     console.debug('The following atoms were modified:');
     for (const node of snapshot.getNodes_UNSTABLE({ isModified: true })) {
+      // eslint-disable-next-line no-console
       console.debug(node.key, snapshot.getLoadable(node));
     }
   }, [snapshot]);

--- a/src/lib/utils/index.tsx
+++ b/src/lib/utils/index.tsx
@@ -1,13 +1,20 @@
-export const orderByAttribute = (
-  orderedListIds: string[],
-  list: { id: string; opacity: string }[]
-) =>
-  list.sort((a, b) => {
-    const indexA = orderedListIds.indexOf(a.id);
-    const indexB = orderedListIds.indexOf(b.id);
+import type { ContextualBasemapsId, WidgetSlugType } from 'types/widget';
 
-    if (indexA === -1) return 1;
-    if (indexB === -1) return -1;
+export function orderByAttribute(
+  layerIds: (WidgetSlugType | ContextualBasemapsId | 'custom-area')[],
+  layers: { id: string; opacity: string }[]
+) {
+  const index = layerIds.reduce((map, id, index) => {
+    map[id] = index;
+    return map;
+  }, {});
+
+  const copyOfLayers = [...layers];
+
+  return copyOfLayers.sort((a, b) => {
+    const indexA = (index[a.id] ?? Number.MAX_VALUE) as number;
+    const indexB = (index[b.id] ?? Number.MAX_VALUE) as number;
 
     return indexA - indexB;
   });
+}

--- a/src/lib/utils/index.tsx
+++ b/src/lib/utils/index.tsx
@@ -1,0 +1,13 @@
+export const orderByAttribute = (
+  orderedListIds: string[],
+  list: { id: string; opacity: string }[]
+) =>
+  list.sort((a, b) => {
+    const indexA = orderedListIds.indexOf(a.id);
+    const indexB = orderedListIds.indexOf(b.id);
+
+    if (indexA === -1) return 1;
+    if (indexB === -1) return -1;
+
+    return indexA - indexB;
+  });

--- a/src/store/layers/index.ts
+++ b/src/store/layers/index.ts
@@ -1,0 +1,23 @@
+import { array, object, string, number } from '@recoiljs/refine';
+import { atom } from 'recoil';
+import { urlSyncEffect } from 'recoil-sync';
+
+import { ContextualBasemapsId, WidgetSlugType } from 'types/widget';
+
+const layerSchema = object({
+  id: string(),
+  opacity: string(),
+});
+
+export const activeLayersAtom = atom<
+  { id: WidgetSlugType | ContextualBasemapsId | 'custom-area'; opacity: string }[]
+>({
+  key: 'layers',
+  default: [{ id: 'mangrove_habitat_extent', opacity: '1' }],
+  effects: [
+    urlSyncEffect({
+      refine: array(layerSchema),
+      history: 'replace',
+    }),
+  ],
+});

--- a/src/store/map/index.ts
+++ b/src/store/map/index.ts
@@ -45,7 +45,7 @@ export const mapCursorAtom = atom<'grab' | 'pointer' | 'crosshair'>({
 });
 
 export const layersSettingsAtom = atom({
-  key: 'layers',
+  key: 'layers-settings',
   default: null,
   effects: [
     urlSyncEffect({

--- a/tests/layers.spec.ts
+++ b/tests/layers.spec.ts
@@ -66,8 +66,8 @@ test.describe('Can activate wordwise layers in widgets', () => {
     ({ categoryIds, locationType, layersIds, slug }) =>
       categoryIds?.includes(ALL_DATASETS_CATEGORY) &&
       locationType?.includes(WORDWIDE_LOCATION) &&
-      layersIds?.length &&
-      slug !== 'mangrove_iucn_ecoregion' // REMOVE THIS LINE WHEN THE LAYER URL BUG IS FIXED
+      layersIds?.length
+    // slug !== 'mangrove_iucn_ecoregion' // REMOVE THIS LINE WHEN THE LAYER URL BUG IS FIXED
   );
   for (const widget of widgetsWithLayers) {
     test(`Layer "${widget.layersIds[0] as string}" of ${widget.name}`, async ({ page }) => {


### PR DESCRIPTION
## Active layer params added to URL

### Overview

_From now on, the layer and widget can be activated independently. That means the widget and layer should be managed separately stored and updated in the URL accordingly.  This PR adds layers to the URL (with opacity but without the possibility of changing it yet), and adds implementation to activate layers from the platform aside from the widget _

### Designs

_Link to the related design prototypes (if applicable)_

### Testing instructions

_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._

### Feature relevant tickets

_[Link to the related task manager tickets](https://vizzuality.atlassian.net/browse/GMW-714?atlOrigin=eyJpIjoiOTU4ZjM5NGY3YmU1NDdiZTllMGI0MDE0ZGJhOGJmMmQiLCJwIjoiaiJ9)_

---

## Checklist before submitting

- [ ] Meaningful commits and code rebased on `develop`.
- [ ] Update CHANGELOG
- [ ] If this PR adds feature that should be tested for regressions when
      deploying to staging/production, please add brief testing instructions
      to the deploy checklist 
