### PR TITLE
fisheries dev

### DIFF
--- a/src/containers/datasets/fisheries/index.tsx
+++ b/src/containers/datasets/fisheries/index.tsx
@@ -8,7 +8,7 @@ const FisheriesWrapper = () => {
   return (
     <div className={cn(WIDGET_CARD_WRAPPER_STYLE, 'space-y-4')}>
       <Fisheries />
-      {process.env.NEXT_PUBLIC_FEATURE_FLAG_WIDGETS && (
+      {process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' && (
         <>
           <div className="absolute left-4 right-4 my-4 h-0.5 bg-brand-800/30" />
           <CommercialFisheriesProduction />


### PR DESCRIPTION
This pull request updates the logic for displaying the `CommercialFisheriesProduction` widget in the `FisheriesWrapper` component. Now, the widget will only be shown in the development environment, instead of being controlled by a feature flag.

Display logic update:

* Changed the condition to render the `CommercialFisheriesProduction` widget from checking the `NEXT_PUBLIC_FEATURE_FLAG_WIDGETS` environment variable to only rendering when `NEXT_PUBLIC_VERCEL_ENV` is set to `'development'` in `src/containers/datasets/fisheries/index.tsx`.
