### PR TITLE
fix planet info popup

### DIFF
--- a/src/containers/datasets/index.tsx
+++ b/src/containers/datasets/index.tsx
@@ -246,6 +246,8 @@ export const INFO = {
   mangrove_species_location: SpeciesLocationInfo,
   mangrove_salt_marsh: SaltMarshInfo,
   mangrove_contextual_layers: PlanetSatelliteBasemapInfo,
+  planet_medres_visual_monthly: PlanetSatelliteBasemapInfo,
+  planet_medres_analytic_monthly: PlanetSatelliteBasemapInfo,
   mangrove_commercial_fisheries_production: CommercialFisheriesProductionInfo,
 };
 


### PR DESCRIPTION
This pull request adds support for two new Planet satellite basemap datasets to the `INFO` export in `src/containers/datasets/index.tsx`. These additions will allow the application to recognize and display information for the new monthly visual and analytic medium-resolution basemaps.

Dataset additions:

* Added `planet_medres_visual_monthly` and `planet_medres_analytic_monthly` to the `INFO` export, both using the `PlanetSatelliteBasemapInfo` configuration.
