### PR TITLE
node update, offset to popup

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -51,7 +51,7 @@ export default defineConfig([
       ],
 
       'unused-imports/no-unused-vars': [
-        'warn',
+        'error',
         {
           vars: 'all',
           varsIgnorePattern: '^_',

--- a/src/components/draggable/index.tsx
+++ b/src/components/draggable/index.tsx
@@ -4,21 +4,24 @@ type DraggableProps = {
   id: string;
   position: { x: number; y: number };
   isPinned?: boolean;
+  yOffset?: number;
   children: (params: {
     listeners: ReturnType<typeof useDraggable>['listeners'];
     attributes: ReturnType<typeof useDraggable>['attributes'];
   }) => React.ReactNode;
 };
 
-export default function Draggable({ id, position, children, isPinned }: DraggableProps) {
+export default function Draggable({ id, position, children, yOffset = 50 }: DraggableProps) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({ id });
 
   if (!position) return null;
 
+  const top = Math.max(0, position.y - yOffset);
+
   const style: React.CSSProperties = {
     position: 'absolute',
     left: position.x,
-    top: position.y,
+    top,
     transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
     transition: 'transform 0.1s ease-out',
     zIndex: 10000,

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -22,7 +22,7 @@ const LayerManagerContainer = () => {
 
   const [, setInteractiveLayerIds] = useRecoilState(interactiveLayerIdsAtom);
 
-  const activeLayersIds = layers?.map((l) => l.id);
+  const activeLayersIds = useMemo(() => layers?.map((l) => l?.id), [layers]);
 
   const ACTIVE_LAYERS = useMemo(() => {
     const filteredLayers = activeLayersIds?.filter(

--- a/src/containers/map/pop-up/index.tsx
+++ b/src/containers/map/pop-up/index.tsx
@@ -28,7 +28,6 @@ import type { LocationPopUp, RestorationPopUp, RestorationSitesPopUp } from 'typ
 import MapPopupDragHandler from './pop-up-controls/drag';
 import MapPopupClose from './pop-up-controls/close';
 import MapPopupPin from './pop-up-controls/pin';
-import { set } from 'date-fns';
 
 type Position = { x: number; y: number };
 
@@ -133,7 +132,7 @@ const MapPopup = ({
           </div>
 
           {/* Pop-up content */}
-          <ScrollArea className="relative -mb-8 grow overflow-y-auto overflow-x-hidden">
+          <ScrollArea className="relative grow overflow-y-auto overflow-x-hidden">
             {/* Gradients */}
             <div className="pointer-events-none absolute top-0 left-0 right-0 z-10 h-8 bg-gradient-to-b from-white to-transparent" />
             <div className="pointer-events-none absolute bottom-0 left-6 right-6 z-10 h-8 bg-gradient-to-t from-white to-transparent" />

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -44,7 +44,7 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
     },
   };
 
-  if (Boolean(children.type() === null)) return null;
+  if (Boolean(children?.type() === null)) return null;
 
   const isCollapsed: boolean =
     isDrawingToolEnabled || isDrawingUploadToolEnabled ? false : widgetsCollapsed[id];


### PR DESCRIPTION
This pull request introduces several improvements and minor fixes across the codebase, mainly focusing on stricter linting, enhanced draggable component flexibility, performance optimizations, and UI refinements. The most notable changes include upgrading the unused variable lint rule to an error, making the `Draggable` component more configurable, and optimizing layer ID calculations with `useMemo`.

**Linting and Code Quality:**
* Changed the ESLint rule `'unused-imports/no-unused-vars'` from a warning to an error, enforcing stricter code hygiene for unused variables.

**Component Enhancements:**
* Added a `yOffset` prop to the `Draggable` component (defaulting to 50) to allow vertical offset customization, and updated the calculation of the `top` style property accordingly.

**Performance Optimizations:**
* Memoized the calculation of `activeLayersIds` in the `LayerManagerContainer` using `useMemo` to avoid unnecessary recalculations when `layers` changes.

**UI and Usability Fixes:**
* Removed an unused import of `set` from `date-fns` in the map pop-up container, cleaning up the code.
* Fixed the check for `children.type()` in the `WidgetWrapper` to handle cases where `children` might be undefined.
* Removed the negative bottom margin class from the `ScrollArea` in the pop-up component for improved layout.