### PR TITLE
fisheries raster layer

### DIFF
--- a/src/containers/datasets/fisheries/commercial-fisheries-production/layer.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/layer.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue } from 'recoil';
 
 import type { LayerProps } from 'types/layers';
 
-import { useLayers, useSource } from './hooks';
+import { useLayer, useSource } from './hooks';
 import { useRouter } from 'next/router';
 
 const MangrovesCommercialFisheriesProductionLayer = ({
@@ -29,20 +29,18 @@ const MangrovesCommercialFisheriesProductionLayer = ({
     return activeLayer?.filter;
   }, [query.layers, activeLayer, id]);
 
-  const SOURCE = useSource();
-  const LAYERS = useLayers({
-    id,
+  const SOURCE = useSource({ filter });
+  const LAYERS = useLayer({
+    id: `${id}-${filter || 'finfish'}`,
     opacity: parseFloat(activeLayer.opacity),
     visibility: activeLayer.visibility,
-    indicator: filter,
   });
 
   if (!SOURCE || !LAYERS) return null;
+
   return (
-    <Source {...SOURCE}>
-      {LAYERS.map((LAYER) => (
-        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
-      ))}
+    <Source key={`${SOURCE.id}-${SOURCE.tiles?.[0] ?? ''}`} {...SOURCE}>
+      <Layer {...LAYERS} beforeId={beforeId} />
     </Source>
   );
 };


### PR DESCRIPTION
This pull request refactors the commercial fisheries production map layer to use raster tiles instead of vector layers, simplifying the code and improving performance. The main changes include removing complex color interpolation logic, updating hooks to return raster sources and layers, and adjusting the component to render a single raster layer per filter.

**Refactor to raster tile approach:**

* Replaced vector source and multiple vector layers with a single raster source and raster layer in `useSource` and `useLayer` hooks, removing the need for color interpolation and filtering logic. [[1]](diffhunk://#diff-869e9b64f8da642d97707c3c05486ca9ad902dbb6e1635f3667c95fa520bfaccL1-R1) [[2]](diffhunk://#diff-869e9b64f8da642d97707c3c05486ca9ad902dbb6e1635f3667c95fa520bfaccL149-R109)
* Updated `MangrovesCommercialFisheriesProductionLayer` to use the new raster-based hooks and render a single `Layer` instead of mapping over multiple layers. [[1]](diffhunk://#diff-2e8f50791a1f89740f01d045ec1adbb853bf4196925fe97a0407a02d0e3d44f8L10-R10) [[2]](diffhunk://#diff-2e8f50791a1f89740f01d045ec1adbb853bf4196925fe97a0407a02d0e3d44f8L32-R43)

**Code simplification and cleanup:**

* Removed the `COLORS` constant and related color interpolation logic, as it's no longer needed with raster tiles.
* Cleaned up unused imports and unnecessary props in hooks and component. [[1]](diffhunk://#diff-869e9b64f8da642d97707c3c05486ca9ad902dbb6e1635f3667c95fa520bfaccL1-R1) [[2]](diffhunk://#diff-869e9b64f8da642d97707c3c05486ca9ad902dbb6e1635f3667c95fa520bfaccL16-L99) [[3]](diffhunk://#diff-2e8f50791a1f89740f01d045ec1adbb853bf4196925fe97a0407a02d0e3d44f8L10-R10)
