### PR TITLE
[FE](fix): default layer opacities

### DIFF
--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -469,7 +469,7 @@ export function useSources(): SourceProps[] {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -512,7 +512,15 @@ export function useLayers({
           // Adjust the heatmap radius by zoom level
           'heatmap-radius': ['interpolate', ['linear'], ['zoom'], 0, 2, 9, 20],
           // Transition from heatmap to circle layer by zoom level
-          'heatmap-opacity': ['interpolate', ['linear'], ['zoom'], 2, 1, 11, opacity],
+          'heatmap-opacity': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            opacity * 2,
+            opacity * 1,
+            opacity * 11,
+            opacity * 0.5,
+          ],
         },
         layout: {
           visibility,
@@ -533,7 +541,15 @@ export function useLayers({
           'circle-stroke-color': 'rgba(255, 194, 0, 1)',
           'circle-stroke-width': 1,
           'circle-blur': 0.5,
-          'circle-opacity': ['interpolate', ['linear'], ['zoom'], 9, 0, 10, opacity],
+          'circle-opacity': [
+            'interpolate',
+            ['linear'],
+            ['zoom'],
+            opacity * 9,
+            opacity * 0,
+            opacity * 10,
+            opacity * 0.7,
+          ],
         },
         layout: {
           visibility,

--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -184,7 +184,7 @@ export function useSource(): SourceProps {
 }
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -233,7 +233,7 @@ export function useSource(): SourceProps {
 }
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/contextual-layers/allen-coral-reef/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/allen-coral-reef/hooks.tsx
@@ -16,7 +16,7 @@ export function useSource(): SourceProps {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/contextual-layers/basemaps-planet/visual/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/basemaps-planet/visual/hooks.tsx
@@ -28,7 +28,7 @@ export function useSource(): SourceProps & { key: string } {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -39,7 +39,7 @@ export function useLayer({
     id,
     type: 'raster',
     paint: {
-      'raster-opacity': 0.5,
+      'raster-opacity': opacity * 0.5,
     },
     layout: {
       visibility,

--- a/src/containers/datasets/contextual-layers/global-tidal-wetland-change/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/global-tidal-wetland-change/hooks.tsx
@@ -16,7 +16,7 @@ export function useSource(): SourceProps {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/contextual-layers/protected-areas/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/protected-areas/hooks.tsx
@@ -12,7 +12,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/contextual-layers/salt-marsh/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/salt-marsh/hooks.tsx
@@ -15,7 +15,7 @@ export function useSource(): SourceProps {
 }
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/contextual-layers/tidal-flats/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/tidal-flats/hooks.tsx
@@ -16,7 +16,7 @@ export function useSource(): SourceProps {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/drivers-change/hooks.tsx
+++ b/src/containers/datasets/drivers-change/hooks.tsx
@@ -117,7 +117,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -144,7 +144,7 @@ export function useLayers({
       'source-layer': 'main_loss_drivers',
       paint: {
         'fill-color': ['match', ['get', 'primary_driver'], ...COLORS, '#ccc'],
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.65,
       },
       layout: {
         visibility,

--- a/src/containers/datasets/fisheries/hooks.tsx
+++ b/src/containers/datasets/fisheries/hooks.tsx
@@ -170,7 +170,7 @@ export function useSource(): SourceProps {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/flood-protection/storms/layers/area.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/area.tsx
@@ -18,7 +18,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -49,7 +49,7 @@ export function useLayers({
           max,
           '#63589F',
         ],
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.7,
         'fill-outline-color': [
           'interpolate',
           ['linear'],

--- a/src/containers/datasets/flood-protection/storms/layers/population.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/population.tsx
@@ -19,7 +19,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -49,7 +49,7 @@ export function useLayers({
           max,
           '#672044',
         ],
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.6,
       },
       layout: {
         visibility,

--- a/src/containers/datasets/flood-protection/storms/layers/stock.tsx
+++ b/src/containers/datasets/flood-protection/storms/layers/stock.tsx
@@ -19,7 +19,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -49,7 +49,7 @@ export function useLayers({
           max,
           '#2A5674',
         ],
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.8,
       },
       layout: {
         visibility,

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -222,7 +222,7 @@ export function useSource(): SourceProps {
 export function useLayers({
   year,
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   year: number;

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -236,7 +236,7 @@ export function useSource(years: number[]): SourceProps {
 }
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/iucn-ecoregion/hooks.tsx
+++ b/src/containers/datasets/iucn-ecoregion/hooks.tsx
@@ -147,7 +147,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 0.5,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -175,7 +175,7 @@ export function useLayers({
       paint: {
         'fill-color': ['match', ['get', 'overall_assessment'], ...COLORS, '#ccc'],
 
-        'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, opacity],
+        'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, opacity * 0.55],
       },
       layout: {
         visibility,
@@ -190,7 +190,7 @@ export function useLayers({
         'line-color': ['match', ['get', 'overall_assessment'], ...COLORS, '#ccc'],
         'line-width': 1.75,
         'line-offset': -0.3,
-        'line-opacity': opacity,
+        'line-opacity': opacity * 0.55,
       },
       layout: {
         visibility,

--- a/src/containers/datasets/national-dashboard/hooks.tsx
+++ b/src/containers/datasets/national-dashboard/hooks.tsx
@@ -71,7 +71,7 @@ export function useSource({
 export function useLayers({
   id,
   settings,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -243,7 +243,7 @@ export function useSources(): SourceProps[] {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/protection/hooks.tsx
+++ b/src/containers/datasets/protection/hooks.tsx
@@ -201,7 +201,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/restoration-sites/hooks.tsx
+++ b/src/containers/datasets/restoration-sites/hooks.tsx
@@ -123,7 +123,7 @@ export function useSource(): SourceProps {
 }
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];

--- a/src/containers/datasets/restoration/hooks.tsx
+++ b/src/containers/datasets/restoration/hooks.tsx
@@ -13,7 +13,7 @@ export function useSource(): SourceProps {
 }
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -44,7 +44,12 @@ export function useLayers({
               100,
               '#224294',
             ],
-            'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, opacity],
+            'fill-opacity': [
+              'case',
+              ['boolean', ['feature-state', 'hover'], false],
+              1,
+              opacity * 0.6,
+            ],
             'fill-outline-color': [
               'interpolate',
               ['linear'],

--- a/src/containers/datasets/species-distribution/hooks.tsx
+++ b/src/containers/datasets/species-distribution/hooks.tsx
@@ -80,7 +80,7 @@ export function useSource(): SourceProps {
 
 export function useLayers({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -146,7 +146,7 @@ export function useLayers({
           maxValue,
           '#205272',
         ],
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.6,
       },
       layout: {
         visibility,
@@ -183,7 +183,7 @@ export function useLayers({
           '#205272',
         ],
         'line-width': 1,
-        'line-opacity': 1,
+        'line-opacity': opacity * 0.6,
       },
     },
   ];

--- a/src/containers/datasets/species-location/hooks.tsx
+++ b/src/containers/datasets/species-location/hooks.tsx
@@ -61,7 +61,7 @@ export function useSource(): SourceProps {
 
 export function useLayer({
   id,
-  opacity = 1,
+  opacity,
   visibility = 'visible',
 }: {
   id: LayerProps['id'];
@@ -100,7 +100,7 @@ export function useLayer({
       filter: ['any', ...dataFiltered?.map((id) => ['in', id, ['get', 'location_idn']])],
       paint: {
         'fill-pattern': 'pattern',
-        'fill-opacity': opacity,
+        'fill-opacity': opacity * 0.5,
       },
       layout: {
         visibility,


### PR DESCRIPTION
## Default layer opacities

### Testing instructions

Check default opacity in following layers (_it should be less than full opacity when user sets the layer initially_):

- Alerts
- Basemap planet
- Drivers of change
- Restoration
- Species distribution
- Species location
- Flood protection area 
- Flood protection population 
- Flood protection stock
- IUCN Ecoregion


