### PR TITLE
guide modal

### DIFF
--- a/src/containers/help/index.tsx
+++ b/src/containers/help/index.tsx
@@ -13,23 +13,20 @@ import { SwitchRoot, SwitchThumb, SwitchWrapper } from 'components/ui/switch';
 import HELP_SVG from 'svgs/tools-bar/help.svg?sprite';
 import { useLocalStorage } from 'usehooks-ts';
 
- import GuideModalIntro from './modal-intro';
+import GuideModalIntro from './modal-intro';
 
 export const HelpContainer = () => {
-  const [guideLocalStorage, setGuideLocalStorage] = useLocalStorage<boolean>('guideLocalStorage', false);
+  const [guideLocalStorage] = useLocalStorage<boolean>('guideLocalStorage', false);
   const [isOpen, setIsOpen] = useState(false);
   const [isActive, setIsActive] = useRecoilState(activeGuideAtom);
 
-
   const handleClick = () => {
-    setIsActive((prev) => !prev);
-
-    // Only show modal the first time the switch is clicked
-    if (!guideLocalStorage) {
-      setGuideLocalStorage(true);
-      setIsOpen(true);
-    }
-  };  
+    setIsActive((prev) => {
+      const nextState = !prev;
+      setIsOpen(nextState);
+      return nextState;
+    });
+  };
 
   return (
     <div>
@@ -64,9 +61,7 @@ export const HelpContainer = () => {
           </div>
         </PopoverContent>
       </Popover>
-
-      {/* Show the modal ONLY if it's the first time clicking the switch */}
-      {guideLocalStorage && <GuideModalIntro isOpen={isOpen} />}
+      {!guideLocalStorage && isOpen && <GuideModalIntro isOpen={isOpen} setIsOpen={setIsOpen} />}
     </div>
   );
 };

--- a/src/containers/help/modal-intro/index.tsx
+++ b/src/containers/help/modal-intro/index.tsx
@@ -1,4 +1,8 @@
-import { useState } from 'react';
+import { useLocalStorage } from 'usehooks-ts';
+
+import { activeGuideAtom } from 'store/guide';
+
+import { useRecoilValue } from 'recoil';
 
 import VideoIntro from 'containers/help/video-intro';
 
@@ -11,11 +15,21 @@ import {
   DialogTitle,
 } from 'components/ui/dialog';
 
-export const GuideModalIntro = ({ isOpen }) => {
-  const [showDialog, setShowDialog] = useState(!!isOpen);
+export const GuideModalIntro = ({ isOpen, setIsOpen }) => {
+  const [guideLocalStorage, setGuideLocalStorage] = useLocalStorage<boolean>(
+    'guideLocalStorage',
+    false,
+  );
+  const isActive = useRecoilValue(activeGuideAtom);
+
+  const handleClick = () => {
+    if (!guideLocalStorage) {
+      setGuideLocalStorage(true);
+    }
+  };
 
   return (
-    <Dialog open={showDialog}>
+    <Dialog open={isActive && isOpen}>
       <DialogContent className="z-50 space-y-6 p-8 text-black/85">
         <DialogHeader className="space-y-6">
           <DialogTitle className="text-3xl font-light">Navigation help</DialogTitle>
@@ -26,10 +40,10 @@ export const GuideModalIntro = ({ isOpen }) => {
         <div className="relative h-full min-h-[300px] w-full rounded-3xl">
           <VideoIntro />
         </div>
-        <Button onClick={() => setShowDialog(false)} className="text-sm font-bold">
-          Got it!
+        <Button onClick={handleClick} className="text-sm font-bold">
+          Got it! Don't show again
         </Button>
-        <DialogClose onClose={() => setShowDialog(false)} />
+        <DialogClose onClose={() => setIsOpen(false)} />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
This pull request refactors the logic for handling the guide modal in the `HelpContainer` and `GuideModalIntro` components to improve clarity and functionality. The changes streamline state management, ensure proper synchronization of modal visibility, and enhance user experience by modifying the "Don't show again" behavior.

### Refactoring of `HelpContainer`:

* Removed the `setGuideLocalStorage` call in `HelpContainer` and adjusted the `handleClick` logic to synchronize `isOpen` and `isActive` states, ensuring consistent behavior when toggling the guide modal. (`[src/containers/help/index.tsxL19-R28](diffhunk://#diff-96600aae4bcb94d95c8a38e8e01352a7d9a9505504f9a234b4081b9eb4f3d6d4L19-R28)`)
* Updated the conditional rendering of the `GuideModalIntro` component to include `setIsOpen` and ensure the modal only opens when appropriate conditions are met. (`[src/containers/help/index.tsxL67-R64](diffhunk://#diff-96600aae4bcb94d95c8a38e8e01352a7d9a9505504f9a234b4081b9eb4f3d6d4L67-R64)`)

### Updates to `GuideModalIntro`:

* Introduced `useLocalStorage` and `useRecoilValue` in `GuideModalIntro` to manage local storage and atom state directly, removing redundant state logic. (`[src/containers/help/modal-intro/index.tsxL1-R5](diffhunk://#diff-89723f6392052cde31660677519e2c8e01699e0e42fe333bb6e20b4372341c7aL1-R5)`)
* Enhanced the modal's "Got it!" button to update the local storage value and prevent the modal from reappearing unnecessarily. (`[[1]](diffhunk://#diff-89723f6392052cde31660677519e2c8e01699e0e42fe333bb6e20b4372341c7aL14-R32)`, `[[2]](diffhunk://#diff-89723f6392052cde31660677519e2c8e01699e0e42fe333bb6e20b4372341c7aL29-R46)`)