### PR TITLE
monitores areas layer removed

### DIFF
--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -367,11 +367,6 @@ export function useSources(): SourceProps[] {
 
   return [
     {
-      id: 'monitored-alerts',
-      type: 'vector',
-      url: 'mapbox://globalmangrovewatch.c5dgz6m3',
-    },
-    {
       id: 'alerts-heatmap-vector',
       type: 'vector',
       url: 'mapbox://globalmangrovewatch.bkhacq4t',
@@ -389,7 +384,6 @@ export function useLayers({
   visibility?: Visibility;
 }): {
   'alerts-heatmap-vector': LayerProps[];
-  'monitored-alerts': LayerProps[];
 } {
   return {
     'alerts-heatmap-vector': [
@@ -445,23 +439,6 @@ export function useLayers({
         },
 
         layout: { visibility },
-      },
-    ],
-    'monitored-alerts': [
-      {
-        id: `${id}-line`,
-        type: 'line',
-        source: 'monitored-alerts',
-        'source-layer': 'alert_region_tiles',
-        minzoom: 0,
-        paint: {
-          'line-color': '#00857F',
-          'line-opacity': opacity,
-          'line-width': 1,
-        },
-        layout: {
-          visibility,
-        },
       },
     ],
   };

--- a/src/containers/datasets/alerts/map-legend.tsx
+++ b/src/containers/datasets/alerts/map-legend.tsx
@@ -10,16 +10,6 @@ const AlertsMapLegend = () => {
         />
         <p>Alerts</p>
       </div>
-      <div className="flex space-x-2">
-        <div className="flex">
-          <div className="flex flex-col">
-            <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-            <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-          </div>
-          <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-        </div>
-        <p className="text-sm font-normal">Monitored area</p>
-      </div>
     </div>
   );
 };

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -233,16 +233,6 @@ const AlertsWidget = () => {
             <p className="items-center pt-6 font-sans text-lg font-light leading-7">
               There are <span className="font-bold"> 535</span> areas monitored in the world.
             </p>
-            <div className="flex space-x-2">
-              <div className="flex">
-                <div className="flex flex-col">
-                  <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-                  <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-                </div>
-                <div className="text-brand-900 h-2 w-2 border-2 border-brand-800" />
-              </div>
-              <p className="text-sm font-normal">Monitored area</p>
-            </div>
           </div>
           <div>
             <SuggestedLayers


### PR DESCRIPTION
This pull request removes the "Monitored Alerts" vector layer and its associated legend and widget UI elements from the alerts dataset. The changes simplify the code by eliminating support for this layer both in the data hooks and in the user interface.

**Removal of "Monitored Alerts" layer and related UI:**

* Removed the `'monitored-alerts'` vector source from the `useSources` hook, so it is no longer available as a data source.
* Removed the `'monitored-alerts'` layer configuration from the `useLayers` hook, including its style and visibility logic. [[1]](diffhunk://#diff-2e7a0465ecd5c1dbe42b1bd6ed2a2ffb34099bbe7159061b0ab9daba9b096b4dL392) [[2]](diffhunk://#diff-2e7a0465ecd5c1dbe42b1bd6ed2a2ffb34099bbe7159061b0ab9daba9b096b4dL450-L466)

**UI cleanup for "Monitored Alerts":**

* Removed the "Monitored area" legend entry from the `AlertsMapLegend` component, so it no longer appears in the map legend.
* Removed the "Monitored area" visual indicator from the `AlertsWidget` component, cleaning up the widget's display.
