### PR TITLE
fix: remove duplicated monitored areas text from alerts widget

### DIFF
--- a/src/containers/datasets/alerts-staging/widget.tsx
+++ b/src/containers/datasets/alerts-staging/widget.tsx
@@ -254,10 +254,6 @@ const AlertsWidget = () => {
               <p className="text-sm font-normal">Monitored area</p>
             </div>
           </div>
-
-          <p className="items-center pt-6 font-sans text-lg leading-7 font-light">
-            There are <span className="font-bold"> 535</span> areas monitored in the world.
-          </p>
         </>
       )}
     </div>


### PR DESCRIPTION
This pull request makes a minor change to the `AlertsWidget` component by removing a paragraph that displayed the total number of monitored areas. This simplifies the widget's UI and removes the hardcoded information.