### PR TITLE
refactor: extract locationQueryOptions to deduplicate server prefetch

### DIFF
--- a/src/app/[[...params]]/page.tsx
+++ b/src/app/[[...params]]/page.tsx
@@ -4,7 +4,7 @@ import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query
 import turfBbox from '@turf/bbox';
 import type { Metadata } from 'next';
 
-import type { DataResponse } from '@/containers/datasets/locations/hooks';
+import { locationQueryOptions, type DataResponse } from '@/containers/datasets/locations/hooks';
 import MainApp from '@/containers/main-app';
 
 const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
@@ -34,17 +34,7 @@ export default async function Page({ params }: { params: Promise<{ params?: stri
 
   if (locationId) {
     try {
-      await queryClient.prefetchQuery({
-        queryKey: ['location', locationType, locationId],
-        queryFn: async () => {
-          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/locations/${locationId}`, {
-            headers: { 'Content-Type': 'application/json' },
-          });
-          if (!res.ok) throw new Error(`Location fetch failed: ${res.status}`);
-          const json = await res.json();
-          return { data: json.data } as { data: DataResponse['data'][0] };
-        },
-      });
+      await queryClient.prefetchQuery(locationQueryOptions(locationType, locationId));
 
       const cached = queryClient.getQueryData<{ data: DataResponse['data'][0] }>([
         'location',

--- a/src/app/embedded/[[...params]]/page.tsx
+++ b/src/app/embedded/[[...params]]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from 'next/navigation';
 import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
 
-import type { DataResponse } from '@/containers/datasets/locations/hooks';
+import { locationQueryOptions, type DataResponse } from '@/containers/datasets/locations/hooks';
 import EmbeddedWrapper from '@/containers/embedded/wrapper';
 
 const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
@@ -21,17 +21,7 @@ export default async function EmbeddedPage({ params }: { params: Promise<{ param
 
   if (locationId) {
     try {
-      await queryClient.prefetchQuery({
-        queryKey: ['location', locationType, locationId],
-        queryFn: async () => {
-          const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/locations/${locationId}`, {
-            headers: { 'Content-Type': 'application/json' },
-          });
-          if (!res.ok) throw new Error(`Location fetch failed: ${res.status}`);
-          const json = await res.json();
-          return { data: json.data } as { data: DataResponse['data'][0] };
-        },
-      });
+      await queryClient.prefetchQuery(locationQueryOptions(locationType, locationId));
 
       const cached = queryClient.getQueryData<{ data: DataResponse['data'][0] }>([
         'location',

--- a/src/containers/datasets/locations/hooks.tsx
+++ b/src/containers/datasets/locations/hooks.tsx
@@ -1,4 +1,9 @@
-import { useQuery, UseQueryOptions, useQueryClient } from '@tanstack/react-query';
+import {
+  queryOptions as rqQueryOptions,
+  useQuery,
+  UseQueryOptions,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import API from 'services/api';
 
@@ -8,6 +13,23 @@ export type DataResponse = {
   data: Location[];
   metadata: unknown;
 };
+
+/**
+ * Server-safe queryOptions for prefetching a single location (uses `fetch`, not Axios).
+ */
+export function locationQueryOptions(locationType?: string, locationId?: string) {
+  return rqQueryOptions({
+    queryKey: ['location', locationType, locationId],
+    queryFn: async () => {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/locations/${locationId}`, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) throw new Error(`Location fetch failed: ${res.status}`);
+      const json = await res.json();
+      return { data: json.data } as { data: DataResponse['data'][0] };
+    },
+  });
+}
 
 const fetchLocations = () =>
   API.request<DataResponse>({


### PR DESCRIPTION
This pull request refactors how location data is prefetched and queried in both the main and embedded pages by introducing a reusable, server-safe query options function. The changes centralize the location fetching logic and improve code maintainability.

**Refactoring and centralization of location data fetching:**

* Introduced a new `locationQueryOptions` function in `hooks.tsx` that encapsulates server-safe query options for fetching a single location using `fetch` instead of Axios. This function is now used for all server-side location prefetching.
* Updated both `page.tsx` and `embedded/page.tsx` to use the new `locationQueryOptions` function for location data prefetching, replacing the previous inline query option objects and fetch logic. ([src/app/[[...params]]/page.tsxL37-R37](diffhunk://#diff-b91ef0acbc51b1f41c408df4b50daac8f759b326cb9cc8415c99f7de3fbeafc3L37-R37), [src/app/embedded/[[...params]]/page.tsxL24-R24](diffhunk://#diff-c3ba0d06fdfd76eed7dabb79438676ec06a9fa14e3ddb15c96c5b169a785520eL24-R24))

**Imports and dependency updates:**

* Modified imports in `page.tsx`, `embedded/page.tsx`, and `hooks.tsx` to include the new `locationQueryOptions` and to import `queryOptions` as `rqQueryOptions` from `@tanstack/react-query`. ([src/app/[[...params]]/page.tsxL7-R7](diffhunk://#diff-b91ef0acbc51b1f41c408df4b50daac8f759b326cb9cc8415c99f7de3fbeafc3L7-R7), [src/app/embedded/[[...params]]/page.tsxL6-R6](diffhunk://#diff-c3ba0d06fdfd76eed7dabb79438676ec06a9fa14e3ddb15c96c5b169a785520eL6-R6), [src/containers/datasets/locations/hooks.tsxL1-R6](diffhunk://#diff-819d03664543fe67d2fea1e9637a4d43eca5690d7ed18a22548184e2c7155e43L1-R6))