### PR TITLE
map tip moved to top widget

### DIFF
--- a/src/components/contextual-layers/index.tsx
+++ b/src/components/contextual-layers/index.tsx
@@ -24,7 +24,7 @@ const ContextualLayersComponent = ({
   name,
 }: ContextualLayersComponentProps) => {
   return (
-    <div className="relative flex flex-col space-y-5 rounded-b-3xl bg-brand-800/10 p-3">
+    <div className="relative flex flex-col space-y-5 rounded-3xl bg-brand-800/10 p-3">
       <div className="flex items-center justify-between space-x-8">
         <div className="flex items-center">
           <div className="flex items-center space-x-4">

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -13,7 +13,7 @@ import NoData from 'containers/widgets/no-data';
 
 import Chart from 'components/chart';
 import DateSelect from 'components/planet-date-select';
-import ContextualLayers from 'components/contextual-layers';
+import ContextualLayersWrapper from 'containers/widget/contextual-layers';
 import Icon from 'components/ui/icon';
 import Loading from 'components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from 'components/ui/popover';
@@ -22,6 +22,8 @@ import {
   WIDGET_SELECT_STYLES,
   WIDGET_SENTENCE_STYLE,
 } from 'styles/widgets';
+
+import { widgets } from 'containers/widgets/constants';
 
 import ARROW_SVG from 'svgs/ui/arrow.svg?sprite';
 
@@ -44,6 +46,12 @@ const AlertsWidget = () => {
     () => activeLayers?.find(({ id }) => id === 'planet_medres_visual_monthly'),
     [activeLayers]
   );
+
+  const widgetInfo = useMemo(
+    () => widgets.find((widget) => widget.slug === 'mangrove_alerts'),
+    [widgets]
+  );
+  const contextualLayers = useMemo(() => widgetInfo?.contextualLayers || [], [widgetInfo]);
 
   const { data, isLoading, isFetched, isError, isPlaceholderData, refetch } = useAlerts(
     startDate,
@@ -192,6 +200,14 @@ const AlertsWidget = () => {
             </Popover>
             .
           </p>
+          <div className="-mx-2">
+            <ContextualLayersWrapper
+              origin="mangrove_alerts"
+              id={contextualLayers[0].id}
+              description={contextualLayers[0].description}
+            />
+          </div>
+
           <Legend />
           <Chart config={config} />
           <Chart

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import cn from 'lib/classnames';
 
@@ -25,6 +25,9 @@ import ARROW_SVG from 'svgs/ui/arrow-filled.svg?sprite';
 import HabitatExtentChart from './chart';
 import { useMangroveHabitatExtent, widgetSlug } from './hooks';
 import { trackEvent } from 'lib/analytics/ga';
+import ContextualLayersWrapper from 'containers/widget/contextual-layers';
+
+import { widgets } from 'containers/widgets/constants';
 
 const HabitatExtent = () => {
   const queryClient = useQueryClient();
@@ -76,6 +79,14 @@ const HabitatExtent = () => {
     },
     [setYear]
   );
+
+  const widgetInfo = useMemo(() => {
+    return widgets.find((widget) => widget.slug === 'mangrove_habitat_extent');
+  }, [widgets]);
+
+  const contextualLayers = useMemo(() => {
+    return widgetInfo?.contextualLayers || [];
+  }, [widgetInfo]);
 
   if (noData) return <NoData />;
 
@@ -198,7 +209,14 @@ const HabitatExtent = () => {
             </span>{' '}
             of the coastline.
           </p>
-          <HabitatExtentChart legend={legend} config={config} />
+          <div className="-mx-2">
+            <ContextualLayersWrapper
+              origin="mangrove_alerts"
+              id={contextualLayers[0].id}
+              description={contextualLayers[0].description}
+            />
+            <HabitatExtentChart legend={legend} config={config} />
+          </div>
         </div>
       )}
     </div>

--- a/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
+++ b/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import cn from 'lib/classnames';
 
@@ -19,10 +19,18 @@ import ARROW_SVG from 'svgs/ui/arrow-filled.svg?sprite';
 import MangrovesInProtectedAreasChart from './chart';
 import { useMangrovesInProtectedAreas } from './hooks';
 import { trackEvent } from 'lib/analytics/ga';
+import { widgets } from 'containers/widgets/constants';
+import ContextualLayersWrapper from 'containers/widget/contextual-layers';
 
 const MangrovesInProtectedAreas = () => {
   const [selectedUnit, setUnit] = useState('ha');
   const { data, isFetched, isFetching } = useMangrovesInProtectedAreas({ unit: selectedUnit });
+
+  const widgetInfo = useMemo(
+    () => widgets.find((widget) => widget.slug === 'mangrove_protection'),
+    [widgets]
+  );
+  const contextualLayers = useMemo(() => widgetInfo?.contextualLayers || [], [widgetInfo]);
 
   if (isFetched && !Object.keys(data || {}).length) return <NoData />;
 
@@ -118,6 +126,13 @@ const MangrovesInProtectedAreas = () => {
               </PopoverContent>
             </Popover>
           </p>
+          <div className="-mx-2">
+            <ContextualLayersWrapper
+              origin="mangrove_protection"
+              id={contextualLayers[0].id}
+              description={contextualLayers[0].description}
+            />
+          </div>
           <MangrovesInProtectedAreasChart config={data.config} legend={data.legend} />
           <p className="text-sm italic">
             Note: This represents the proportion of mangroves known to occur within protected areas.

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -15,7 +15,6 @@ import WidgetApplicability from './applicability';
 import WidgetHeader from './header';
 import { getLayerActive } from './selector';
 import Helper from 'containers/help/helper';
-import ContextualLayersWrapper from 'containers/widget/contextual-layers';
 
 type ChildrenType = ReactElement & { type?: () => null };
 
@@ -34,7 +33,7 @@ type WidgetLayoutProps = {
 };
 
 const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
-  const { children, title, id, className, applicability, info, contextualLayers } = props;
+  const { children, title, id, className, applicability, info } = props;
   const { enabled: isDrawingToolEnabled } = useRecoilValue(drawingToolAtom);
   const { enabled: isDrawingUploadToolEnabled } = useRecoilValue(drawingUploadToolAtom);
   const isLayerActive = useRecoilValue(getLayerActive(id));
@@ -92,7 +91,6 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
                 {!info && <WidgetControls id={id} />}
               </WidgetHeader>
             </Helper>
-
             <div
               data-testid={`widget-${id}-content`}
               className={cn({
@@ -105,14 +103,6 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
             </div>
             {applicability && <WidgetApplicability id={id} applicability={applicability} />}
           </div>
-
-          {!!contextualLayers?.length && (
-            <ContextualLayersWrapper
-              origin={id}
-              id={contextualLayers[0].id}
-              description={contextualLayers[0].description}
-            />
-          )}
         </div>
       </motion.div>
     </AnimatePresence>


### PR DESCRIPTION
This pull request refactors how contextual layers are rendered within dataset widgets by moving the contextual layers UI out of the generic widget wrapper and directly into each relevant widget component. This change allows for more granular control and customization of contextual layers per widget, and improves maintainability by reducing coupling between the widget wrapper and individual widgets.

**Refactoring contextual layers rendering:**

* Removed the contextual layers logic and `ContextualLayersWrapper` component from the generic `WidgetWrapper` in `src/containers/widget/index.tsx`, eliminating the need to pass contextual layers as props and decoupling the contextual layers UI from the widget container. [[1]](diffhunk://#diff-4b8f24b3d1c8989e4345a730b359932cc5997ab5ef7957f27ec97c41e00cfc2cL18) [[2]](diffhunk://#diff-4b8f24b3d1c8989e4345a730b359932cc5997ab5ef7957f27ec97c41e00cfc2cL37-R36) [[3]](diffhunk://#diff-4b8f24b3d1c8989e4345a730b359932cc5997ab5ef7957f27ec97c41e00cfc2cL108-L115)

* Added logic to retrieve contextual layers from the `widgets` constants and render the `ContextualLayersWrapper` directly inside each of the following widget components:
  - `src/containers/datasets/alerts/widget.tsx` for the "mangrove_alerts" widget. [[1]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95L16-R16) [[2]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95R26-R27) [[3]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95R50-R55) [[4]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95R203-R210)
  - `src/containers/datasets/habitat-extent/widget.tsx` for the "mangrove_habitat_extent" widget. [[1]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74L1-R1) [[2]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74R28-R30) [[3]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74R83-R90) [[4]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74R212-R220)
  - `src/containers/datasets/mangroves-in-protected-areas/widget.tsx` for the "mangrove_protection" widget. [[1]](diffhunk://#diff-29d5055c20f20714079fd234209465c1dcd7dbd6459d225cbe7e0a51c0f70844L1-R1) [[2]](diffhunk://#diff-29d5055c20f20714079fd234209465c1dcd7dbd6459d225cbe7e0a51c0f70844R22-R34) [[3]](diffhunk://#diff-29d5055c20f20714079fd234209465c1dcd7dbd6459d225cbe7e0a51c0f70844R129-R135)

**UI adjustment:**

* Updated the border radius on the main container in the `ContextualLayersComponent` from `rounded-b-3xl` to `rounded-3xl` for a more consistent appearance.
