### PR TITLE
fisheries info

### DIFF
--- a/src/containers/datasets/fisheries/commercial-fisheries-production/info.mdx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/info.mdx
@@ -4,7 +4,11 @@ import LayoutMdx from 'layouts/mdx';
 
 ## Overview:
 
-This map displays the modelled density of commercially important prawn species due to the presence of mangrove ecosystems. The model was fit using expert-identified drivers of mangrove fish and invertebrate density and data from published field studies from around the world. Mangrove area, sea surface salinity, sea surface temperature, tidal amplitude, mangrove edge, change in extent, net primary productivity, sampling method, and mangrove geomorphic type were identified as key variables determining density. A model was created for three species of prawn determined to be both mangrove-affiliated and commercially important. Estimates of density are displayed in units of individuals per 100m2 (10m x 10m) and refer to juvenile and resident prawn. Predictions are only available for the Indian Ocean, Red Sea, and Western Pacific due to a lack of field data from other regions.
+This map displays the modelled density of commercially important prawn species due to the presence of mangrove ecosystems.
+
+The model was fit using expert-identified drivers of mangrove fish and invertebrate density and data from published field studies from around the world. Mangrove area, sea surface salinity, sea surface temperature, tidal amplitude, mangrove edge, change in extent, net primary productivity, sampling method, and mangrove geomorphic type were identified as key variables determining density.
+
+A model was created for three species of prawn determined to be both mangrove-affiliated and commercially important. Estimates of density are displayed in units of individuals per 100 m² (10 m × 10 m) and refer to juvenile and resident prawn. Predictions are only available for the Indian Ocean, Red Sea, and Western Pacific due to a lack of field data from other regions.
 
 ## Reference:
 

--- a/src/containers/datasets/fisheries/commercial-fisheries-production/map-legend.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/map-legend.tsx
@@ -55,10 +55,10 @@ const CommercialFisheriesProductionMapLegend = () => {
 
   return (
     <div className="flex flex-col space-y-2 font-sans text-sm text-black/60">
-      {commercialFisheriesProductionFilter && (
-        <p>Commercial {commercialFisheriesProductionFilter} productivity (per 100 m2) </p>
-      )}
-
+      <p>
+        Commercial {commercialFisheriesProductionFilter || 'finfish'} productivity (per 100 m
+        <sup>2</sup>){' '}
+      </p>
       {LEGEND_RANGES[commercialFisheriesProductionFilter] &&
         commercialFisheriesProductionFilter !== 'finfish' &&
         LEGEND_RANGES[commercialFisheriesProductionFilter].map(({ color, range }, index) => (

--- a/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
@@ -155,7 +155,7 @@ const CommercialFisheriesProduction = () => {
             </SelectContent>
           </Select>{' '}
           by an average of <span className="font-bold">{averageValueByIndicator}</span>{' '}
-          individuals/100m<sup>2</sup> (10mx10m).
+          <span className="whitespace-nowrap">individuals / 100 m² (10 m × 10 m).</span>
         </p>
 
         <Loading visible={isFetching && !isFetched} iconClassName="flex w-10 h-10 m-auto my-10" />


### PR DESCRIPTION
This pull request makes several improvements to the presentation and clarity of units and descriptions in the commercial fisheries production dataset components. The changes ensure consistent formatting of units (using "100 m²" and "10 m × 10 m"), clarify default filter behavior, and improve the readability of the overview section.

Improvements to unit formatting and clarity:

* Updated all references to density units from "100m2" or "100 m2" to "100 m² (10 m × 10 m)" for clarity and consistency across the overview, map legend, and widget components. [[1]](diffhunk://#diff-375879b1f5643c9cfa0451ffa4f30babfa0a8badba5bf89d9ce49d8c9296ecb3L7-R11) [[2]](diffhunk://#diff-5be3a5c35542fd864ab0a91bcdb5c2b3e653912474465f54f2d9adfa46ac37c1L58-R61) [[3]](diffhunk://#diff-c07a90d1c4519bbf083f459b90f4c4bdc2caa224d90a932336ae43c70b3296cbL158-R158)

User interface and display improvements:

* Changed the map legend to always display the filter label, defaulting to "finfish" if no filter is selected, improving user understanding of the displayed data.
* Improved the overview section in the `info.mdx` file by splitting long paragraphs for better readability and updating unit formatting.
* Ensured consistent use of non-breaking spaces and typographic symbols in the widget display for improved appearance and clarity.
