### PR TITLE
fix: map scroll zoom

### DIFF
--- a/src/components/map/index.tsx
+++ b/src/components/map/index.tsx
@@ -17,10 +17,10 @@ export const CustomMap: FC<CustomMapProps> = ({
   initialViewState,
   bounds,
   onMapViewStateChange,
-  dragPan,
-  dragRotate,
-  scrollZoom,
-  doubleClickZoom,
+  dragPan = true,
+  dragRotate = true,
+  scrollZoom = true,
+  doubleClickZoom = true,
   onLoad,
   ...mapboxProps
 }) => {


### PR DESCRIPTION
This pull request makes a small improvement to the `CustomMap` component by setting default values for several map interaction props. This ensures that features like drag, rotate, and zoom are enabled by default unless explicitly disabled.

- Set default values to `true` for the `dragPan`, `dragRotate`, `scrollZoom`, and `doubleClickZoom` props in the `CustomMap` component to improve usability and prevent unexpected behavior when these props are not provided. (`src/components/map/index.tsx`)