### PR TITLE
saved areas

### DIFF
--- a/src/containers/navigation/menu/profile/subscriptions.tsx
+++ b/src/containers/navigation/menu/profile/subscriptions.tsx
@@ -1,29 +1,58 @@
 'use client';
 
+import { useMemo, useState } from 'react';
+
 import { Button } from 'components/ui/button';
 import { SwitchWrapper, SwitchRoot, SwitchThumb } from 'components/ui/switch';
 import {
   useGetUserNotificationPreferences,
   usePostToggleLocationAlerts,
 } from '@/containers/subscriptions/hooks';
+import { Loading } from '@/components/ui/loading';
+
+import { DataUserNotificationPreferencesToggleLocationAlerts } from '@/containers/subscriptions/hooks';
 
 const SubscriptionsContent = () => {
-  const { data } = useGetUserNotificationPreferences();
-
+  const { data, isLoading } = useGetUserNotificationPreferences();
   const toggleMutation = usePostToggleLocationAlerts();
 
-  const handleClickAlerts = () => {
-    toggleMutation.mutate({
-      ...data?.notification_preferences,
-      location_alerts: !data?.notification_preferences?.location_alerts,
-    });
+  const userPreferences = useMemo(
+    () => (data ? (data.data as DataUserNotificationPreferencesToggleLocationAlerts) : undefined),
+    [data]
+  );
+
+  const [selection, setSelection] = useState<
+    Partial<DataUserNotificationPreferencesToggleLocationAlerts>
+  >({});
+
+  const effective = useMemo(() => {
+    if (!userPreferences) return undefined;
+    return { ...userPreferences, ...selection };
+  }, [userPreferences, selection]);
+
+  if (isLoading || !effective) return <Loading />;
+
+  const handleToggleLocationAlerts = (checked: boolean) => {
+    setSelection((d) => ({ ...d, location_alerts: checked }));
   };
 
-  const handleClickWhatsNew = () => {
-    return toggleMutation.mutate({
-      ...data?.notification_preferences,
-      newsletter: data?.notification_preferences?.newsletter,
-    });
+  const handleToggleNewsletter = (checked: boolean) => {
+    setSelection((d) => ({ ...d, newsletter: checked }));
+  };
+
+  const hasChanges = Object.keys(selection).length > 0;
+
+  const handleSaveChanges = () => {
+    if (!userPreferences) return;
+
+    toggleMutation.mutate(
+      { ...userPreferences, ...selection } as DataUserNotificationPreferencesToggleLocationAlerts,
+      {
+        onSuccess: () => {
+          setSelection({});
+        },
+      }
+    );
   };
 
   return (
@@ -35,32 +64,38 @@ const SubscriptionsContent = () => {
             Emails with mangrove disturbance alerts related to your saved areas.
           </p>
         </div>
+
         <SwitchWrapper id="alerts">
           <SwitchRoot
-            onClick={handleClickAlerts}
-            checked={!!data?.notification_preferences?.location_alerts}
+            checked={effective.location_alerts}
+            onCheckedChange={handleToggleLocationAlerts}
           >
             <SwitchThumb />
           </SwitchRoot>
         </SwitchWrapper>
       </div>
+
       <div className="flex items-center justify-between gap-12">
         <div className="flex max-w-sm flex-col justify-between gap-2">
           <span className="text-lg font-light">What's new</span>
           <p className="text-sm text-[#939393]">
-            Weekly updates on mangrove conservation news and the latest platform enhancements.{' '}
+            Weekly updates on mangrove conservation news and the latest platform enhancements.
           </p>
         </div>
-        <SwitchWrapper id="alerts">
-          <SwitchRoot
-            onClick={handleClickWhatsNew}
-            checked={data?.notification_preferences?.newsletter}
-          >
+
+        <SwitchWrapper id="newsletter">
+          <SwitchRoot checked={effective.newsletter} onCheckedChange={handleToggleNewsletter}>
             <SwitchThumb />
           </SwitchRoot>
         </SwitchWrapper>
       </div>
-      <Button className="w-fit" size="lg">
+
+      <Button
+        className="w-fit"
+        size="lg"
+        onClick={handleSaveChanges}
+        disabled={!hasChanges || toggleMutation.isLoading}
+      >
         Save changes
       </Button>
     </div>

--- a/src/containers/subscriptions/hooks.ts
+++ b/src/containers/subscriptions/hooks.ts
@@ -2,21 +2,15 @@ import { useQuery, useMutation, useQueryClient, type UseQueryOptions } from '@ta
 
 import API from 'services/api';
 
-export type NotificationPreference = {
-  description: string;
-  location_alerts: boolean;
-  newsletter: boolean;
-  platform_updates: boolean;
-};
-
-export type UserNotificationPreferencesResponse = {
-  notification_preferences: NotificationPreference;
-};
-
 export type DataUserNotificationPreferencesToggleLocationAlerts = {
   location_alerts: boolean;
   platform_updates: boolean;
   newsletter: boolean;
+};
+
+export type UserNotificationPreferencesResponse = {
+  data: DataUserNotificationPreferencesToggleLocationAlerts;
+  isPending: boolean;
 };
 
 // ---------------------


### PR DESCRIPTION
This pull request refactors the user notification preferences UI and improves the server-side logic for handling location data. The main changes include making notification toggles for alerts and newsletters more user-friendly by batching changes and providing immediate UI feedback, and enhancing the server-side data fetching logic for locations to be more robust and maintainable.

**UI/UX improvements for user notification preferences:**

* Refactored `SubscriptionsContent` to use local state for notification preferences, allowing users to toggle multiple settings (alerts and newsletter) before saving all changes at once, with a "Save changes" button that is only enabled when there are unsaved changes. Also added a loading state while preferences are fetched. [[1]](diffhunk://#diff-258417455b9d859473f5ba4b2d144d04023b8f7e3dcb2c2c5aa458faa3a1bcefR3-R55) [[2]](diffhunk://#diff-258417455b9d859473f5ba4b2d144d04023b8f7e3dcb2c2c5aa458faa3a1bcefR67-R98)
* Updated the notification preferences type definitions to simplify and clarify the data structure, ensuring consistency between client and server data.

**Server-side data fetching enhancements:**

* Moved the instantiation of `QueryClient` inside `getServerSideProps` to avoid potential issues with shared state across requests. ([src/pages/[[...params]].tsxL40-R41](diffhunk://#diff-529dbd6e03731b6f6b018c15bc797205c347fa931aa7098e61cd54555b8d61b7L40-R41))
* Improved server-side location fetching by using `prefetchQuery` and validating location types up front. The logic now returns a 404 for invalid types or fetch errors, and ensures location bounds are cached if available. ([src/pages/[[...params]].tsxR63-R96](diffhunk://#diff-529dbd6e03731b6f6b018c15bc797205c347fa931aa7098e61cd54555b8d61b7R63-R96))