### PR TITLE
[FE](fix): minor fixes

### DIFF
--- a/src/containers/categories-menu/index.tsx
+++ b/src/containers/categories-menu/index.tsx
@@ -42,7 +42,7 @@ const Category = () => {
           <button key={category.value} type="button" value={category.value} onClick={handleClick}>
             <div
               className={cn({
-                'relative flex-1 items-center justify-center rounded-xl border border-black/15 p-3 text-xs md:p-6 md:text-sm':
+                'relative flex-1 items-center justify-center rounded-xl border border-black/15 p-3 text-xs md:p-5 md:text-sm':
                   true,
                 'border-2 border-brand-800 font-bold text-brand-800':
                   category.value === categorySelected,

--- a/src/containers/datasets/drawing-tool/index.tsx
+++ b/src/containers/datasets/drawing-tool/index.tsx
@@ -67,7 +67,7 @@ const WidgetDrawingTool = () => {
   useUploadFile(acceptedFiles?.[0], onUploadFile);
 
   useEffect(() => {
-    setMapCursor(isDrawingToolEnabled ? 'crosshair' : 'grab');
+    setMapCursor(isDrawingToolEnabled ? 'cell' : 'grab');
   }, [setMapCursor, isDrawingToolEnabled]);
 
   return (

--- a/src/containers/datasets/drawing-upload-tool/index.tsx
+++ b/src/containers/datasets/drawing-upload-tool/index.tsx
@@ -61,7 +61,7 @@ const WidgetDrawingUploadTool = () => {
   useUploadFile(acceptedFiles?.[0], onUploadFile);
 
   useEffect(() => {
-    setMapCursor(isDrawingUploadToolEnabled ? 'crosshair' : 'grab');
+    setMapCursor(isDrawingUploadToolEnabled ? 'cell' : 'grab');
   }, [setMapCursor, isDrawingUploadToolEnabled]);
 
   const conditionalProps =

--- a/src/containers/datasets/fisheries/tooltip.tsx
+++ b/src/containers/datasets/fisheries/tooltip.tsx
@@ -14,7 +14,7 @@ const CustomTooltip = ({ payload }: TooltipProps) => {
         <span className="font-bold">
           {category} {unit}:
         </span>{' '}
-        {valueFormatted}
+        <span className="whitespace-nowrap">{valueFormatted}</span>
       </p>
     </div>
   );

--- a/src/containers/datasets/species-distribution/widget.tsx
+++ b/src/containers/datasets/species-distribution/widget.tsx
@@ -2,6 +2,8 @@ import { createRef, useState, useLayoutEffect } from 'react';
 
 import cn from 'lib/classnames';
 
+import NoData from 'containers/widgets/no-data';
+
 import Icon from 'components/icon';
 import Loading from 'components/loading';
 import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from 'styles/widgets';
@@ -23,6 +25,7 @@ const SpeciesDistribution = () => {
     isFetched,
     isPlaceholderData,
   } = useMangroveSpecies();
+
   const isWorldwide = location === 'Worldwide';
   // const total = data?.total;
   const ref = createRef<HTMLDivElement>();
@@ -34,7 +37,7 @@ const SpeciesDistribution = () => {
     }
   }, []);
 
-  if (noData) return null;
+  if (noData) return <NoData />;
   return (
     <div className={WIDGET_CARD_WRAPPER_STYLE}>
       <Loading

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -328,18 +328,20 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
         );
         hoveredStateId = null;
       }
-
-      if (interactiveLayers || restorationData) {
+      if (isDrawingToolEnabled && !customGeojson) {
+        setCursor('cell');
+      } else if (interactiveLayers || restorationData) {
         setCursor('pointer');
       } else setCursor('grab');
     },
-    [setCursor, map]
+    [cursor, map, isDrawingToolEnabled, customGeojson]
   );
 
   const handleMapLoad = useCallback(() => {
     setLoaded(true);
   }, []);
   const pitch = map?.getPitch();
+
   return (
     <div
       className="print:page-break-after print:page-break-inside-avoid absolute top-0 left-0 z-0 h-screen w-screen print:relative print:top-4 print:w-[90vw]"

--- a/src/containers/widgets/no-data/index.tsx
+++ b/src/containers/widgets/no-data/index.tsx
@@ -4,13 +4,12 @@ import NO_DATA_SVG from 'svgs/ui/no-data.svg?sprite';
 
 const NoData = () => {
   return (
-    <div className="m-auto ml-[3%] flex min-h-[334px] w-full max-w-full break-inside-avoid flex-col items-center justify-center rounded-3xl bg-white pt-8 pr-5 pl-10 shadow-widget md:ml-0">
+    <div className="m-auto flex w-full max-w-full break-inside-avoid flex-col items-center justify-center rounded-3xl bg-white py-8">
       <Icon className="h-40 w-40" icon={NO_DATA_SVG} description="No data" />
-      {/* md:h-fit-content ml-[3%] w-[94%] rounded-2xl border border-[#DADED0] bg-white px-1 py-1 shadow-widget md:ml-0 md:w-[540px] */}
       <p className="text-center font-sans text-xs leading-5 sm:text-base sm:leading-6">
-        Sorry, there are <b>no data</b> for this location.
+        Sorry, there are <b>no data</b> for this category.
         <br />
-        Try with another category.
+        Try with another location.
       </p>
     </div>
   );

--- a/src/store/map/index.ts
+++ b/src/store/map/index.ts
@@ -39,7 +39,7 @@ export const interactiveLayerIdsAtom = atom<LayerProps['id'][]>({
   default: [],
 });
 
-export const mapCursorAtom = atom<'grab' | 'pointer' | 'crosshair'>({
+export const mapCursorAtom = atom<'grab' | 'pointer' | 'cell'>({
   key: 'mapCursor',
   default: 'grab',
 });


### PR DESCRIPTION
## Minor fixes

### Overview

- [x] Add cell cursor when user is drawing
Note: _Maybe should be useful to have a fourth cursor for when you're done drawing and want to move the dots. If we leave the cell, it gives the impression that several polygons can be painted, and if we leave the grab or the pointer, it does not seem that they can move_.

- [x] Fix break on fisheries chart tooltip
- [x] Fix space on widgets deck category button
