### PR TITLE
alerts new layer

### DIFF
--- a/cloud-functions/fetch-alerts-heatmap/index.js
+++ b/cloud-functions/fetch-alerts-heatmap/index.js
@@ -62,7 +62,7 @@ const alertsJob = async (
   // First try to get data from cache in order to reduce costs
   const cacheKey = `_${startDate}_${endDate}`;
   if (cache[cacheKey]) {
-    console.log(`Rensponse from cache ${cacheKey}`);
+    console.log(`Response from cache ${cacheKey}`);
     return cache[cacheKey];
   }
   const options = {
@@ -73,7 +73,7 @@ const alertsJob = async (
 
   // Run the query as a job
   const [job] = await bigquery.createQueryJob(options);
-  console.log(`Job ${job.id} started.`);
+  console.info(`Job ${job.id} started.`);
 
   // Wait for the query to finish
   const [rows] = await job.getQueryResults();


### PR DESCRIPTION
This pull request updates how alert heatmap data is sourced and visualized in the application, moving from a GeoJSON/tiles-based approach to using a Mapbox vector source and improving the heatmap rendering logic. It also makes minor improvements to logging in the cloud function.

**Alert heatmap data source and visualization updates:**

* Replaces the previous GeoJSON (`alerts-heatmap`) and tile source (`alerts-tiles`) with a single Mapbox vector source (`alerts-heatmap-vector`) in `useSources` and updates the corresponding layer configuration in `useLayers`. This streamlines data loading and leverages vector data for more efficient map rendering. [[1]](diffhunk://#diff-2e7a0465ecd5c1dbe42b1bd6ed2a2ffb34099bbe7159061b0ab9daba9b096b4dL375-R377) [[2]](diffhunk://#diff-2e7a0465ecd5c1dbe42b1bd6ed2a2ffb34099bbe7159061b0ab9daba9b096b4dL404-R447)
* Refactors the heatmap layer to use the new vector source, adjusts the heatmap's weight to interpolate based on the `months_diff` property (making recent alerts more prominent), and tweaks the color ramp, radius, and opacity for better visual clarity.

**Code cleanup and logging improvements:**

* Fixes a typo in a log message from "Rensponse" to "Response" and changes a console log to `console.info` for better log level usage in the `fetch-alerts-heatmap` cloud function. [[1]](diffhunk://#diff-09dae4570f62e96fd4074e9a01a64bf7238dd7aaadde3d397e107e2528238a40L65-R65) [[2]](diffhunk://#diff-09dae4570f62e96fd4074e9a01a64bf7238dd7aaadde3d397e107e2528238a40L76-R76)