### PR TITLE
feat: replace inline print styles with dedicated print report page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,6 @@ Each deploys independently via `.github/workflows/deploy-*.yml` on push to `deve
 - **Styling is Tailwind v4** with `prettier-plugin-tailwindcss` sorting classes on save. `cn` helper at `@/lib/classnames`. Widget-shared class constants live in `src/styles/widgets.ts` (e.g. `WIDGET_CARD_WRAPPER_STYLE`, `WIDGET_SENTENCE_STYLE`).
 - **i18n**: Transifex Native, locales `en`/`fr`/`es` (`localeDetection: false`). Strings that should not be translated get `className="notranslate"` (see numeric values in widgets).
 - **Analytics**: use the `trackEvent` wrapper from `@/lib/analytics/ga` — only fires when `NEXT_PUBLIC_GA_ID` is set.
-- **Print mode**: `printModeState` drives a print CSS path — many widget components have `print:` Tailwind variants. Don't strip them when refactoring.
 - **Prettier**: single quotes, trailing commas `es5`, 100 char width. Pre-commit hook runs lint-staged (`.lintstagedrc.js`).
 
 ## Testing

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[[...params]]/layout.tsx
+++ b/src/app/[[...params]]/layout.tsx
@@ -5,7 +5,7 @@ import Providers from './providers';
 export default function ParamsLayout({ children }: { children: React.ReactNode }) {
   return (
     <Providers>
-      <div className="relative h-screen w-screen overflow-hidden print:overflow-visible">
+      <div className="relative h-screen w-screen overflow-hidden">
         <MapContainer mapId="default" />
         {children}
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           }}
         />
       </head>
-      <body>
+      <body className="bg-brand-400 print:bg-white">
         {/* Global Site Tag (gtag.js) - Google Analytics */}
         <Script
           strategy="afterInteractive"

--- a/src/app/print-report/[[...params]]/layout.tsx
+++ b/src/app/print-report/[[...params]]/layout.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+
+import MapContainer from '@/containers/map';
+import PrintHeader from '@/containers/print-report/print-header';
+import PrintLegend from '@/containers/print-report/print-legend';
+
+export default function PrintReportLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="print-report relative min-h-screen w-full bg-white p-4">
+      <Image
+        src="/images/logo-bg.png"
+        alt="Global Mangrove Watch"
+        width={80}
+        height={93}
+        className="absolute top-0 right-0 z-10"
+      />
+      <PrintHeader />
+      <div className="print-report-map relative h-[60vh] w-full overflow-hidden rounded-3xl border border-gray-200">
+        <MapContainer mapId="print-report" hideControls />
+        <PrintLegend />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/app/print-report/[[...params]]/page.tsx
+++ b/src/app/print-report/[[...params]]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound } from 'next/navigation';
+
+import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import turfBbox from '@turf/bbox';
+
+import type { DataResponse } from '@/containers/datasets/locations/hooks';
+import PrintReportPage from '@/containers/print-report';
+
+const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
+
+export default async function Page({ params }: { params: Promise<{ params?: string[] }> }) {
+  const { params: urlParams } = await params;
+  const locationType = urlParams?.[0] ?? null;
+  const locationId = urlParams?.[1] ?? null;
+
+  if (locationType && !ALLOWED_LOCATION_TYPES.includes(locationType)) {
+    notFound();
+  }
+
+  const queryClient = new QueryClient();
+
+  if (locationId) {
+    try {
+      await queryClient.prefetchQuery({
+        queryKey: ['location', locationType, locationId],
+        queryFn: async () => {
+          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/locations/${locationId}`, {
+            headers: { 'Content-Type': 'application/json' },
+          });
+          if (!res.ok) throw new Error(`Location fetch failed: ${res.status}`);
+          const json = await res.json();
+          return { data: json.data } as { data: DataResponse['data'][0] };
+        },
+      });
+
+      const cached = queryClient.getQueryData<{ data: DataResponse['data'][0] }>([
+        'location',
+        locationType,
+        locationId,
+      ]);
+
+      if (cached?.data?.bounds) {
+        queryClient.setQueryData(['location-bounds'], turfBbox(cached.data.bounds));
+      }
+    } catch {
+      notFound();
+    }
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <PrintReportPage />
+    </HydrationBoundary>
+  );
+}

--- a/src/components/contextual-layers/index.tsx
+++ b/src/components/contextual-layers/index.tsx
@@ -1,4 +1,8 @@
-import { ReactElement } from 'react';
+import { ReactElement, useMemo } from 'react';
+
+import { usePathname } from 'next/navigation';
+
+import { useSyncActiveLayers } from '@/store/layers';
 
 import type { WidgetSlugType } from 'types/widget';
 
@@ -22,6 +26,13 @@ const ContextualLayersComponent = ({
   thumbSource,
   name,
 }: ContextualLayersComponentProps) => {
+  const pathname = usePathname();
+  const isPrintReport = pathname?.startsWith('/print-report');
+  const [activeLayers] = useSyncActiveLayers();
+  const isActive = useMemo(() => activeLayers?.some((l) => l.id === id), [activeLayers, id]);
+
+  if (isPrintReport && !isActive) return null;
+
   return (
     <div className="bg-brand-800/10 relative flex flex-col space-y-5 rounded-3xl p-3">
       <div className="flex items-center justify-between space-x-8">
@@ -32,7 +43,7 @@ const ContextualLayersComponent = ({
             <Content id={id} description={description} />
           </div>
         </div>
-        <Controls id={id} origin={origin} />
+        {!isPrintReport && <Controls id={id} origin={origin} />}
       </div>
     </div>
   );

--- a/src/components/widget-controls/index.tsx
+++ b/src/components/widget-controls/index.tsx
@@ -25,7 +25,7 @@ const WidgetControls = ({ id, content }: WidgetControlsType) => {
   const layer = id ? LAYERS?.[id] : content?.layer;
 
   return (
-    <div className="flex items-center space-x-2 print:hidden">
+    <div className="flex items-center space-x-2">
       {!!download && <Download id={id} content={download} />}
       {!!info && <Info id={id} content={info} />}
       {!!layer && <LayerToggle id={id} />}

--- a/src/containers/datasets/alerts-staging/widget.tsx
+++ b/src/containers/datasets/alerts-staging/widget.tsx
@@ -109,10 +109,10 @@ const AlertsWidget = () => {
             between{' '}
             <Popover>
               <PopoverTrigger>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedStartDate?.label}
                   <ARROW_SVG
-                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 print:hidden"
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2"
                     role="img"
                     title="Arrow"
                   />
@@ -153,10 +153,10 @@ const AlertsWidget = () => {
             and{' '}
             <Popover>
               <PopoverTrigger>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedEndDate?.label}
                   <ARROW_SVG
-                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 print:hidden"
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2"
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -122,10 +122,10 @@ const AlertsWidget = () => {
             between{' '}
             <Popover>
               <PopoverTrigger>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedStartDate?.label}
                   <ARROW_SVG
-                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current print:hidden"
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
                     role="img"
                     title="Arrow"
                   />
@@ -166,10 +166,10 @@ const AlertsWidget = () => {
             and{' '}
             <Popover>
               <PopoverTrigger>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedEndDate?.label}
                   <ARROW_SVG
-                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current print:hidden"
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/carbon-market-potential/widget.tsx
+++ b/src/containers/datasets/carbon-market-potential/widget.tsx
@@ -50,10 +50,10 @@ const CarbonMarketPotentialWidget = () => {
             The extent of investible blue carbon (ha) at{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {label}
                   <ARROW_SVG
-                    className={`fill-current ${`${WIDGET_SELECT_ARROW_STYLES} print:hidden`} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />
@@ -93,10 +93,10 @@ const CarbonMarketPotentialWidget = () => {
             in <span className="font-bold"> {location}</span> is {investibleBlueCarbonValue}{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {unit.label}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/customize-widgets-deck/widget.tsx
+++ b/src/containers/datasets/customize-widgets-deck/widget.tsx
@@ -60,10 +60,10 @@ const CustomizeWidgetsDeck = () => {
           <span className="notranslate font-bold">
             <Dialog>
               <DialogTrigger>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {filteredWidgetsToDisplay.length} of {widgets.length - 1}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
@@ -129,7 +129,7 @@ const CommercialFisheriesProduction = () => {
               >
                 <SelectValue className="inline-flex w-fit" />
                 <ARROW_SVG
-                  className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 print:hidden"
+                  className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2"
                   role="img"
                   title="Arrow"
                 />

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -184,10 +184,10 @@ const FloodProtection = ({
             during {selectedPeriod === 'annual' ? 'an' : 'a'}{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {LABELS[selectedPeriod].short}
                   <ARROW_SVG
-                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current print:hidden"
+                    className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/habitat-change/widget.tsx
+++ b/src/containers/datasets/habitat-change/widget.tsx
@@ -72,11 +72,11 @@ const HabitatExtent = () => {
               {' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                  <span className={`${WIDGET_SELECT_STYLES}`}>
                     {' '}
                     {currentStartYear}
                     <TRIANGLE_SVG
-                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
@@ -121,10 +121,10 @@ const HabitatExtent = () => {
             <span className="notranslate font-bold">
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                  <span className={`${WIDGET_SELECT_STYLES}`}>
                     {currentEndYear}
                     <TRIANGLE_SVG
-                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
@@ -180,7 +180,7 @@ const HabitatExtent = () => {
               </li>
             ))}
           </ul>
-          <div className="w-full print:scale-x-90 print:transform">
+          <div className="w-full">
             <Chart config={config} />
           </div>
 

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -127,10 +127,10 @@ const HabitatExtent = () => {
               {area}{' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                  <span className={`${WIDGET_SELECT_STYLES}`}>
                     {selectedUnitAreaExtent}
                     <ARROW_SVG
-                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
@@ -162,10 +162,10 @@ const HabitatExtent = () => {
             in{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {year || defaultYear}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />

--- a/src/containers/datasets/height/chart.tsx
+++ b/src/containers/datasets/height/chart.tsx
@@ -4,7 +4,7 @@ import Chart from '@/components/chart';
 
 const HeightChart = ({ legend, config }) => {
   return (
-    <div className="flex flex-1 flex-col items-center justify-between py-10 print:max-w-[120mm] print:px-0">
+    <div className="flex flex-1 flex-col items-center justify-between py-10">
       <Legend items={legend} variant="horizontal" />
       <Chart config={config} />
     </div>

--- a/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
+++ b/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
@@ -46,10 +46,10 @@ const MangrovesInProtectedAreas = () => {
               {data.protectedArea}{' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                  <span className={`${WIDGET_SELECT_STYLES}`}>
                     {selectedUnit}
                     <ARROW_SVG
-                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       aria-hidden={true}
                     />
@@ -89,10 +89,10 @@ const MangrovesInProtectedAreas = () => {
             out of a total <span className="font-bold">{data.totalArea}</span>{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedUnit}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />

--- a/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
@@ -16,10 +16,10 @@ const IndicatorYear = ({ years, yearSelected, setYearSelected }: IndicatorYearPr
         {years?.length > 1 && (
           <Popover>
             <PopoverTrigger asChild>
-              <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+              <span className={`${WIDGET_SELECT_STYLES}`}>
                 {yearSelected}
                 <ARROW_SVG
-                  className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                  className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                   role="img"
                   title="Arrow"
                 />

--- a/src/containers/datasets/net-change/chart.tsx
+++ b/src/containers/datasets/net-change/chart.tsx
@@ -3,7 +3,7 @@ import Chart from '@/components/chart';
 import NetChangeLegend from './legend';
 const NetChangeChart = ({ config }) => {
   return (
-    <div className="print:max-w-[120mm]">
+    <div>
       <NetChangeLegend />
       <Chart config={config} />
     </div>

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -112,10 +112,10 @@ const NetChangeWidget = () => {
             <span className="font-bold"> {netChange}</span>{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedUnit}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
@@ -155,10 +155,10 @@ const NetChangeWidget = () => {
             between{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {currentStartYear}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
@@ -192,10 +192,10 @@ const NetChangeWidget = () => {
             and{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES} print:border-hidden`}>
+                <span className={`${WIDGET_SELECT_STYLES}`}>
                   {currentEndYear}
                   <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES} print:hidden`}
+                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />

--- a/src/containers/embedded/map/index.tsx
+++ b/src/containers/embedded/map/index.tsx
@@ -102,10 +102,7 @@ const EmbeddedMap = ({ mapId }: { mapId: string }) => {
   }, [map, locationBounds, screenWidth]);
 
   return (
-    <div
-      className="print:page-break-after print:page-break-inside-avoid absolute top-0 left-0 z-0 h-screen w-screen print:relative print:h-[90vh] print:w-screen"
-      ref={containerRef}
-    >
+    <div className="absolute top-0 left-0 z-0 h-screen w-screen" ref={containerRef}>
       <Map
         id={mapId}
         reuseMaps

--- a/src/containers/location-widget/index.tsx
+++ b/src/containers/location-widget/index.tsx
@@ -88,7 +88,7 @@ const LocationWidget = () => {
 
   return (
     <>
-      <div className="bg-brand-600 shadow-control relative flex h-52 flex-col justify-between rounded-3xl bg-[url(/images/location-bg.svg)] bg-cover bg-center text-center print:hidden">
+      <div className="bg-brand-600 shadow-control relative flex h-52 flex-col justify-between rounded-3xl bg-[url(/images/location-bg.svg)] bg-cover bg-center text-center">
         <Dialog open={isOpen}>
           <DialogTrigger asChild>
             <button

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -145,7 +145,6 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
               className={cn({
                 'hover:bg-brand-800/10 flex h-full w-full flex-1 items-center justify-between px-4 py-1 hover:rounded-2xl':
                   true,
-                'print:hidden': screenWidth >= breakpoints.lg,
                 'pointer-events-none': locationId === locationsToDisplay[index].id,
                 'bg-brand-800/5 border-brand-800 rounded-2xl border-2': focusedIndex === index,
               })}

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -21,7 +21,6 @@ import {
   useSyncBasemap,
   useSyncURLBounds,
 } from '@/store/map';
-import { printModeState } from '@/store/print-mode';
 
 import { useQueryClient } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
@@ -66,7 +65,7 @@ export const MAP_DEFAULT_PROPS = {
   maxZoom: 20,
 };
 
-const MapContainer = ({ mapId }: { mapId: string }) => {
+const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: boolean }) => {
   const [position, setPosition] = useAtom(mapDraggableTooltipPositionAtom);
   const mapPopUpDimensions = useAtomValue(mapDraggableTooltipDimensionsAtom);
 
@@ -82,7 +81,6 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
   const { enabled: isUploadToolEnabled, uploadedGeojson } = useAtomValue(drawingUploadToolAtom);
   const [URLBounds, setURLBounds] = useSyncURLBounds();
   const [cursor, setCursor] = useAtom(mapCursorAtom);
-  const isPrintingMode = useAtomValue(printModeState);
   const [tmpCamera, setTmpCamera] = useAtom(tmpCameraAtom);
   const { navigate } = useLocationNavigation();
 
@@ -514,10 +512,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
           iucnEcoregionInfo={iucnEcoregionPopUp}
         />
       )}
-      <div
-        className="print:page-break-after print:page-break-inside-avoid absolute top-0 left-0 z-0 h-screen w-screen print:relative print:top-4 print:w-[90vw]"
-        ref={mapRef}
-      >
+      <div className="absolute top-0 left-0 z-0 h-screen w-screen" ref={mapRef}>
         <Map
           id={mapId}
           reuseMaps
@@ -550,61 +545,63 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
                   onSetCustomPolygon={handleCustomPolygon}
                 />
               )}
-              <Controls className="absolute right-5 bottom-9 hidden items-center md:block print:hidden">
-                <div className="flex flex-col space-y-2 pt-1">
-                  {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
-                  <Helper
-                    className={{
-                      button: 'top-1 left-8 z-20',
-                      tooltip: 'w-80',
-                    }}
-                    tooltipPosition={{ top: 0, left: 330 }}
-                    message="Use this icon to show the map in full screen. Widgets and other menu items will be hidden until the icon is clicked again. "
-                  >
-                    <FullScreenControl />
-                  </Helper>
-                  <Helper
-                    className={{
-                      button: 'top-1 left-8 z-20',
-                      tooltip: 'w-80',
-                    }}
-                    tooltipPosition={{ top: 0, left: 330 }}
-                    message="Use this function to generate a link to a user-customized map on GMW or to embed a customized map into another website."
-                  >
-                    <ShareControl
-                      disabled={
-                        isDrawingToolEnabled ||
-                        isUploadToolEnabled ||
-                        !!customGeojson ||
-                        !!uploadedGeojson
-                      }
-                    />
-                  </Helper>
-                  <Helper
-                    className={{
-                      button: 'top-1 left-8 z-20',
-                      tooltip: 'w-80',
-                    }}
-                    tooltipPosition={{ top: 0, left: 330 }}
-                    message="Select this icon to choose from a variety of basemaps, enable visualization of the high-resolution mangrove extent, or to select high resolution imagery from Planet."
-                  >
-                    <BasemapSettingsControl />
-                  </Helper>
-                  <Helper
-                    className={{
-                      button: 'top-1 left-8 z-20',
-                      tooltip: 'w-80',
-                    }}
-                    tooltipPosition={{ top: 0, left: 330 }}
-                    message="Use the + icon to zoom into the map and the – button to zoom out of the map"
-                  >
-                    <div className="border-box shadow-control flex flex-col overflow-hidden rounded-3xl">
-                      <ZoomControl mapId={mapId} />
-                      {pitch !== 0 && <PitchReset mapId={mapId} />}
-                    </div>
-                  </Helper>
-                </div>
-              </Controls>
+              {!hideControls && (
+                <Controls className="absolute right-5 bottom-9 hidden items-center md:block">
+                  <div className="flex flex-col space-y-2 pt-1">
+                    {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
+                    <Helper
+                      className={{
+                        button: 'top-1 left-8 z-20',
+                        tooltip: 'w-80',
+                      }}
+                      tooltipPosition={{ top: 0, left: 330 }}
+                      message="Use this icon to show the map in full screen. Widgets and other menu items will be hidden until the icon is clicked again. "
+                    >
+                      <FullScreenControl />
+                    </Helper>
+                    <Helper
+                      className={{
+                        button: 'top-1 left-8 z-20',
+                        tooltip: 'w-80',
+                      }}
+                      tooltipPosition={{ top: 0, left: 330 }}
+                      message="Use this function to generate a link to a user-customized map on GMW or to embed a customized map into another website."
+                    >
+                      <ShareControl
+                        disabled={
+                          isDrawingToolEnabled ||
+                          isUploadToolEnabled ||
+                          !!customGeojson ||
+                          !!uploadedGeojson
+                        }
+                      />
+                    </Helper>
+                    <Helper
+                      className={{
+                        button: 'top-1 left-8 z-20',
+                        tooltip: 'w-80',
+                      }}
+                      tooltipPosition={{ top: 0, left: 330 }}
+                      message="Select this icon to choose from a variety of basemaps, enable visualization of the high-resolution mangrove extent, or to select high resolution imagery from Planet."
+                    >
+                      <BasemapSettingsControl />
+                    </Helper>
+                    <Helper
+                      className={{
+                        button: 'top-1 left-8 z-20',
+                        tooltip: 'w-80',
+                      }}
+                      tooltipPosition={{ top: 0, left: 330 }}
+                      message="Use the + icon to zoom into the map and the – button to zoom out of the map"
+                    >
+                      <div className="border-box shadow-control flex flex-col overflow-hidden rounded-3xl">
+                        <ZoomControl mapId={mapId} />
+                        {pitch !== 0 && <PitchReset mapId={mapId} />}
+                      </div>
+                    </Helper>
+                  </div>
+                </Controls>
+              )}
 
               {!!position && !!locationPopUp.info && (
                 <Marker
@@ -629,7 +626,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
           )}
         </Map>
 
-        {/* {!isPrintingMode && (
+        {!hideControls && (
           <>
             <Media lessThan="md">
               <div className="absolute top-20">
@@ -642,7 +639,7 @@ const MapContainer = ({ mapId }: { mapId: string }) => {
               </div>
             </Media>
           </>
-        )} */}
+        )}
       </div>
     </>
   );

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -512,7 +512,14 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
           iucnEcoregionInfo={iucnEcoregionPopUp}
         />
       )}
-      <div className="absolute top-0 left-0 z-0 h-screen w-screen" ref={mapRef}>
+      <div
+        className={
+          hideControls
+            ? 'relative z-0 h-full w-full'
+            : 'absolute top-0 left-0 z-0 h-screen w-screen'
+        }
+        ref={mapRef}
+      >
         <Map
           id={mapId}
           reuseMaps

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -118,7 +118,7 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
   }, [activeLayerNoPlanet, locationId]);
 
   return (
-    <div className="print:hidden">
+    <div>
       {!!legendLayers?.length && (
         <>
           <button
@@ -149,8 +149,7 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
               >
                 <div
                   className={cn({
-                    'box-content flex flex-col overflow-y-auto p-4 md:max-h-[55vh] print:hidden':
-                      true,
+                    'box-content flex flex-col overflow-y-auto p-4 md:max-h-[55vh]': true,
                   })}
                 >
                   <SortableList

--- a/src/containers/map/legend/mobile/index.tsx
+++ b/src/containers/map/legend/mobile/index.tsx
@@ -32,7 +32,7 @@ const Legend = () => {
   };
 
   return (
-    <div className="flex w-screen justify-center print:hidden">
+    <div className="flex w-screen justify-center">
       {!!activeLayers?.length && (
         <>
           <button
@@ -60,8 +60,8 @@ const Legend = () => {
               className="fixed md:right-[73px]"
             >
               <div className="shadow-medium animate-in data-[state=open]:fade-in-60 data-[state=close]:slide-in-from-bottom-0 data-[state=open]:slide-in-from-bottom-16 w-[360px] gap-4 rounded-3xl border bg-white duration-300">
-                <div className="box-content flex max-h-[70vh] flex-col space-y-1 divide-y divide-black/42 overflow-y-auto pt-4 md:px-4 md:print:hidden">
-                  <div className="box-content flex flex-col space-y-1 divide-y divide-black/42 overflow-y-auto px-4 pt-4 md:max-h-[55vh] print:hidden">
+                <div className="box-content flex max-h-[70vh] flex-col space-y-1 divide-y divide-black/42 overflow-y-auto pt-4 md:px-4">
+                  <div className="box-content flex flex-col space-y-1 divide-y divide-black/42 overflow-y-auto px-4 pt-4 md:max-h-[55vh]">
                     {activeLayers?.map((l) => {
                       return <LegendItem id={l.id} key={l.id} l={l} />;
                     })}

--- a/src/containers/navigation/index.tsx
+++ b/src/containers/navigation/index.tsx
@@ -7,7 +7,7 @@ import News from '@/containers/navigation/news';
 const HELPER_ID = 'menu-categories';
 
 const AppTools = () => (
-  <div className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[540px] rounded-[32px] px-5 shadow-md md:block print:hidden">
+  <div className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[540px] rounded-[32px] px-5 shadow-md md:block">
     {/* <div className="grid h-full grid-cols-4 gap-4"> */}
     <div className="flex h-full items-center justify-around">
       <div className="flex items-center justify-center">

--- a/src/containers/print-report/index.tsx
+++ b/src/containers/print-report/index.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
+import { useSyncActiveWidgets } from '@/store/widgets';
+
+import { useAtom } from 'jotai';
+
+import { WIDGETS } from '@/containers/datasets';
+import { widgets, ANALYSIS_WIDGETS_SLUGS } from '@/containers/widgets/constants';
+import { useWidgets } from '@/containers/widgets/hooks';
+
+import type { WidgetTypes } from 'types/widget';
+
+const PrintReportPage = () => {
+  const [{ customGeojson }] = useAtom(drawingToolAtom);
+  const [{ uploadedGeojson }] = useAtom(drawingUploadToolAtom);
+  const [activeWidgets] = useSyncActiveWidgets();
+  const enabledWidgets = useWidgets();
+
+  const widgetsAvailable = useMemo(() => {
+    if (customGeojson || uploadedGeojson) {
+      return widgets.filter(({ slug }) => ANALYSIS_WIDGETS_SLUGS.includes(slug));
+    }
+    return enabledWidgets.filter(
+      ({ slug }) => activeWidgets?.includes(slug) && slug !== 'widgets_deck_tool'
+    );
+  }, [activeWidgets, enabledWidgets, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
+
+  return (
+    <div className="columns-2 gap-4 p-4 pt-6">
+      {widgetsAvailable.map(({ slug, name }) => {
+        const Widget = WIDGETS[slug];
+        if (!Widget) return null;
+        return (
+          <div
+            key={slug}
+            className="mb-4 break-inside-avoid overflow-hidden rounded-3xl border border-gray-100 bg-white p-6 shadow-sm print:max-h-[calc(100vh-20mm)]"
+          >
+            <h3 className="mb-3 text-xs font-semibold tracking-wider text-black/60 uppercase">
+              {name}
+            </h3>
+            <Widget />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PrintReportPage;

--- a/src/containers/print-report/print-header.tsx
+++ b/src/containers/print-report/print-header.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+
+import { useSyncLocation } from 'hooks/use-sync-location';
+
+import { useLocation } from '@/containers/datasets/locations/hooks';
+import type { LocationTypes } from '@/containers/datasets/locations/types';
+
+const PrintHeader = () => {
+  const { type, id } = useSyncLocation();
+  const locationType = (type ?? 'worldwide') as LocationTypes;
+  const {
+    data: { name: locationName },
+  } = useLocation(id, locationType, {
+    enabled: (!!locationType && !!id) || locationType !== 'custom-area',
+  });
+
+  const displayName = useMemo(() => {
+    if (locationType === 'custom-area') return 'Custom Area';
+    return locationName || 'Worldwide';
+  }, [locationType, locationName]);
+
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
+
+  return (
+    <div className="flex items-center gap-4 py-4">
+      <button
+        type="button"
+        onClick={handlePrint}
+        className="print-report-no-print bg-brand-800 hover:bg-brand-800/90 rounded-3xl px-8 py-2 text-sm font-semibold text-white shadow-md transition-colors"
+      >
+        Print report
+      </button>
+      <div>
+        <h1 className="text-3xl font-light text-black/85 first-letter:uppercase">{displayName}</h1>
+        <p className="mt-1 text-sm text-black/60">
+          Powered by Global Mangrove Watch &middot; globalmangrovewatch.org
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PrintHeader;

--- a/src/containers/print-report/print-legend.tsx
+++ b/src/containers/print-report/print-legend.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useMemo } from 'react';
+
+import { useSyncActiveLayers } from '@/store/layers';
+
+import { MAP_LEGENDS } from '@/containers/datasets';
+import { LAYERS } from '@/containers/layers/constants';
+
+const PrintLegend = () => {
+  const [activeLayers] = useSyncActiveLayers();
+
+  const legendItems = useMemo(() => {
+    if (!activeLayers?.length) return [];
+    return activeLayers
+      .filter((l) => !l.id.includes('planet') && l.id !== 'custom-area')
+      .map((l) => {
+        const legendKey = Object.keys(MAP_LEGENDS).find(
+          (k) =>
+            (l.id?.startsWith('mangrove_national_dashboard') && l.id?.includes(k)) || l.id === k
+        );
+        const LegendComponent = legendKey ? (MAP_LEGENDS[legendKey] as React.ElementType) : null;
+        const layerMeta = LAYERS.find((w) => w.id === l.id);
+        const title = l.id.includes('mangrove_national_dashboard_layer')
+          ? 'National Dashboard'
+          : layerMeta?.name;
+        if (!title && !l.id.includes('mangrove_national_dashboard_layer')) return null;
+        return { id: l.id, title, LegendComponent };
+      })
+      .filter(Boolean);
+  }, [activeLayers]);
+
+  if (!legendItems.length) return null;
+
+  return (
+    <div className="absolute right-4 bottom-4 z-50 max-w-72 rounded-2xl bg-white/90 p-4 shadow-md backdrop-blur-sm">
+      <h4 className="mb-2 text-xs font-bold tracking-wider text-black/85 uppercase">Legend</h4>
+      <div className="space-y-3">
+        {legendItems.map((item) => (
+          <div key={item.id}>
+            <p className="text-xs font-semibold tracking-wider text-black/85 uppercase">
+              {item.title}
+            </p>
+            {item.LegendComponent && (
+              <div className="pt-1 pl-1">
+                <item.LegendComponent />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default PrintLegend;

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -66,8 +66,7 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
         exit="expanded"
         transition={{ type: 'tween', duration: 0.6 }}
         className={cn({
-          'bg-blur group shadow-card isolate w-full rounded-4xl bg-white md:ml-0 print:w-[90%]!':
-            true,
+          'bg-blur group shadow-card isolate w-full rounded-4xl bg-white md:ml-0': true,
           'w-full! border-none p-0! shadow-none!': info,
           [className]: !!className,
           'border-none p-0': info,

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useMemo, FC } from 'react';
 
-import cn from '@/lib/classnames';
+import { usePathname, useSearchParams } from 'next/navigation';
 
 import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
-import { locationToolAtom } from '@/store/sidebar';
 import { useSyncActiveWidgets } from '@/store/widgets';
 
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom } from 'jotai';
 import { motion } from 'motion/react';
 import { useWindowSize } from 'usehooks-ts';
 
@@ -21,7 +20,6 @@ import { widgets, ANALYSIS_WIDGETS_SLUGS } from '@/containers/widgets/constants'
 
 import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { breakpoints } from '@/styles/styles.config';
-import { BUTTON_STYLES } from 'styles/widgets';
 import { WidgetTypes } from 'types/widget';
 
 import SETTINGS_SVG from '@/svgs/ui/settings';
@@ -85,13 +83,15 @@ const WidgetsContainer: FC = () => {
     );
   }, [activeWidgets, enabledWidgets, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
 
-  const locationTool = useAtomValue(locationToolAtom);
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  const onClickDownload = useCallback(() => {
-    setTimeout(() => {
-      window.print();
-    }, 2000);
-  }, []);
+  const handlePrintReport = useCallback(() => {
+    const qs = searchParams.toString();
+    const printPath = `/print-report${pathname === '/' ? '' : pathname}`;
+    const url = qs ? `${printPath}?${qs}` : printPath;
+    window.open(url, '_blank');
+  }, [pathname, searchParams]);
 
   return (
     <WidgetsLayout>
@@ -120,10 +120,7 @@ const WidgetsContainer: FC = () => {
       )}
 
       {screenWidth > 0 && screenWidth >= breakpoints.md && (
-        <div
-          data-testid="widgets-wrapper"
-          className="print:m-auto print:grid print:w-screen print:grid-cols-2 print:pr-24"
-        >
+        <div data-testid="widgets-wrapper">
           {widgetsAvailable.map(({ slug, name, ...props }) => {
             const Widget = WIDGETS[slug];
             return (
@@ -133,9 +130,6 @@ const WidgetsContainer: FC = () => {
                 id={slug}
                 applicability={props?.applicability}
                 contextualLayers={props?.contextualLayers}
-                className={cn({
-                  'print:min-w-135 print:scale-95 print:transform print:break-inside-avoid': true,
-                })}
               >
                 {WIDGETS[slug] && <Widget />}
               </WidgetWrapper>
@@ -158,7 +152,7 @@ const WidgetsContainer: FC = () => {
               whileHover="hover"
               animate="rest"
               // centers the button in the middle of the sidebar (sidebar width less the button width divided by 2)
-              className="fixed bottom-3 left-[calc((560px-48px)/2)] z-20 print:hidden"
+              className="fixed bottom-3 left-[calc((560px-48px)/2)] z-20"
             >
               <motion.button
                 className="bg-brand-800 shadow-control flex min-w-[48px] items-center space-x-4 rounded-full p-4 text-xs font-semibold text-white"
@@ -178,58 +172,17 @@ const WidgetsContainer: FC = () => {
         </Helper>
         <WidgetsDeckContent />
       </Dialog>
-      {/* <div className="flex w-full justify-center py-4 print:hidden">
-        <Helper
-          className={{
-            button:
-              locationTool === 'upload' || locationTool === 'area'
-                ? 'hidden'
-                : '-bottom-2.5 right-0',
-            tooltip: 'w-fit-content',
-          }}
-          tooltipPosition={{ top: 50, left: 10 }}
-          message="use this button to download the current map view and associated widgets as a pdf file"
-        >
+      {!!widgetsAvailable.length && (
+        <div className="flex w-full justify-center py-4">
           <button
-            className={cn({
-              [BUTTON_STYLES]: true,
-              'm-auto bg-brand-800 text-white': true,
-              // hidden: !customGeojson && !uploadedGeojson,
-            })}
-            // disabled={!customGeojson && !uploadedGeojson}
-            onClick={onClickDownload}
+            type="button"
+            className="bg-brand-800 hover:bg-brand-800/90 rounded-3xl px-6 py-2 text-sm font-semibold text-white transition-colors"
+            onClick={handlePrintReport}
           >
-            Download report as PDF
+            Print PDF report
           </button>
-        </Helper>
-      </div> */}
-      {!!widgets.length ? (
-        <div className="flex w-full justify-center py-4 print:hidden">
-          <Helper
-            className={{
-              button:
-                locationTool === 'upload' || locationTool === 'area'
-                  ? 'hidden'
-                  : 'right-0 -bottom-2.5',
-              tooltip: 'w-fit-content',
-            }}
-            tooltipPosition={{ top: 50, left: 10 }}
-            message="use this button to download the current map view and associated widgets as a pdf file"
-          >
-            <button
-              className={cn({
-                [BUTTON_STYLES]: true,
-                'bg-brand-800 m-auto text-white': true,
-                hidden: !customGeojson && !uploadedGeojson,
-              })}
-              disabled={!customGeojson && !uploadedGeojson}
-              onClick={onClickDownload}
-            >
-              Download report as PDF
-            </button>
-          </Helper>
         </div>
-      ) : null}
+      )}
     </WidgetsLayout>
   );
 };

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -3,9 +3,11 @@ import { useCallback, useMemo, FC } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 
 import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
+import { locationToolAtom } from '@/store/sidebar';
 import { useSyncActiveWidgets } from '@/store/widgets';
 
-import { useAtom } from 'jotai';
+import { useIsFetching } from '@tanstack/react-query';
+import { useAtom, useAtomValue } from 'jotai';
 import { motion } from 'motion/react';
 import { useWindowSize } from 'usehooks-ts';
 
@@ -19,6 +21,7 @@ import WidgetWrapper from '@/containers/widget';
 import { widgets, ANALYSIS_WIDGETS_SLUGS } from '@/containers/widgets/constants';
 
 import { Dialog, DialogTrigger } from '@/components/ui/dialog';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { breakpoints } from '@/styles/styles.config';
 import { WidgetTypes } from 'types/widget';
 
@@ -83,6 +86,10 @@ const WidgetsContainer: FC = () => {
     );
   }, [activeWidgets, enabledWidgets, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
 
+  const locationTool = useAtomValue(locationToolAtom);
+  const isCustomArea = !!(customGeojson || uploadedGeojson);
+  const fetchingCount = useIsFetching();
+  const isPrintDisabled = isCustomArea && fetchingCount > 0;
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
@@ -174,13 +181,33 @@ const WidgetsContainer: FC = () => {
       </Dialog>
       {!!widgetsAvailable.length && (
         <div className="flex w-full justify-center py-4">
-          <button
-            type="button"
-            className="bg-brand-800 hover:bg-brand-800/90 rounded-3xl px-6 py-2 text-sm font-semibold text-white transition-colors"
-            onClick={handlePrintReport}
+          <Helper
+            className={{
+              button:
+                locationTool === 'upload' || locationTool === 'area'
+                  ? 'hidden'
+                  : 'right-0 -bottom-2.5',
+              tooltip: 'w-fit-content',
+            }}
+            tooltipPosition={{ top: 50, left: 10 }}
+            message="Use this button to open the current map view and associated widgets as a printable PDF report."
           >
-            Print PDF report
-          </button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <button
+                    type="button"
+                    className="bg-brand-800 hover:bg-brand-800/90 rounded-3xl px-6 py-2 text-sm font-semibold text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={handlePrintReport}
+                    disabled={isPrintDisabled}
+                  >
+                    Print PDF report
+                  </button>
+                </span>
+              </TooltipTrigger>
+              {isPrintDisabled && <TooltipContent>Loading analysis data...</TooltipContent>}
+            </Tooltip>
+          </Helper>
         </div>
       )}
     </WidgetsLayout>

--- a/src/containers/widgets/widgets-cards-controls/expand-collapse-widgets/index.tsx
+++ b/src/containers/widgets/widgets-cards-controls/expand-collapse-widgets/index.tsx
@@ -48,7 +48,6 @@ const ExpandCollapseWidgets: FC = () => {
           'text-brand-800 shadow-control disabled:text-opacity-60 h-8 w-full rounded-4xl bg-white px-4 py-1 font-sans text-sm font-semibold transition-colors md:ml-0 md:w-[262px]':
             true,
           'bg-white': widgetsCollapsedChecker,
-          'print:hidden': screenWidth >= breakpoints.md,
         })}
         disabled={widgets.length <= 1}
         onClick={handleWidgetsCollapsed}

--- a/src/containers/widgets/widgets-cards-controls/index.tsx
+++ b/src/containers/widgets/widgets-cards-controls/index.tsx
@@ -15,7 +15,7 @@ const WidgetsCardsControls: FC = () => {
     <div className="py-1">
       <div
         className={cn({
-          'grid w-full grid-cols-2 justify-between gap-1 print:hidden': true,
+          'grid w-full grid-cols-2 justify-between gap-1': true,
           hidden: locationTool === 'area' || locationTool === 'upload',
         })}
       >

--- a/src/containers/widgets/widgets-cards-controls/widgets-deck/index.tsx
+++ b/src/containers/widgets/widgets-cards-controls/widgets-deck/index.tsx
@@ -43,7 +43,7 @@ const WidgetsDeck: FC = () => {
             type="button"
             data-testid="widgets-deck-trigger"
             className={cn({
-              'text-brand-800 shadow-control ml-1 flex h-8 w-full items-center justify-center rounded-4xl bg-white px-10 py-1 font-sans text-sm font-semibold transition-colors md:ml-0 md:w-[262px] print:hidden':
+              'text-brand-800 shadow-control ml-1 flex h-8 w-full items-center justify-center rounded-4xl bg-white px-10 py-1 font-sans text-sm font-semibold transition-colors md:ml-0 md:w-[262px]':
                 true,
             })}
           >

--- a/src/hooks/use-sync-location/index.ts
+++ b/src/hooks/use-sync-location/index.ts
@@ -23,6 +23,9 @@ const parse = (pathname: string): SyncedLocation => {
   if (path.startsWith('/embedded')) {
     path = path.slice('/embedded'.length) || '/';
   }
+  if (path.startsWith('/print-report')) {
+    path = path.slice('/print-report'.length) || '/';
+  }
   const [, segment, id] = path.split('/');
   if (!segment || !isLocationSegment(segment)) return { type: null, id: null };
   return { type: segment, id: id ?? null };

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -2,16 +2,6 @@ import { useCallback } from 'react';
 
 import { useMap } from 'react-map-gl';
 
-import cn from '@/lib/classnames';
-
-import { printModeState } from '@/store/print-mode';
-
-import { useAtomValue } from 'jotai';
-
-import { useSyncLocation } from 'hooks/use-sync-location';
-
-import { useLocation } from '@/containers/datasets/locations/hooks';
-import type { LocationTypes } from '@/containers/datasets/locations/types';
 import WelcomeIntroMessage from '@/containers/welcome-message';
 import WidgetsContainer from '@/containers/widgets';
 
@@ -19,13 +9,6 @@ import Logo from 'components/logo';
 
 const DesktopLayout = () => {
   const map = useMap();
-
-  const isPrintingMode = useAtomValue(printModeState);
-
-  const { type, id } = useSyncLocation();
-  const locationType = (type ?? 'worldwide') as LocationTypes;
-  const { data: locationData } = useLocation(id, locationType);
-  const location = locationData?.name;
 
   const handleReset = useCallback(() => {
     // `useMap()` returns a truthy MapCollection even before any <Map /> has
@@ -48,24 +31,6 @@ const DesktopLayout = () => {
       />
 
       <div className="relative h-screen w-screen">
-        {isPrintingMode && (
-          <div className="print:absolute print:top-6 print:z-50 print:text-black">
-            <h1
-              className={cn({
-                'm-auto w-screen text-center first-letter:uppercase': true,
-                'text-lg': (location?.length ?? 0) < 10,
-                'text-md': (location?.length ?? 0) > 10,
-              })}
-            >
-              {location}
-            </h1>
-
-            <p className="text-center">
-              Powered by Global Mangrove Watch. https://www.globalmangrovewatch.org
-            </p>
-          </div>
-        )}
-
         <WidgetsContainer />
 
         <WelcomeIntroMessage />

--- a/src/layouts/mobile/index.tsx
+++ b/src/layouts/mobile/index.tsx
@@ -28,7 +28,7 @@ const MobileLayout = () => {
   }, [map]);
 
   return (
-    <div className="pointer-events-none h-screen print:bg-transparent">
+    <div className="pointer-events-none h-screen">
       <Link className="pointer-events-auto fixed -top-1 left-0 z-10" href="/" onClick={handleReset}>
         <Image
           src="/images/mobile-header.svg"

--- a/src/layouts/widgets/index.tsx
+++ b/src/layouts/widgets/index.tsx
@@ -26,7 +26,7 @@ const WidgetsLayout = (props: PropsWithChildren) => {
           transition={{
             duration: 0.4,
           }}
-          className="scrollbar-hide pointer-events-auto left-0 h-full w-screen py-14 md:absolute md:top-0 md:w-[572px] md:overflow-y-auto md:bg-transparent md:px-4 print:bg-transparent print:px-0"
+          className="scrollbar-hide pointer-events-auto left-0 h-full w-screen py-14 md:absolute md:top-0 md:w-[572px] md:overflow-y-auto md:bg-transparent md:px-4"
         >
           <LocationWidget />
           {children}

--- a/src/store/print-mode/index.ts
+++ b/src/store/print-mode/index.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const printModeState = atom(false);

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -107,15 +107,6 @@
   display: none !important;
 }
 
-/* Print report page — force the map wrapper (normally absolute h-screen w-screen) to fill container */
-.print-report-map > div:first-of-type {
-  position: relative !important;
-  width: 100% !important;
-  height: 100% !important;
-  top: unset !important;
-  left: unset !important;
-}
-
 /* Hide mapbox built-in controls */
 .print-report-map .mapboxgl-ctrl-top-left,
 .print-report-map .mapboxgl-ctrl-top-right,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,16 +1,6 @@
 @config '../../tailwind.config.mjs';
 @import 'tailwindcss';
 
-body {
-  background-color: #00c5bd;
-}
-
-@media print {
-  body {
-    background-color: #fff;
-  }
-}
-
 @-webkit-keyframes autofill {
   0%,
   100% {
@@ -80,10 +70,6 @@ body {
   .scroll-thin::-webkit-scrollbar {
     width: 0.5rem;
   }
-
-  .print {
-    display: none;
-  }
 }
 .recharts-brush-texts {
   display: none;
@@ -121,15 +107,35 @@ body {
   display: none !important;
 }
 
+/* Print report page — force the map wrapper (normally absolute h-screen w-screen) to fill container */
+.print-report-map > div:first-of-type {
+  position: relative !important;
+  width: 100% !important;
+  height: 100% !important;
+  top: unset !important;
+  left: unset !important;
+}
+
+/* Hide mapbox built-in controls */
+.print-report-map .mapboxgl-ctrl-top-left,
+.print-report-map .mapboxgl-ctrl-top-right,
+.print-report-map .mapboxgl-ctrl-bottom-left,
+.print-report-map .mapboxgl-ctrl-bottom-right {
+  display: none !important;
+}
+
 @media print {
-  @page {
-    size: landscape;
+  .print-report {
+    background-color: #fff;
   }
 
-  body {
-    width: 260mm; /* A4 width in millimeters */
-    height: 210mm; /* A4 height in millimeters */
-    margin: 0 auto;
+  .print-report-no-print {
+    display: none;
+  }
+
+  @page {
+    size: A4 landscape;
+    margin: 10mm;
   }
 }
 

--- a/src/styles/mapbox.css
+++ b/src/styles/mapbox.css
@@ -650,11 +650,6 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
   border: 2px dotted #202020;
   opacity: 0.5;
 }
-@media print {
-  .mapbox-improve-map {
-    display: none;
-  }
-}
 
 .mapboxgl-ctrl-attrib-inner {
   position: absolute !important;
@@ -676,8 +671,5 @@ a.mapboxgl-ctrl-logo.mapboxgl-compact {
   :nth-child(4),
   :nth-child(5) {
     visibility: visible;
-    @media print {
-      display: none;
-    }
   }
 }

--- a/src/styles/widgets.js
+++ b/src/styles/widgets.js
@@ -4,6 +4,6 @@ export const WIDGET_SENTENCE_STYLE =
 export const WIDGET_SUBTITLE_STYLE = 'm-0 text-xs font-semibold tracking-[0.0625rem] uppercase';
 export const BUTTON_STYLES = 'rounded-3xl py-1 px-4 text-sm font-semibold';
 export const WIDGET_SELECT_STYLES =
-  'first-line:after relative cursor-pointer border-b-2 border-b-brand-800 font-bold print:border-b-transparent';
+  'first-line:after relative cursor-pointer border-b-2 border-b-brand-800 font-bold';
 export const WIDGET_SELECT_ARROW_STYLES =
   'absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2';


### PR DESCRIPTION
This pull request introduces a new print report feature and refines print styling and behavior across the application. It adds a dedicated print report layout and page, adjusts widget and component styles to improve print output, and ensures that print-specific UI elements are handled consistently. The most important changes are outlined below.

**Print Report Feature:**

* Added a new `print-report` layout and page, including a custom header, legend, and logo, and implemented data prefetching and validation for allowed location types. (`src/app/print-report/[[...params]]/layout.tsx`, `src/app/print-report/[[...params]]/page.tsx`) ([src/app/print-report/[[...params]]/layout.tsxR1-R25](diffhunk://#diff-822a5eb0ce3732206d5bcdbe59e6bf5f0951f114135c2599d4c38ac722a9675aR1-R25), [src/app/print-report/[[...params]]/page.tsxR1-R55](diffhunk://#diff-14dae9b02a81854c0528f2b260e2f1b5bba42df49333f978bbe081f7aa6331feR1-R55))

**Widget and Component Print Styling:**

* Removed most `print:hidden` and `print:border-hidden` classes from widget controls, popover triggers, and arrow icons to ensure these elements are visible in print mode. This affects many widgets, including alerts, carbon market potential, fisheries, flood protection, habitat change, habitat extent, mangroves in protected areas, and customize widgets deck. (`src/containers/datasets/*/widget.tsx`, `src/components/widget-controls/index.tsx`) [[1]](diffhunk://#diff-7a91ad9dec84894659dfd5ca99000c03a5bcef5929ed4e067fba2497aca1326dL112-R115) [[2]](diffhunk://#diff-7a91ad9dec84894659dfd5ca99000c03a5bcef5929ed4e067fba2497aca1326dL156-R159) [[3]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95L125-R128) [[4]](diffhunk://#diff-838d5a5c2b31b6508b2e99a7d1d8d4bc716b67c7783bfe345c0566e95fe4aa95L169-R172) [[5]](diffhunk://#diff-41876d32ce3ce8ffcf0f6183a0f30dd13c9312269ea2faa61cc0193b043d659cL53-R56) [[6]](diffhunk://#diff-41876d32ce3ce8ffcf0f6183a0f30dd13c9312269ea2faa61cc0193b043d659cL96-R99) [[7]](diffhunk://#diff-c9eb9b5017b946a0b89b12a72ca2a2ea2676fa8dbe95439783d2649d39097914L63-R66) [[8]](diffhunk://#diff-c07a90d1c4519bbf083f459b90f4c4bdc2caa224d90a932336ae43c70b3296cbL132-R132) [[9]](diffhunk://#diff-38269f781dbbcf41763e9650698aeec3aa8399a6ef5512d0d81e13477eb17971L187-R190) [[10]](diffhunk://#diff-acee15b594b1e6980cb18a64c0c432301c866bb8976eab00e3bb7e09f8c97ac5L75-R79) [[11]](diffhunk://#diff-acee15b594b1e6980cb18a64c0c432301c866bb8976eab00e3bb7e09f8c97ac5L124-R127) [[12]](diffhunk://#diff-acee15b594b1e6980cb18a64c0c432301c866bb8976eab00e3bb7e09f8c97ac5L183-R183) [[13]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74L130-R133) [[14]](diffhunk://#diff-76f0a7defc360bb3650ea7b2822c63e738b3b37cc9ccd8bdb5e62f1074d89a74L165-R168) [[15]](diffhunk://#diff-e28153cefc76c9932bd6570b01d794b1cb2836a61e7d2c3f66fdac30018f98c9L7-R7) [[16]](diffhunk://#diff-29d5055c20f20714079fd234209465c1dcd7dbd6459d225cbe7e0a51c0f70844L49-R52) [[17]](diffhunk://#diff-29d5055c20f20714079fd234209465c1dcd7dbd6459d225cbe7e0a51c0f70844L92-R95) [[18]](diffhunk://#diff-c5a24c61d85f920d01738b68d7b49a8602a54a3b4aabef7d8abd3b9f0ffef5d4L28-R28)

* Updated background color for print mode to white and removed print-specific overflow and scaling styles from main layouts and charts. (`src/app/layout.tsx`, `src/app/[[...params]]/layout.tsx`, `src/containers/datasets/habitat-change/widget.tsx`, `src/containers/datasets/height/chart.tsx`) [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L49-R49) [src/app/[[...params]]/layout.tsxL8-R8](diffhunk://#diff-ecf3aed46e0014b71d55baa17d760379aa243ae85abb0223a81e11616a7f6006L8-R8), [[2]](diffhunk://#diff-acee15b594b1e6980cb18a64c0c432301c866bb8976eab00e3bb7e09f8c97ac5L183-R183) [[3]](diffhunk://#diff-e28153cefc76c9932bd6570b01d794b1cb2836a61e7d2c3f66fdac30018f98c9L7-R7)

**Contextual Layers Print Logic:**

* Modified `ContextualLayersComponent` to only render active layers in print report mode and to hide layer controls when printing. (`src/components/contextual-layers/index.tsx`) [[1]](diffhunk://#diff-33d11d9704b3595f1ba4ec5ee4ccb618267d560feeaa83f259016c88ba08869dL1-R5) [[2]](diffhunk://#diff-33d11d9704b3595f1ba4ec5ee4ccb618267d560feeaa83f259016c88ba08869dR29-R35) [[3]](diffhunk://#diff-33d11d9704b3595f1ba4ec5ee4ccb618267d560feeaa83f259016c88ba08869dL35-R46)

**Documentation:**

* Updated documentation to remove outdated references to print mode and print-specific Tailwind variants. (`CLAUDE.md`)