### PR TITLE
hardcoded layers removed

### DIFF
--- a/src/containers/datasets/national-dashboard/constants.ts
+++ b/src/containers/datasets/national-dashboard/constants.ts
@@ -1,10 +1,1 @@
 export const COLORS = ['#ECDA9A', '#00C5BD', '#FFADAD'];
-
-export const DATA_SOURCES = {
-  'globalmangrovewatch.atkcyrph': 'AUS_mangrove_cover_2022',
-  'globalmangrovewatch.3nw6ym2a': 'MangroveExtent2020KenyaFinalQAv2',
-  'globalmangrovewatch.35tuojsj': 'MangroveExtent2020MozambiqueFinalQAv2',
-  'globalmangrovewatch.dk6v2gg1': 'car_mangroves',
-  'globalmangrovewatch.2took1l0': 'MangroveExtent2020TanzaniaFinalQAv2',
-  'globalmangrovewatch.4ifqc3wd': 'MangroveExtent2020MadagascarFinalQAv3',
-};

--- a/src/containers/datasets/national-dashboard/indicator-sources/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-sources/index.tsx
@@ -10,8 +10,6 @@ import { SwitchRoot, SwitchThumb, SwitchWrapper } from 'components/ui/switch';
 import WidgetControls from 'components/widget-controls';
 import type { ActiveLayers } from 'types/layers';
 
-import { DATA_SOURCES } from '../constants';
-
 import IndicatorExtent from './extent';
 import IndicatorSource from './source';
 import type { IndicatorSourcesTypes } from './types';
@@ -52,7 +50,7 @@ const IndicatorSources = ({
             location: locationIso,
             layerIndex,
             source: dataSource.layer_link,
-            source_layer: dataSource.source_layer || DATA_SOURCES[dataSource.layer_link],
+            source_layer: dataSource.source_layer,
           },
         },
         activeLayers
@@ -75,7 +73,7 @@ const IndicatorSources = ({
               location: locationIso,
               layerIndex,
               source: dataSource.layer_link,
-              source_layer: dataSource.source_layer || DATA_SOURCES[dataSource.layer_link],
+              source_layer: dataSource.source_layer,
             },
           },
         ] as ActiveLayers[]);

--- a/src/containers/datasets/species-threatened/hooks.tsx
+++ b/src/containers/datasets/species-threatened/hooks.tsx
@@ -108,7 +108,7 @@ export function useMangroveSpeciesThreatened(
     const { categories, total, species, threatened } = speciesData;
 
     const threatenedLegend: number | string = getThreatened(threatened, total);
-    const speciesByGroup = groupBy(species, (s) => s.red_list_cat);
+    const speciesByGroup = groupBy(species, (s) => s?.red_list_cat);
 
     const chartData = Object.entries(categories)?.map((item) => ({
       value: item[1],

--- a/src/containers/layers/constants.tsx
+++ b/src/containers/layers/constants.tsx
@@ -78,15 +78,6 @@ export const LAYERS = [
     id: 'custom-area',
   },
   {
-    name: 'Digital Earth Australia',
-    id: 'national_dashboard_source_AUS_mangrove_cover_2022',
-  },
-  {
-    name: 'Save Our Mangroves Now project',
-    id: 'national_dashboard_source_MangroveExtent2020MozambiqueFinalQAv2',
-  },
-
-  {
     name: 'Allen coral atlas',
     id: 'mangrove_allen_coral_reef',
   },


### PR DESCRIPTION
This pull request primarily removes the `DATA_SOURCES` mapping and its usage from the national dashboard indicator sources, simplifying how source layers are determined. It also includes a small fix to prevent errors when grouping species by their red list category, and removes some unused layer definitions.

Key changes include:

**National Dashboard Data Source Simplification:**
* Removed the `DATA_SOURCES` mapping from `constants.ts` and updated all references to use `dataSource.source_layer` directly, reducing indirection and potential for mismatches. (`src/containers/datasets/national-dashboard/constants.ts` [[1]](diffhunk://#diff-54645c5eda22f5f479982cd1d894344986d19b10fd13a2b6ef5a908adec2c058L2-L10) `src/containers/datasets/national-dashboard/indicator-sources/index.tsx` [[2]](diffhunk://#diff-dd6cf30da251756d206681946a1ba9c9a27f5e7fc7e382c4b4445fe2a529d624L13-L14) [[3]](diffhunk://#diff-dd6cf30da251756d206681946a1ba9c9a27f5e7fc7e382c4b4445fe2a529d624L55-R53) [[4]](diffhunk://#diff-dd6cf30da251756d206681946a1ba9c9a27f5e7fc7e382c4b4445fe2a529d624L78-R76)

**Layers Cleanup:**
* Removed unused layer definitions related to national dashboard sources from the `LAYERS` array, keeping only relevant layers. (`src/containers/layers/constants.tsx` [src/containers/layers/constants.tsxL80-L88](diffhunk://#diff-bb53d3606301f9ab29c31cdda5b9f63b0bd1588c1f384d51937252096c82beabL80-L88))

**Bug Fixes:**
* Updated the grouping function in the species threatened hook to safely access the `red_list_cat` property, preventing errors if the property is missing. (`src/containers/datasets/species-threatened/hooks.tsx` [src/containers/datasets/species-threatened/hooks.tsxL111-R111](diffhunk://#diff-d93abb300cfbcef88e20d0aeedc683bcebae8c5f8495f1910aa98e12f3e23075L111-R111))
