### PR TITLE
highlight removed when clicking outside

### DIFF
--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -377,6 +377,11 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
       }
     }
     if (!restorationFeature) {
+      map?.removeFeatureState({
+        sourceLayer: 'MOW_Global_Mangrove_Restoration_202212',
+        source: 'mangrove_restoration',
+        id: clickedStateIdRef.current,
+      });
       removePopup('restoration');
     }
     // Restoration Sites
@@ -469,6 +474,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
         );
         hoveredStateId = null;
       }
+
       if (isDrawingToolEnabled && !customGeojson) {
         setCursor('cell');
       } else if (interactiveLayers || restorationData) {


### PR DESCRIPTION
This pull request makes a minor update to the map interaction logic in `src/containers/map/index.tsx`. The main change ensures that the feature state for mangrove restoration is properly removed when the restoration feature is not present, improving the reliability of map state management.

Map interaction improvements:

* Added logic to remove the feature state for mangrove restoration when `restorationFeature` is not present, preventing stale state issues.
* Minor code formatting adjustment after resetting `hoveredStateId` to improve readability.
