### PR TITLE
default-layers-order

### DIFF
--- a/src/containers/widgets/constants.ts
+++ b/src/containers/widgets/constants.ts
@@ -335,11 +335,12 @@ export const WIDGETS_BY_CATEGORY = [
 ];
 
 export const LAYERS_BY_CATEGORY: { [key: string]: string[] } = {
-  distribution_and_change: ['mangrove_habitat_extent', 'mangrove_net_change'],
+  distribution_and_change: ['mangrove_alerts', 'mangrove_net_change', 'mangrove_habitat_extent'],
   restoration_and_conservation: [
-    'mangrove_habitat_extent',
-    'mangrove_net_change',
+    'mangrove_rest_sites',
     'mangrove_alerts',
+    'mangrove_net_change',
+    'mangrove_habitat_extent',
   ],
   climate_and_policy: ['mangrove_blue_carbon'],
   ecosystem_services: ['mangrove_biomass', 'mangrove_height', 'mangrove_blue_carbon'],


### PR DESCRIPTION
This pull request updates the `LAYERS_BY_CATEGORY` constant in `src/containers/widgets/constants.ts` to reorganize and expand the layer assignments for different categories. The changes aim to improve the logical grouping of layers.

Key changes to `LAYERS_BY_CATEGORY`:

* Added `mangrove_alerts` to the `distribution_and_change` category and reordered the layers for better organization.
* Introduced `mangrove_rest_sites` to the `restoration_and_conservation` category and reordered the layers for consistency.
