### PR TITLE
pop up clusters fix

### DIFF
--- a/src/containers/datasets/restoration-sites/map-pop-up/collapsible-item.tsx
+++ b/src/containers/datasets/restoration-sites/map-pop-up/collapsible-item.tsx
@@ -19,6 +19,7 @@ const PopupRestorationSitesCollapsibleItem = ({
       label: `restoration sites pop up - expand/collapse`,
     });
   };
+
   return (
     <Collapsible onOpenChange={handleAnalytics} defaultOpen>
       <CollapsibleTrigger

--- a/src/containers/datasets/restoration-sites/map-pop-up/index.tsx
+++ b/src/containers/datasets/restoration-sites/map-pop-up/index.tsx
@@ -24,7 +24,7 @@ const PopupRestorationSites = ({ info }: { info: RestorationSitesPopUp }) => {
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="flex w-full flex-col space-y-2 border-none px-6 pb-6 font-sans shadow-none">
-          {info.cluster && (
+          {info.point_count && (
             <p className="text-sm text-black/85">
               <span>
                 There are <strong>{info.point_count}</strong> restoration sites in this location.{' '}

--- a/src/containers/datasets/restoration-sites/widget.tsx
+++ b/src/containers/datasets/restoration-sites/widget.tsx
@@ -74,7 +74,7 @@ const RestorationSitesWidget = () => {
             <p className={WIDGET_SENTENCE_STYLE}>
               There are <span className="font-bold">{data.data?.length}</span> restoration sites in{' '}
               {data.location}
-              {!areFiltersEmpty && ' that match your criteria'}.
+              {!areFiltersEmpty && ' that match your criteria'}.<sup>*</sup>
             </p>
           )}
           {data.data?.length === 0 && (
@@ -132,6 +132,18 @@ const RestorationSitesWidget = () => {
               filtersSelected={filtersSelected}
             />
           )}
+          <div className="text-sm">
+            <sup>*</sup>As entered into the Mangrove Restoration Tracker Tool. Enter your data{' '}
+            <a
+              href="https://mrtt.globalmangrovewatch.org/auth/login"
+              rel="noopener noreferrer"
+              target="_blank"
+              className="font-semibold text-brand-800 underline"
+            >
+              here
+            </a>
+            .
+          </div>
         </div>
       )}
     </div>

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -322,21 +322,22 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
     if (!restorationFeature) {
       removePopup('restoration');
     }
-
     // Restoration Sites
     if (restorationSitesFeature) {
-      const infoParsed = Object.entries(LABELS).reduce((acc, [key, label]) => {
-        const value = restorationSitesFeature.properties[key];
+      const infoParsed = restorationSitesFeature?.properties.cluster
+        ? { point_count: restorationSitesFeature?.properties.point_count }
+        : Object.entries(LABELS).reduce((acc, [key, label]) => {
+            const value = restorationSitesFeature.properties[key];
 
-        if (key === 'landscape_name' || key === 'site_name') {
-          acc[label] = [value];
-        } else {
-          const parsed = value ? JSON.parse(value) : null;
-          acc[label] = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
-        }
+            if (key === 'landscape_name' || key === 'site_name') {
+              acc[label] = [value];
+            } else {
+              const parsed = value ? JSON.parse(value) : null;
+              acc[label] = Array.isArray(parsed) ? parsed : parsed ? [parsed] : [];
+            }
 
-        return acc;
-      }, {});
+            return acc;
+          }, {});
 
       setRestorationSitesPopUp({
         ...restorationSitesPopUp,


### PR DESCRIPTION
This pull request updates the restoration sites map pop-up and widget to improve how cluster information is displayed and clarifies the data source for restoration site counts. The main changes focus on ensuring that the correct property (`point_count`) is used to indicate the number of restoration sites in a cluster and providing users with transparency about the data source.

**Cluster information handling:**
* Updated the logic in `MapContainer` to pass only the `point_count` property (instead of the entire cluster object) when the map feature represents a cluster of restoration sites.
* Modified `PopupRestorationSites` to display the cluster message based on the presence of `point_count` rather than a generic `cluster` property.

**Widget improvements and data transparency:**
* Added a superscript asterisk to the widget's sentence when filters are applied, indicating additional information is available.
* Added a footnote to the widget explaining that restoration site data is sourced from the Mangrove Restoration Tracker Tool, including a link for users to enter their own data.

**Analytics and UI:**
* Minor update to the pop-up collapsible item to ensure analytics tracking remains consistent with UI changes.