### PR TITLE
rest sites tooltip

### DIFF
--- a/src/containers/datasets/restoration-sites/hooks.tsx
+++ b/src/containers/datasets/restoration-sites/hooks.tsx
@@ -124,7 +124,7 @@ export function useSource(): SourceProps {
     cluster: true,
   };
 }
-export function useLayer({
+export function useLayers({
   id,
   opacity,
   visibility = 'visible',
@@ -142,10 +142,26 @@ export function useLayer({
       type: 'circle',
       filter: ['has', 'point_count'],
       paint: {
-        'circle-color': '#CC61B0',
+        'circle-color': [
+          'step',
+          ['get', 'point_count'],
+          '#CC61B0', // color for small clusters
+          50,
+          '#FF9F1C', // medium clusters
+          200,
+          '#FF4040', // large clusters
+        ],
         'circle-stroke-width': 1,
-        'circle-stroke-color': '#CC61B0',
-        'circle-radius': ['step', ['get', 'point_count'], 10, 100, 20, 500, 30],
+        'circle-stroke-color': '#FFFFFF',
+        'circle-radius': [
+          'step',
+          ['get', 'point_count'],
+          15, // radius for clusters with 1-25 points
+          15,
+          25, // radius for clusters with 25-50 points
+          50,
+          35, // radius for clusters with 50+ points
+        ],
         'circle-opacity': opacity,
         'circle-stroke-opacity': opacity,
       },
@@ -164,7 +180,7 @@ export function useLayer({
         'circle-color': '#CC61B0',
         'circle-radius': 5,
         'circle-stroke-width': 1,
-        'circle-stroke-color': '#CC61B0',
+        'circle-stroke-color': '#FFFFFF',
         'circle-opacity': opacity,
         'circle-stroke-opacity': opacity,
       },
@@ -180,13 +196,15 @@ export function useLayer({
       type: 'symbol',
       filter: ['has', 'point_count'],
       layout: {
-        'text-field': ['get', 'point_count_abbreviated'],
+        'text-field': ['format', ['get', 'point_count_abbreviated'], { 'font-scale': 1.2 }],
         'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
         'text-size': 12,
         visibility,
       },
       paint: {
         'text-color': '#ffffff',
+        'text-halo-color': '#fff',
+        'text-halo-width': 0.5,
         'text-opacity': opacity,
       },
     },

--- a/src/containers/datasets/restoration-sites/layer.tsx
+++ b/src/containers/datasets/restoration-sites/layer.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useMemo } from 'react';
+
 import { Source, Layer } from 'react-map-gl';
 
 import { activeLayersAtom } from 'store/layers';
@@ -6,20 +8,31 @@ import { useRecoilValue } from 'recoil';
 
 import type { LayerProps } from 'types/layers';
 
-import { useLayer, useSource } from './hooks';
+import { useLayers, useSource } from './hooks';
 
-const MangrovesRestorationSitesLayer = ({ beforeId, id }: LayerProps) => {
+const MangrovesRestorationSitesLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
   const activeLayers = useRecoilValue(activeLayersAtom);
-  const activeLayer = activeLayers?.find((l) => l.id === 'mangrove_rest_sites');
+  const activeLayer = activeLayers?.find((l) => l.id.includes('mangrove_rest_sites'));
 
   const SOURCE = useSource();
-  const LAYERS = useLayer({
+  const LAYERS = useLayers({
     id,
     opacity: parseFloat(activeLayer.opacity),
     visibility: activeLayer.visibility,
   });
 
+  const ids = useMemo(() => LAYERS.map((layer) => layer.id), [LAYERS]);
+
+  useEffect(() => {
+    if (!!ids.length) {
+      onAdd(ids);
+      return () => onRemove(ids);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onAdd, onRemove]);
+
   if (!SOURCE || !LAYERS) return null;
+
   return (
     <Source key={SOURCE.id} {...SOURCE}>
       {LAYERS.map((LAYER) => (

--- a/src/containers/map/restoration-sites-popup/detail/index.tsx
+++ b/src/containers/map/restoration-sites-popup/detail/index.tsx
@@ -1,0 +1,32 @@
+const Detail = ({
+  label,
+  pct,
+  value,
+  unit,
+}: {
+  label: string;
+  pct: number;
+  value: string;
+  unit?: string;
+}) => (
+  <div className="flex w-full items-center font-sans">
+    <div className="w-[165px] whitespace-nowrap text-right text-sm font-light">{label}</div>
+    <div className="mx-4 flex h-4 w-[126px] bg-white">
+      <div
+        className="relative h-full bg-[#B2CBF9]"
+        style={{ width: `${100}%`, marginRight: !!pct && pct > 0 ? 2 : 0 }}
+      >
+        <span
+          className="absolute h-full grow bg-slate-100 text-xxs"
+          style={{ left: `${pct * 10}%`, right: 0 }}
+        />
+      </div>
+    </div>
+    <div className="whitespace-nowrap text-sm font-semibold">
+      {value}
+      {!!unit && typeof value === 'number' && unit}
+    </div>
+  </div>
+);
+
+export default Detail;

--- a/src/containers/map/restoration-sites-popup/index.tsx
+++ b/src/containers/map/restoration-sites-popup/index.tsx
@@ -1,0 +1,97 @@
+import { useCallback, useState } from 'react';
+
+import cn from 'lib/classnames';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import { WIDGET_CARD_WRAPPER_STYLE } from 'styles/widgets';
+import { RestorationSitesPopUp } from 'types/map';
+
+const PopupRestorationSites = ({
+  info,
+}: {
+  className?: string;
+  info: {
+    popupInfo: RestorationSitesPopUp;
+  };
+}) => {
+  const [open, setOpen] = useState(false);
+  const handleClick = useCallback(() => {
+    setOpen(!open);
+  }, [open]);
+
+  return (
+    <div
+      className={cn({
+        [WIDGET_CARD_WRAPPER_STYLE]: true,
+        'shadow-b-widget space-x-2 rounded-b-3xl border border-t border-slate-100 bg-white px-6 py-4':
+          true,
+      })}
+    >
+      <button className="flex w-full items-center justify-between" onClick={handleClick}>
+        <h2 className="cursor-pointer whitespace-nowrap py-5 text-xs font-bold uppercase -tracking-tighter text-black/85">
+          RESTORATION SITES
+        </h2>
+        <div
+          className={cn({
+            'z-50 font-normal text-brand-800': true,
+            'mb-2 text-5xl': open,
+            'text-3xl': !open,
+          })}
+        >
+          {open ? '-' : '+'}
+        </div>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key="content"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{ duration: 0.4, ease: [0.04, 0.62, 0.23, 0.98] }}
+          >
+            {info.popupInfo.cluster && (
+              <p className="text-sm text-black/85">
+                <span>
+                  There are <strong>{info.popupInfo.point_count}</strong> restoration sites in this
+                  location.{' '}
+                </span>
+                <span className="font-extralight">
+                  Zoom in to view more details about each site
+                </span>
+              </p>
+            )}
+
+            <div className="flex w-full justify-between font-sans">
+              {info.popupInfo.site_name && (
+                <div className="flex flex-col">
+                  <span className="text-left text-sm font-semibold text-brand-800">Site</span>
+                  <span className="text-left text-xxs font-light uppercase leading-5 text-black/85">
+                    {info.popupInfo.site_name}
+                  </span>
+                </div>
+              )}
+
+              {info.popupInfo.landscape_name && (
+                <div className="flex flex-col">
+                  <span className="text-left text-sm font-semibold text-brand-800">Landscape</span>
+                  <span className="text-left text-xxs font-light uppercase leading-5 text-black/85">
+                    {info.popupInfo.landscape_name}
+                  </span>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default PopupRestorationSites;

--- a/src/containers/map/restoration-sites-popup/restoration-data-group/index.tsx
+++ b/src/containers/map/restoration-sites-popup/restoration-data-group/index.tsx
@@ -1,0 +1,27 @@
+import { format } from 'd3-format';
+const numberFormat = format(',.0f');
+
+const RestorationDataGroup = ({
+  label,
+  value,
+  pct,
+  unit,
+}: {
+  label: string;
+  value: string | number;
+  pct?: string;
+  unit?: string;
+}) => {
+  return (
+    <div className="flex flex-col pr-6 pb-6 font-sans text-sm text-black/85">
+      <div className="font-sans font-light">{label}</div>
+      <div className="font-semibold">
+        {typeof value === 'number' ? numberFormat(value) : value} {!!value && !!unit && unit}{' '}
+        {!!pct && `(${pct}%)`}
+        {!value && value !== 0 && '-'}
+      </div>
+    </div>
+  );
+};
+
+export default RestorationDataGroup;

--- a/src/containers/map/restoration-sites-popup/sections/details/index.tsx
+++ b/src/containers/map/restoration-sites-popup/sections/details/index.tsx
@@ -1,0 +1,92 @@
+import cn from 'lib/classnames';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import Detail from 'containers/map/restoration-popup/detail';
+
+import { WIDGET_SUBTITLE_STYLE } from 'styles/widgets';
+import type { RestorationPopUp } from 'types/map';
+
+const Details = ({
+  data,
+  isOpen,
+  handleClick,
+}: {
+  data: RestorationPopUp;
+  isOpen: boolean;
+  handleClick: () => void;
+}) => {
+  const {
+    Tidal_range,
+    Tidal_range1,
+    Ant_SLR,
+    Ant_SLR1,
+    Future_SLR,
+    Future_SLR1,
+    Time_Loss,
+    Time_Loss1,
+    Flow_Group,
+    Flow_Group1,
+    Med_Patch,
+    Med_Patch_1,
+    Contig_Group,
+    Contig_Group1,
+  } = data;
+
+  return (
+    <div
+      className={cn({
+        'box-border flex w-[500px] cursor-pointer flex-col items-start border-t border-slate-100 p-6 font-sans':
+          true,
+        'max-h-[72px] overflow-hidden': !isOpen,
+      })}
+    >
+      <div className="flex w-full items-center justify-between pb-6" onClick={handleClick}>
+        <span className="m-0 text-sm font-semibold">
+          <h3 className={WIDGET_SUBTITLE_STYLE}>DETAILS</h3>
+        </span>
+        <span
+          className={cn({
+            'text-brand-800': true,
+            'text-5xl': isOpen,
+            'text-3xl': !isOpen,
+          })}
+        >
+          {isOpen ? '-' : '+'}
+        </span>
+      </div>
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.section
+            key="content"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{ duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] }}
+          >
+            <div className="flex w-full grow flex-col items-center justify-between">
+              <Detail label="Tidal range" pct={Tidal_range1} value={Tidal_range} />
+              <Detail label="Antecedent SLR" pct={Ant_SLR1} value={Ant_SLR} />
+              <Detail label="Future SLR" pct={Future_SLR1} value={Future_SLR} />
+              <Detail label="Timing of loss" pct={Time_Loss1} value={Time_Loss} />
+              <Detail label="Hydrological disturbance" pct={Flow_Group1} value={Flow_Group} />
+              <Detail label="Patch size and number" pct={Med_Patch_1} value={Med_Patch} />
+              <Detail
+                label="Patch connectivity"
+                pct={Contig_Group1}
+                value={Contig_Group}
+                unit="%"
+              />
+            </div>
+          </motion.section>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default Details;

--- a/src/containers/map/restoration-sites-popup/sections/ecosysyem-services/index.tsx
+++ b/src/containers/map/restoration-sites-popup/sections/ecosysyem-services/index.tsx
@@ -1,0 +1,82 @@
+import cn from 'lib/classnames';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import RestorationDataGroup from 'containers/map/restoration-popup/restoration-data-group';
+
+import { WIDGET_SUBTITLE_STYLE } from 'styles/widgets';
+import type { RestorationPopUp } from 'types/map';
+
+const EcosystemServices = ({
+  data,
+  isOpen,
+  handleClick,
+}: {
+  data: RestorationPopUp;
+  isOpen: boolean;
+  handleClick: () => void;
+}) => {
+  const { SOC, AGB, Fish_Score_Inv, Fish_Score } = data;
+  return (
+    <div
+      className={cn({
+        'box-border flex w-[500px] cursor-pointer flex-col items-start border-t border-slate-100 px-6 pt-6 font-sans':
+          true,
+        'max-h-[84px] overflow-hidden': !isOpen,
+      })}
+    >
+      <div className="mb-6 flex w-full items-center justify-between" onClick={handleClick}>
+        <div className="space-y-0.5">
+          <h3 className={WIDGET_SUBTITLE_STYLE}>ECOSYSTEM SERVICES</h3>
+          <p className="text-xs font-light">for restored mangroves</p>
+        </div>
+        <span
+          className={cn({
+            'text-brand-800': true,
+            'text-5xl': isOpen,
+            'text-3xl': !isOpen,
+          })}
+        >
+          {isOpen ? '-' : '+'}
+        </span>
+      </div>
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.section
+            key="content"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{
+              duration: 0.8,
+              ease: [0.04, 0.62, 0.23, 0.98],
+              opacity: { delay: 0.1 },
+            }}
+          >
+            <div className="w-fit-content grid grid-flow-col grid-rows-2 gap-2">
+              <RestorationDataGroup label="Mean soil organic carbon" value={SOC} unit="mtCO₂e" />
+              <RestorationDataGroup label="Mean aboveground carbon" value={AGB} unit="mtCO₂e" />
+
+              <RestorationDataGroup
+                label="Commercial invert catch
+             enhancement value"
+                value={Fish_Score_Inv}
+              />
+              <RestorationDataGroup
+                label="Commercial fish catch
+             enhancement value"
+                value={Fish_Score}
+              />
+            </div>
+          </motion.section>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default EcosystemServices;

--- a/src/containers/map/restoration-sites-popup/sections/restoration-scores/index.tsx
+++ b/src/containers/map/restoration-sites-popup/sections/restoration-scores/index.tsx
@@ -1,0 +1,103 @@
+import cn from 'lib/classnames';
+
+import { AnimatePresence, motion } from 'framer-motion';
+
+import RestorationDataGroup from 'containers/map/restoration-popup/restoration-data-group';
+
+import { WIDGET_SUBTITLE_STYLE } from 'styles/widgets';
+import type { RestorationPopUp } from 'types/map';
+
+const RestorationScores = ({
+  data,
+  isOpen,
+  handleClick,
+}: {
+  data: RestorationPopUp;
+  isOpen: boolean;
+  handleClick: () => void;
+}) => {
+  const { Class, Max_Area_20_ha, Area_loss_ha, Rest_Area_Loss, Loss_Driver, Rest_Score } = data;
+
+  const nonRestScore = 100 - Rest_Score;
+
+  return (
+    <div
+      className={cn({
+        'box-border flex w-[500px] cursor-pointer flex-col items-start border-t border-slate-100 p-6 font-sans':
+          true,
+        'max-h-[72px] overflow-hidden': !isOpen,
+      })}
+    >
+      <div className="flex w-full items-center justify-between pb-6" onClick={handleClick}>
+        <span>
+          <h3 className={WIDGET_SUBTITLE_STYLE}>RESTORATION SCORES</h3>
+        </span>
+        <span
+          className={cn({
+            'text-brand-800': true,
+            'text-5xl': isOpen,
+            'text-3xl': !isOpen,
+          })}
+        >
+          {isOpen ? '-' : '+'}
+        </span>
+      </div>
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.section
+            key="content"
+            initial="collapsed"
+            animate="open"
+            exit="collapsed"
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{ duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] }}
+          >
+            <div className="w-full">
+              <div className="flex grow items-center justify-between">
+                <RestorationDataGroup label="Mangrove type" value={Class} />
+                <RestorationDataGroup
+                  label="Max mangrove area 1996 - 2020"
+                  value={Max_Area_20_ha}
+                  unit="ha"
+                />
+              </div>
+              <div className="flex grow items-start justify-between">
+                <RestorationDataGroup label="Area of Loss" value={Area_loss_ha} unit="ha" />
+                <RestorationDataGroup label="Restorable Area" value={Rest_Area_Loss} unit="ha" />
+                <RestorationDataGroup label="Primary Loss Driver" value={Loss_Driver} />
+              </div>
+            </div>
+
+            <div className="w-full">
+              <h4 className="py-4 font-sans text-sm font-light">Restoration potential score</h4>
+              <div className="flex grow items-center justify-between space-x-6">
+                <div className="h-6 w-full bg-slate-100">
+                  <div
+                    className="relative h-full w-full"
+                    style={{
+                      background:
+                        'linear-gradient(90deg, #F9DDDA 0%, #FFADAD 25.52%, #CE78B3 50.52%, #8478CE 78.13%, #224294 100%)',
+                    }}
+                  >
+                    <span
+                      className="absolute right-0 h-full bg-slate-100"
+                      style={{
+                        width: `${nonRestScore}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="text-4xl">{Rest_Score}</div>
+              </div>
+            </div>
+          </motion.section>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default RestorationScores;

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -4,7 +4,6 @@ import cn from 'lib/classnames';
 
 import { drawingToolAtom, drawingUploadToolAtom } from 'store/drawing-tool';
 import { locationToolAtom } from 'store/sidebar';
-import { activeCategoryAtom } from 'store/sidebar';
 import { activeWidgetsAtom } from 'store/widgets';
 
 import { motion } from 'framer-motion';
@@ -19,7 +18,6 @@ import Helper from 'containers/guide/helper';
 import AppTools from 'containers/navigation';
 import WidgetWrapper from 'containers/widget';
 import { widgets, ANALYSIS_WIDGETS_SLUGS } from 'containers/widgets/constants';
-import { useWidgetsIdsByCategory } from 'containers/widgets/hooks';
 
 import { Dialog, DialogContent, DialogTrigger, DialogClose } from 'components/ui/dialog';
 import Icon from 'components/ui/icon';
@@ -30,8 +28,8 @@ import { WidgetTypes } from 'types/widget';
 import SETTINGS_SVG from 'svgs/ui/settings.svg?sprite';
 
 import { useWidgets } from './hooks';
-import WidgetsMenu from './widgets-menu';
 import WidgetsCardsControls from './widgets-cards-controls';
+import WidgetsMenu from './widgets-menu';
 
 const buttonMotion = {
   rest: {
@@ -88,20 +86,6 @@ const WidgetsContainer: FC = () => {
       ({ slug }) => activeWidgets?.includes(slug) || slug === 'widgets_deck_tool'
     );
   }, [activeWidgets, enabledWidgets, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
-
-  const cat = useWidgetsIdsByCategory(activeWidgets);
-
-  // ensures that the appropriate widgets for a selected category are activated during
-  // the first render. This is crucial when the initial state is being loaded from a URL,
-  //  particularly in cases where the active widgets are not immediately visible on it
-
-  // useEffect(() => {
-  //   if (categorySelected !== cat) {
-  //     const filteredWidgets = widgetsAvailable.map(({ slug }) => slug);
-  //     setActiveWidgets(filteredWidgets);
-  //   }
-  //   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // }, []);
 
   const locationTool = useRecoilValue(locationToolAtom);
 

--- a/src/types/map.d.ts
+++ b/src/types/map.d.ts
@@ -38,6 +38,13 @@ export type RestorationPopUp = {
   Type: string;
 };
 
+export type RestorationSitesPopUp = {
+  cluster: boolean;
+  point_count: number;
+  site_name: string;
+  landscape_name: string;
+};
+
 type ProtectedArea = {
   ISO3: string;
   NAME: string;


### PR DESCRIPTION
This pull request includes significant updates to the restoration sites feature in the map application. The changes primarily focus on enhancing the visualization and interaction with restoration site data, including new popups and improved map layer handling.

### Enhancements to Restoration Sites Visualization and Interaction:

* **Map Layer Handling:**
  * Renamed `useLayer` to `useLayers` and updated the function to handle multiple layers.
  * Modified the `circle-color` and `circle-radius` properties in the `useLayers` function to use a stepped approach for better visualization of different cluster sizes.
  * Added `text-halo-color` and `text-halo-width` properties to improve text visibility on the map.

* **Popup Implementation:**
  * Introduced `RestorationSitesPopup` component to display detailed information about restoration sites in a popup.
  * Added `Detail` and `RestorationDataGroup` components to display detailed metrics within the popup. [[1]](diffhunk://#diff-b37236ab9ff216c0ab3b9e6c33f958bce7a17e23ca4dd90d3abc6d8173985d7aR1-R32) [[2]](diffhunk://#diff-f4c1ce5ad4414dfac2ffaf0ffc4aad2add0ce5de3ecb22fa7ded912248e13184R1-R27)
  * Implemented `Details` and `EcosystemServices` sections within the popup to show specific data points related to restoration sites. [[1]](diffhunk://#diff-7cbcb9162bdde7dc8d860c94666ad4a74645dde467042e312cc4207e7b2eda31R1-R92) [[2]](diffhunk://#diff-87d2b792ff8c9f346d95c03678f229ffcda71764f480f7f397e6580dafda9d0fR1-R82)

* **Map Container Updates:**
  * Added state management for the new `RestorationSitesPopup` in the `MapContainer` component.
  * Updated click handlers to include logic for displaying the restoration sites popup based on map interactions.
  * Included the `RestorationSitesPopup` component in the map's render method to ensure it appears when relevant data is available.

These changes collectively enhance the user experience by providing more detailed and interactive information about restoration sites directly on the map.