### PR TITLE
fill layer fisheries

### DIFF
--- a/src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/hooks.tsx
@@ -195,7 +195,7 @@ export function useLayers({
       source: 'mangrove_commercial_fisheries_production',
       'source-layer': 'all_sp_fit_fn_totals',
       type: 'fill',
-      filter: ['>', ['get', Indicator], 0],
+      ...(Indicator !== 'Finfish' ? { filter: ['>', ['get', Indicator], 0] } : {}),
       minzoom: 0,
       paint: {
         'fill-color': COLOR as mapboxgl.StyleFunction,


### PR DESCRIPTION
This pull request introduces a small change to the `useLayers` hook in the commercial fisheries production container. The update improves how the map layer filter is applied based on the selected `Indicator`, ensuring that the filter is only set for indicators other than 'Finfish'.
