### PR TITLE
finfish layer

### DIFF
--- a/src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx
@@ -165,7 +165,7 @@ export function useLayers({
   visibility?: Visibility;
   indicator?: Data['indicator'];
 }): LayerProps[] {
-  const Indicator = indicator?.charAt(0).toUpperCase() + indicator?.slice(1) || 'Fish';
+  const Indicator = indicator?.charAt(0).toUpperCase() + indicator?.slice(1) || 'Finfish';
 
   const COLOR = useMemo(() => {
     return COLORS[indicator] || COLORS.finfish || '#8800FF';
@@ -179,7 +179,7 @@ export function useLayers({
       source: 'mangrove_commercial_fisheries_production',
       'source-layer': 'all_sp_fit_fn_totals',
       type: 'line',
-      filter: ['>', ['get', Indicator], 0],
+      ...(Indicator !== 'Finfish' ? { filter: ['>', ['get', Indicator], 0] } : {}),
       minzoom: 0,
       paint: {
         'line-color': COLOR as mapboxgl.StyleFunction,

--- a/src/containers/datasets/fisheries/commercial-fisheries-production/map-legend.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/map-legend.tsx
@@ -58,7 +58,9 @@ const CommercialFisheriesProductionMapLegend = () => {
       {commercialFisheriesProductionFilter && (
         <p>Commercial {commercialFisheriesProductionFilter} productivity (per 100 m2) </p>
       )}
+
       {LEGEND_RANGES[commercialFisheriesProductionFilter] &&
+        commercialFisheriesProductionFilter !== 'finfish' &&
         LEGEND_RANGES[commercialFisheriesProductionFilter].map(({ color, range }, index) => (
           <div key={index} className="flex items-center space-x-2">
             <div className="h-2 w-2" style={{ backgroundColor: color }} />
@@ -67,7 +69,8 @@ const CommercialFisheriesProductionMapLegend = () => {
           </div>
         ))}
 
-      {!commercialFisheriesProductionFilter &&
+      {(!commercialFisheriesProductionFilter ||
+        commercialFisheriesProductionFilter === 'finfish') &&
         LEGEND_RANGES['finfish'].map(({ color, range }, index) => (
           <div key={index} className="flex items-center space-x-2">
             <div className="h-2 w-2" style={{ backgroundColor: color }} />

--- a/src/store/layers/index.ts
+++ b/src/store/layers/index.ts
@@ -24,7 +24,7 @@ const layerSchema = object({
   }),
   filter: optional(
     stringLiterals({
-      fish: 'fish',
+      finfish: 'finfish',
       shrimp: 'shrimp',
       crab: 'crab',
       bivalve: 'bivalve',


### PR DESCRIPTION
This pull request updates the terminology and logic for commercial fisheries production layers and legends to consistently use `finfish` instead of `fish`. It also adjusts layer filtering and legend display logic to handle the new indicator, improving clarity and consistency across the UI.

**Terminology update:**

* Changed all references of the indicator from `fish` to `finfish` in the layer schema (`src/store/layers/index.ts`).
* Updated the default indicator value in the `useLayers` hook from `'Fish'` to `'Finfish'` (`src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx`).

**Layer filtering logic:**

* Modified the layer filter so that it only applies when the indicator is not `Finfish`, preventing unnecessary filtering for the default case (`src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx`).

**Legend display logic:**

* Updated the map legend to exclude the `finfish` legend when another filter is selected, and to show the `finfish` legend when no filter or the `finfish` filter is selected (`src/containers/datasets/fisheries/commercial-fisheries-production/map-legend.tsx`). [[1]](diffhunk://#diff-5be3a5c35542fd864ab0a91bcdb5c2b3e653912474465f54f2d9adfa46ac37c1R61-R63) [[2]](diffhunk://#diff-5be3a5c35542fd864ab0a91bcdb5c2b3e653912474465f54f2d9adfa46ac37c1L70-R73)