### PR TITLE
feat: timeline slider for habitat extent widget

### DIFF
--- a/src/components/ui/slider/index.tsx
+++ b/src/components/ui/slider/index.tsx
@@ -4,33 +4,70 @@ import cn from '@/lib/classnames';
 
 import * as SliderPrimitive from '@radix-ui/react-slider';
 
-const Slider = ({ defaultValue, max = 1, step = 0.1, onValueChange, className }) => {
+type SliderProps = {
+  className?: string;
+  trackClassName?: string;
+  rangeClassName?: string;
+  thumbClassName?: string;
+  defaultValue?: number[];
+  value?: number[];
+  min?: number;
+  max?: number;
+  step?: number;
+  showValueLabel?: boolean;
+  onValueChange?: (value: number[]) => void;
+};
+
+const Slider = ({
+  defaultValue,
+  value,
+  min = 0,
+  max = 1,
+  step = 0.1,
+  showValueLabel = true,
+  onValueChange,
+  className,
+  trackClassName,
+  rangeClassName,
+  thumbClassName,
+}: SliderProps) => {
   const [currentValue, setCurrentValue] = useState(defaultValue);
+  const displayValue = value ?? currentValue;
 
   return (
-    <>
-      <SliderPrimitive.Root
-        className={cn({
-          'relative flex h-4 w-full touch-none items-center select-none': true,
-          [className]: !!className,
-        })}
-        defaultValue={defaultValue}
-        max={max}
-        step={step}
-        onValueChange={(value) => {
-          onValueChange(value);
-          setCurrentValue(value);
-        }}
+    <SliderPrimitive.Root
+      className={cn('relative flex h-4 w-full touch-none items-center select-none', className)}
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      step={step}
+      onValueChange={(val) => {
+        onValueChange?.(val);
+        if (value === undefined) {
+          setCurrentValue(val);
+        }
+      }}
+    >
+      <SliderPrimitive.Track
+        className={cn('relative h-[3px] grow rounded-full bg-black/30', trackClassName)}
       >
-        <SliderPrimitive.Track className="relative h-[3px] grow rounded-full bg-black/30">
-          <SliderPrimitive.Range className="absolute h-full rounded-full bg-black" />
-        </SliderPrimitive.Track>
+        <SliderPrimitive.Range
+          className={cn('absolute h-full rounded-full bg-black', rangeClassName)}
+        />
+      </SliderPrimitive.Track>
 
-        <SliderPrimitive.Thumb className="relative block h-3 w-3 cursor-pointer rounded-[10px] border border-white bg-black focus:outline-none">
-          <p className="absolute bottom-3 text-xs text-black/40">{currentValue}</p>
-        </SliderPrimitive.Thumb>
-      </SliderPrimitive.Root>
-    </>
+      <SliderPrimitive.Thumb
+        className={cn(
+          'relative block h-3 w-3 cursor-pointer rounded-[10px] border border-white bg-black focus:outline-none',
+          thumbClassName
+        )}
+      >
+        {showValueLabel && (
+          <p className="absolute bottom-3 text-xs text-black/40">{displayValue}</p>
+        )}
+      </SliderPrimitive.Thumb>
+    </SliderPrimitive.Root>
   );
 };
 

--- a/src/components/ui/slider/index.tsx
+++ b/src/components/ui/slider/index.tsx
@@ -15,6 +15,8 @@ type SliderProps = {
   max?: number;
   step?: number;
   showValueLabel?: boolean;
+  thumbAriaLabel?: string;
+  thumbAriaValueText?: string;
   onValueChange?: (value: number[]) => void;
 };
 
@@ -25,6 +27,8 @@ const Slider = ({
   max = 1,
   step = 0.1,
   showValueLabel = true,
+  thumbAriaLabel,
+  thumbAriaValueText,
   onValueChange,
   className,
   trackClassName,
@@ -58,8 +62,10 @@ const Slider = ({
       </SliderPrimitive.Track>
 
       <SliderPrimitive.Thumb
+        aria-label={thumbAriaLabel}
+        aria-valuetext={thumbAriaValueText}
         className={cn(
-          'relative block h-3 w-3 cursor-pointer rounded-[10px] border border-white bg-black focus:outline-none',
+          'focus-visible:ring-ring relative block h-3 w-3 cursor-pointer rounded-[10px] border border-white bg-black focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
           thumbClassName
         )}
       >

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -34,14 +34,15 @@ const TimelineSlider = ({
     <div className="flex items-center gap-3">
       <button
         aria-label={isPlaying ? 'Pause' : 'Play'}
+        aria-pressed={isPlaying}
         type="button"
         onClick={onTogglePlay}
-        className="bg-brand-800 hover:bg-brand-800/80 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white transition-colors"
+        className="bg-brand-800 hover:bg-brand-800/80 focus-visible:ring-ring flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         {isPlaying ? (
-          <PauseIcon className="h-3.5 w-3.5" />
+          <PauseIcon aria-hidden="true" className="h-3.5 w-3.5" />
         ) : (
-          <PlayIcon className="ml-0.5 h-3.5 w-3.5" />
+          <PlayIcon aria-hidden="true" className="ml-0.5 h-3.5 w-3.5" />
         )}
       </button>
 
@@ -53,12 +54,14 @@ const TimelineSlider = ({
           value={[value]}
           onValueChange={handleValueChange}
           showValueLabel={false}
+          thumbAriaLabel="Year"
+          thumbAriaValueText={String(currentYear)}
           trackClassName="bg-black/20"
           rangeClassName="bg-brand-800"
           thumbClassName="h-3.5 w-3.5 bg-brand-800 rounded-full border-2 shadow"
         />
 
-        <div className="relative mt-0.5 flex w-full justify-between px-0">
+        <div aria-hidden="true" className="relative mt-0.5 flex w-full justify-between px-0">
           {years.map((y, i) => (
             <span
               key={y}

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -1,0 +1,86 @@
+import cn from '@/lib/classnames';
+
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import { LuPause, LuPlay } from 'react-icons/lu';
+
+const PauseIcon = LuPause as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
+const PlayIcon = LuPlay as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
+
+type TimelineSliderProps = {
+  years: number[];
+  currentYear: number;
+  isPlaying: boolean;
+  onYearChange: (year: number) => void;
+  onTogglePlay: () => void;
+};
+
+const TimelineSlider = ({
+  years,
+  currentYear,
+  isPlaying,
+  onYearChange,
+  onTogglePlay,
+}: TimelineSliderProps) => {
+  const currentIndex = years.indexOf(currentYear);
+  const value = currentIndex >= 0 ? currentIndex : years.length - 1;
+
+  const handleValueChange = ([index]: number[]) => {
+    if (isPlaying) onTogglePlay();
+    onYearChange(years[index]);
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <button
+        aria-label={isPlaying ? 'Pause' : 'Play'}
+        type="button"
+        onClick={onTogglePlay}
+        className="bg-brand-800 hover:bg-brand-800/80 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white transition-colors"
+      >
+        {isPlaying ? (
+          <PauseIcon className="h-3.5 w-3.5" />
+        ) : (
+          <PlayIcon className="ml-0.5 h-3.5 w-3.5" />
+        )}
+      </button>
+
+      <div className="relative flex w-full flex-col">
+        <SliderPrimitive.Root
+          className="relative flex h-4 w-full touch-none items-center select-none"
+          min={0}
+          max={years.length - 1}
+          step={1}
+          value={[value]}
+          onValueChange={handleValueChange}
+        >
+          <SliderPrimitive.Track className="relative h-[3px] grow rounded-full bg-black/20">
+            <SliderPrimitive.Range className="bg-brand-800 absolute h-full rounded-full" />
+          </SliderPrimitive.Track>
+
+          <SliderPrimitive.Thumb className="bg-brand-800 block h-3.5 w-3.5 cursor-pointer rounded-full border-2 border-white shadow focus:outline-none" />
+        </SliderPrimitive.Root>
+
+        <div className="relative mt-0.5 flex w-full justify-between px-0">
+          {years.map((y, i) => (
+            <span
+              key={y}
+              className={cn(
+                'text-[10px] leading-none',
+                y === currentYear ? 'text-brand-800 font-semibold' : 'text-black/40'
+              )}
+              style={{
+                position: 'absolute',
+                left: `${(i / (years.length - 1)) * 100}%`,
+                transform: 'translateX(-50%)',
+              }}
+            >
+              {y}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimelineSlider;

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -1,7 +1,8 @@
 import cn from '@/lib/classnames';
 
-import * as SliderPrimitive from '@radix-ui/react-slider';
 import { LuPause, LuPlay } from 'react-icons/lu';
+
+import Slider from '@/components/ui/slider';
 
 const PauseIcon = LuPause as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
 const PlayIcon = LuPlay as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
@@ -45,20 +46,17 @@ const TimelineSlider = ({
       </button>
 
       <div className="relative flex w-full flex-col">
-        <SliderPrimitive.Root
-          className="relative flex h-4 w-full touch-none items-center select-none"
+        <Slider
           min={0}
           max={years.length - 1}
           step={1}
           value={[value]}
           onValueChange={handleValueChange}
-        >
-          <SliderPrimitive.Track className="relative h-[3px] grow rounded-full bg-black/20">
-            <SliderPrimitive.Range className="bg-brand-800 absolute h-full rounded-full" />
-          </SliderPrimitive.Track>
-
-          <SliderPrimitive.Thumb className="bg-brand-800 block h-3.5 w-3.5 cursor-pointer rounded-full border-2 border-white shadow focus:outline-none" />
-        </SliderPrimitive.Root>
+          showValueLabel={false}
+          trackClassName="bg-black/20"
+          rangeClassName="bg-brand-800"
+          thumbClassName="h-3.5 w-3.5 bg-brand-800 rounded-full border-2 shadow"
+        />
 
         <div className="relative mt-0.5 flex w-full justify-between px-0">
           {years.map((y, i) => (

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -2,8 +2,6 @@ import cn from '@/lib/classnames';
 
 import { LuPause, LuPlay } from 'react-icons/lu';
 
-import Slider from '@/components/ui/slider';
-
 const PauseIcon = LuPause as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
 const PlayIcon = LuPlay as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
 
@@ -22,14 +20,8 @@ const TimelineSlider = ({
   onYearChange,
   onTogglePlay,
 }: TimelineSliderProps) => {
-  const currentIndex = years.indexOf(currentYear);
-  const value = currentIndex >= 0 ? currentIndex : years.length - 1;
-
-  const handleValueChange = ([index]: number[]) => {
-    if (isPlaying) onTogglePlay();
-    onYearChange(years[index]);
-  };
-
+  const currentIndex = Math.max(0, years.indexOf(currentYear));
+  const dotPct = years.length > 1 ? (currentIndex / (years.length - 1)) * 100 : 0;
   return (
     <div className="flex items-center gap-3">
       <button
@@ -37,7 +29,7 @@ const TimelineSlider = ({
         aria-pressed={isPlaying}
         type="button"
         onClick={onTogglePlay}
-        className="bg-brand-800 hover:bg-brand-800/80 focus-visible:ring-ring flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        className="border-brand-800 text-brand-800 hover:bg-brand-800/10 focus-visible:ring-ring flex h-[30px] w-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         {isPlaying ? (
           <PauseIcon aria-hidden="true" className="h-3.5 w-3.5" />
@@ -46,38 +38,78 @@ const TimelineSlider = ({
         )}
       </button>
 
-      <div className="relative flex w-full flex-col">
-        <Slider
-          min={0}
-          max={years.length - 1}
-          step={1}
-          value={[value]}
-          onValueChange={handleValueChange}
-          showValueLabel={false}
-          thumbAriaLabel="Year"
-          thumbAriaValueText={String(currentYear)}
-          trackClassName="bg-black/20"
-          rangeClassName="bg-brand-800"
-          thumbClassName="h-3.5 w-3.5 bg-brand-800 rounded-full border-2 shadow"
-        />
+      <div className="relative flex-1">
+        <div className="relative h-4">
+          {years.map((y, i) => {
+            const isCurrent = y === currentYear;
+            return (
+              <button
+                key={y}
+                type="button"
+                aria-label={`Select year ${y}`}
+                aria-current={isCurrent ? 'true' : undefined}
+                onClick={() => {
+                  if (isPlaying) onTogglePlay();
+                  onYearChange(y);
+                }}
+                style={{
+                  left: `calc(12px + (100% - 24px) * ${i / Math.max(1, years.length - 1)})`,
+                }}
+                className="absolute top-1/2 flex h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center focus-visible:outline-none"
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'block h-1.5 w-px',
+                    isCurrent ? 'bg-brand-800 w-0.5' : 'bg-black/56'
+                  )}
+                />
+              </button>
+            );
+          })}
+          <svg
+            aria-hidden="true"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="pointer-events-none absolute top-2.5 -translate-x-1/2 -translate-y-[calc(50%+10px)] transition-[left] duration-150 ease-out"
+            style={{ left: `calc(12px + (100% - 24px) * ${dotPct / 100})` }}
+          >
+            <path d="M0 0H12V6L6 12L0 6V0Z" fill="#00857F" />
+          </svg>
+        </div>
 
-        <div aria-hidden="true" className="relative mt-0.5 flex w-full justify-between px-0">
-          {years.map((y, i) => (
-            <span
-              key={y}
-              className={cn(
-                'text-[10px] leading-none',
-                y === currentYear ? 'text-brand-800 font-semibold' : 'text-black/40'
-              )}
-              style={{
-                position: 'absolute',
-                left: `${(i / (years.length - 1)) * 100}%`,
-                transform: 'translateX(-50%)',
-              }}
-            >
-              {y}
-            </span>
-          ))}
+        <div className="relative mt-1 flex w-full justify-between">
+          {years.map((y, i) => {
+            const isCurrent = y === currentYear;
+            return (
+              <button
+                key={y}
+                type="button"
+                aria-label={`Select year ${y}`}
+                aria-current={isCurrent ? 'true' : undefined}
+                onClick={() => {
+                  if (isPlaying) onTogglePlay();
+                  onYearChange(y);
+                }}
+                style={{
+                  position: 'absolute',
+                  left: `calc(12px + (100% - 24px) * ${i / Math.max(1, years.length - 1)})`,
+                  transform: 'translateX(-50%)',
+                }}
+                className={cn(
+                  'cursor-pointer text-[12px] leading-5 whitespace-nowrap focus-visible:outline-none',
+                  isCurrent
+                    ? 'text-brand-800 font-bold'
+                    : 'font-normal text-black/56 hover:text-black/80'
+                )}
+              >
+                {y}
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/components/ui/timeline/index.tsx
+++ b/src/components/ui/timeline/index.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import cn from '@/lib/classnames';
+
+import PauseIcon from '@/svgs/ui/pause';
+import PlayIcon from '@/svgs/ui/play';
+
+const APPROX_LABEL_WIDTH = 32;
+
+type TimelineProps = {
+  years: number[];
+  currentYear: number;
+  isPlaying: boolean;
+  onYearChange: (year: number) => void;
+  onTogglePlay: () => void;
+};
+
+const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }: TimelineProps) => {
+  const currentIndex = Math.max(0, years.indexOf(currentYear));
+  const dotPct = years.length > 1 ? (currentIndex / (years.length - 1)) * 100 : 0;
+
+  const trackRef = useRef<HTMLDivElement>(null);
+  const tickRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [trackWidth, setTrackWidth] = useState(0);
+
+  useEffect(() => {
+    const el = trackRef.current;
+    if (!el) return;
+    setTrackWidth(el.offsetWidth);
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(([entry]) => {
+      setTrackWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const labelIndices = useMemo(() => {
+    const set = new Set<number>();
+    if (!years.length) return set;
+    if (years.length === 1) {
+      set.add(0);
+      return set;
+    }
+    const widthBudget = trackWidth || years.length * APPROX_LABEL_WIDTH;
+    const maxLabels = Math.max(2, Math.floor(widthBudget / APPROX_LABEL_WIDTH));
+    if (maxLabels >= years.length) {
+      for (let i = 0; i < years.length; i++) set.add(i);
+      return set;
+    }
+    const numGaps = maxLabels - 1;
+    const totalDist = years.length - 1;
+    const baseStep = Math.floor(totalDist / numGaps);
+    const remainder = totalDist - baseStep * numGaps;
+    let pos = 0;
+    set.add(pos);
+    for (let i = 0; i < numGaps; i++) {
+      const extra =
+        Math.floor(((i + 1) * remainder) / numGaps) - Math.floor((i * remainder) / numGaps);
+      pos += baseStep + extra;
+      set.add(pos);
+    }
+    return set;
+  }, [trackWidth, years.length]);
+
+  const goToIndex = useCallback(
+    (idx: number, { focus = false }: { focus?: boolean } = {}) => {
+      const clamped = Math.min(Math.max(idx, 0), years.length - 1);
+      if (years[clamped] === currentYear) return;
+      if (isPlaying) onTogglePlay();
+      onYearChange(years[clamped]);
+      if (focus) {
+        requestAnimationFrame(() => tickRefs.current[clamped]?.focus());
+      }
+    },
+    [years, currentYear, isPlaying, onTogglePlay, onYearChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLButtonElement>, i: number) => {
+      let nextIdx = i;
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          nextIdx = i + 1;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          nextIdx = i - 1;
+          break;
+        case 'Home':
+          nextIdx = 0;
+          break;
+        case 'End':
+          nextIdx = years.length - 1;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      goToIndex(nextIdx, { focus: true });
+    },
+    [goToIndex, years.length]
+  );
+
+  return (
+    <div className="flex items-start gap-3" role="group" aria-label="Year timeline">
+      <button
+        aria-label={isPlaying ? 'Pause timeline' : 'Play timeline'}
+        aria-pressed={isPlaying}
+        type="button"
+        onClick={onTogglePlay}
+        className="border-brand-800/20 text-brand-800 hover:bg-brand-800/10 focus-visible:ring-brand-800 flex h-[30px] w-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full border-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none motion-safe:transition-colors"
+      >
+        {isPlaying ? (
+          <PauseIcon aria-hidden="true" className="h-3 w-3" />
+        ) : (
+          <PlayIcon aria-hidden="true" className="ml-0.5 h-3 w-3" />
+        )}
+      </button>
+
+      <div ref={trackRef} className="relative flex-1">
+        <div className="relative mt-2 h-10">
+          {years.map((y, i) => {
+            const isCurrent = y === currentYear;
+            const showLabel = labelIndices.has(i);
+            return (
+              <button
+                key={y}
+                ref={(el) => {
+                  tickRefs.current[i] = el;
+                }}
+                type="button"
+                aria-label={`Year ${y}`}
+                aria-current={isCurrent ? 'true' : undefined}
+                tabIndex={isCurrent ? 0 : -1}
+                onClick={() => goToIndex(i)}
+                onKeyDown={(e) => handleKeyDown(e, i)}
+                style={{
+                  left: `calc(12px + (100% - 24px) * ${i / Math.max(1, years.length - 1)})`,
+                }}
+                className="focus-visible:ring-brand-800 absolute top-0 flex h-10 -translate-x-1/2 cursor-pointer flex-col items-center justify-start gap-1 rounded-sm focus-visible:ring-2 focus-visible:outline-none"
+              >
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'block',
+                    isCurrent ? 'bg-brand-800 h-1.5 w-0.5 translate-y-1' : 'h-1.5 w-px bg-black/56'
+                  )}
+                />
+                {showLabel && (
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'text-[12px] leading-5',
+                      isCurrent ? 'text-brand-800 font-bold' : 'font-normal text-black/56'
+                    )}
+                  >
+                    {y}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+          <svg
+            aria-hidden="true"
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="pointer-events-none absolute -top-1.75 -translate-x-1/2 motion-safe:transition-[left] motion-safe:duration-150 motion-safe:ease-out"
+            style={{ left: `calc(12px + (100% - 24px) * ${dotPct / 100})` }}
+          >
+            <path d="M0 0H12V6L6 12L0 6V0Z" fill="#00857F" />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Timeline;

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -243,6 +243,7 @@ export function useLayers({
           paint: {
             'fill-color': '#06C4BD',
             'fill-opacity': ['interpolate', ['linear'], ['zoom'], 0, opacity * 1.2, 12, opacity],
+            'fill-opacity-transition': { duration: 600, delay: 0 },
           },
           layout: {
             visibility,
@@ -258,6 +259,7 @@ export function useLayers({
             'line-opacity': opacity,
             'line-width': ['interpolate', ['linear'], ['zoom'], 0, 8, 12, 1],
             'line-blur': ['interpolate', ['linear'], ['zoom'], 0, 50, 12, 0],
+            'line-opacity-transition': { duration: 600, delay: 0 },
           },
           layout: {
             visibility,

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -1,37 +1,106 @@
+import { useEffect, useMemo, useState } from 'react';
+
 import { Source, Layer } from 'react-map-gl';
 
 import { useSyncActiveLayers } from '@/store/layers';
 import { habitatExtentSettings } from '@/store/widgets/habitat-extent';
 
 import { useAtomValue } from 'jotai';
+import type { ExpressionSpecification } from 'mapbox-gl';
 
 import type { LayerProps } from 'types/layers';
 
-import { useLayers, useSource, useMangroveHabitatExtent } from './hooks';
+import { useMangroveHabitatExtent } from './hooks';
+
+const DEFAULT_transitionMs = 600;
+
+const usePrefersReducedMotion = () => {
+  const [reduced, setReduced] = useState(() =>
+    typeof window !== 'undefined' && window.matchMedia
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      : false
+  );
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return reduced;
+};
 
 const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
   const year = useAtomValue(habitatExtentSettings) as number | null;
   const { data } = useMangroveHabitatExtent({ year });
-  const years = data?.years?.sort() || [];
+  const years = useMemo(
+    () => (data?.years?.slice().sort((a, b) => a - b) || []) as number[],
+    [data?.years]
+  );
 
   const currentYear = year || years[years.length - 1];
+  const baseOpacity = parseFloat(activeLayer?.opacity ?? '1');
+  const visibility = activeLayer?.visibility ?? 'visible';
 
-  const SOURCE = useSource({ year: currentYear });
-  const LAYERS = useLayers({
-    year: currentYear,
-    id,
-    opacity: parseFloat(activeLayer?.opacity ?? '1'),
-    visibility: activeLayer?.visibility ?? 'visible',
-  });
-  if (!SOURCE || !LAYERS) return null;
+  const reducedMotion = usePrefersReducedMotion();
+  const transitionMs = reducedMotion ? 0 : DEFAULT_transitionMs;
+
+  if (!years.length || !currentYear) return null;
+
   return (
-    <Source key={SOURCE.id} {...SOURCE}>
-      {LAYERS.map((LAYER) => (
-        <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
-      ))}
-    </Source>
+    <>
+      {years.map((y) => {
+        const isActive = y === currentYear;
+        const fillOpacityActive: ExpressionSpecification = [
+          'interpolate',
+          ['linear'],
+          ['zoom'],
+          0,
+          baseOpacity * 1.2,
+          12,
+          baseOpacity,
+        ];
+        return (
+          <Source
+            key={`habitat_extent_${y}`}
+            id={`habitat_extent_${y}`}
+            type="vector"
+            url={`mapbox://globalmangrovewatch.gmw-v4-extent-${y}`}
+          >
+            <Layer
+              id={`${id}_${y}_fill`}
+              type="fill"
+              source={`habitat_extent_${y}`}
+              source-layer={`gmw_v4_extent_${y}`}
+              paint={{
+                'fill-color': '#06C4BD',
+                'fill-opacity': isActive ? fillOpacityActive : 0,
+                'fill-opacity-transition': { duration: transitionMs, delay: 0 },
+              }}
+              layout={{ visibility }}
+              beforeId={beforeId}
+            />
+            <Layer
+              id={`${id}_${y}_line`}
+              type="line"
+              source={`habitat_extent_${y}`}
+              source-layer={`gmw_v4_extent_${y}`}
+              paint={{
+                'line-color': '#06C4BD',
+                'line-opacity': isActive ? baseOpacity : 0,
+                'line-width': ['interpolate', ['linear'], ['zoom'], 0, 8, 12, 1],
+                'line-blur': ['interpolate', ['linear'], ['zoom'], 0, 50, 12, 0],
+                'line-opacity-transition': { duration: transitionMs, delay: 0 },
+              }}
+              layout={{ visibility }}
+              beforeId={beforeId}
+            />
+          </Source>
+        );
+      })}
+    </>
   );
 };
 

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -26,7 +26,9 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
     opacity: parseFloat(activeLayer?.opacity ?? '1'),
     visibility: activeLayer?.visibility ?? 'visible',
   });
+
   if (!SOURCE || !LAYERS) return null;
+
   return (
     <Source key={SOURCE.id} {...SOURCE}>
       {LAYERS.map((LAYER) => (

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -20,7 +20,8 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
 
   const SOURCE = useSource({ year: currentYear });
   const LAYERS = useLayers({
-    year: currentYear,
+    activeYear: currentYear,
+    years,
     id,
     opacity: parseFloat(activeLayer?.opacity ?? '1'),
     visibility: activeLayer?.visibility ?? 'visible',

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -20,15 +20,12 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
 
   const SOURCE = useSource({ year: currentYear });
   const LAYERS = useLayers({
-    activeYear: currentYear,
-    years,
+    year: currentYear,
     id,
     opacity: parseFloat(activeLayer?.opacity ?? '1'),
     visibility: activeLayer?.visibility ?? 'visible',
   });
-
   if (!SOURCE || !LAYERS) return null;
-
   return (
     <Source key={SOURCE.id} {...SOURCE}>
       {LAYERS.map((LAYER) => (

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -16,7 +16,7 @@ import NoData from '@/containers/widgets/no-data';
 
 import Loading from '@/components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import TimelineSlider from '@/components/ui/timeline-slider';
+import Timeline from '@/components/ui/timeline';
 import {
   WIDGET_CARD_WRAPPER_STYLE,
   WIDGET_SELECT_ARROW_STYLES,
@@ -155,73 +155,11 @@ const HabitatExtent = () => {
           </button>
         </div>
       )}
-      {!!data && !isFetching && !isError && (
-        <div className="space-y-4">
-          {JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === true && (
-            <>
-              <p className={WIDGET_SENTENCE_STYLE}>
-                The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
-                <span className="notranslate font-bold">
-                  {area}{' '}
-                  <Popover>
-                    <PopoverTrigger asChild>
-                      <span className={`${WIDGET_SELECT_STYLES}`}>
-                        {selectedUnitAreaExtent}
-                        <ARROW_SVG
-                          className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                          role="img"
-                          title="Arrow"
-                        />
-                      </span>
-                    </PopoverTrigger>
-                    <PopoverContent className="shadow-border rounded-2xl px-2">
-                      <ul className="z-20 max-h-32 space-y-0.5">
-                        {unitOptions?.map((u) => (
-                          <li key={u}>
-                            <button
-                              aria-label="select unit"
-                              className={cn({
-                                'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
-                                'hover:text-brand-800': selectedUnitAreaExtent !== u,
-                                'pointer-events-none opacity-50': selectedUnitAreaExtent === u,
-                              })}
-                              type="button"
-                              onClick={() => setUnitAreaExtent(u)}
-                              disabled={selectedUnitAreaExtent === u}
-                            >
-                              {u}
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    </PopoverContent>
-                  </Popover>
-                </span>{' '}
-                in <span className="font-bold">{currentYear}</span>, this represents a linear
-                coverage of <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of
-                the
-                <span className="notranslate font-bold">
-                  {' '}
-                  {totalLength} {defaultUnitLinearCoverage}
-                </span>{' '}
-                of the coastline.
-              </p>
-
-              <div className="py-4">
-                {sortedYears.length > 1 && (
-                  <TimelineSlider
-                    years={sortedYears}
-                    currentYear={currentYear}
-                    isPlaying={isPlaying}
-                    onYearChange={handleYearChange}
-                    onTogglePlay={handleTogglePlay}
-                  />
-                )}
-              </div>
-            </>
-          )}
-          {(JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === false ||
-            metadata.location_id === 'custom-area') && (
+      {JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === false &&
+        !!data &&
+        !isFetching &&
+        !isError && (
+          <div className="space-y-4">
             <p className={WIDGET_SENTENCE_STYLE}>
               The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
               <span className="notranslate font-bold">
@@ -309,17 +247,81 @@ const HabitatExtent = () => {
               </span>{' '}
               of the coastline.
             </p>
-          )}
-          <div className="-mx-2">
+
+            <div className="-mx-2">
+              <ContextualLayersWrapper
+                origin="mangrove_alerts"
+                id={contextualLayers[0].id}
+                description={contextualLayers[0].description}
+              />
+              <HabitatExtentChart legend={legend} config={config} />
+            </div>
+          </div>
+        )}
+
+      {JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === true &&
+        !!data &&
+        !isFetching &&
+        !isError && (
+          <div className="space-y-4">
+            <p className={WIDGET_SENTENCE_STYLE}>
+              The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
+              <span className="notranslate font-bold">
+                {area}{' '}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <span className={`${WIDGET_SELECT_STYLES}`}>
+                      {selectedUnitAreaExtent}
+                      <ARROW_SVG
+                        className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
+                        role="img"
+                        title="Arrow"
+                      />
+                    </span>
+                  </PopoverTrigger>
+                  <PopoverContent className="shadow-border rounded-2xl px-2">
+                    <ul className="z-20 max-h-32 space-y-0.5">
+                      {unitOptions?.map((u) => (
+                        <li key={u}>
+                          <button
+                            aria-label="select unit"
+                            className={cn({
+                              'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
+                              'hover:text-brand-800': selectedUnitAreaExtent !== u,
+                              'pointer-events-none opacity-50': selectedUnitAreaExtent === u,
+                            })}
+                            type="button"
+                            onClick={() => setUnitAreaExtent(u)}
+                            disabled={selectedUnitAreaExtent === u}
+                          >
+                            {u}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </PopoverContent>
+                </Popover>
+              </span>{' '}
+              in <span className="font-bold">{currentYear}</span>.
+            </p>
+            <div className="py-4">
+              {sortedYears.length > 1 && (
+                <Timeline
+                  years={sortedYears}
+                  currentYear={currentYear}
+                  isPlaying={isPlaying}
+                  onYearChange={handleYearChange}
+                  onTogglePlay={handleTogglePlay}
+                />
+              )}
+            </div>
             <ContextualLayersWrapper
               origin="mangrove_alerts"
               id={contextualLayers[0].id}
               description={contextualLayers[0].description}
             />
-            <HabitatExtentChart legend={legend} config={config} />
           </div>
-        </div>
-      )}
+        )}
     </div>
   );
 };

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -202,15 +202,17 @@ const HabitatExtent = () => {
             </span>{' '}
             of the coastline.
           </p>
-          {sortedYears.length > 1 && (
-            <TimelineSlider
-              years={sortedYears}
-              currentYear={currentYear}
-              isPlaying={isPlaying}
-              onYearChange={handleYearChange}
-              onTogglePlay={handleTogglePlay}
-            />
-          )}
+          <div className="py-4">
+            {sortedYears.length > 1 && (
+              <TimelineSlider
+                years={sortedYears}
+                currentYear={currentYear}
+                isPlaying={isPlaying}
+                onYearChange={handleYearChange}
+                onTogglePlay={handleTogglePlay}
+              />
+            )}
+          </div>
           <div className="-mx-2">
             <ContextualLayersWrapper
               origin="mangrove_alerts"

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -72,6 +72,7 @@ const HabitatExtent = () => {
     config,
     defaultUnitLinearCoverage,
     noData,
+    metadata,
   } = data;
 
   const sortedYears = useMemo(() => [...(years || [])].sort((a, b) => a - b), [years]);
@@ -156,14 +157,114 @@ const HabitatExtent = () => {
       )}
       {!!data && !isFetching && !isError && (
         <div className="space-y-4">
-          <p className={WIDGET_SENTENCE_STYLE}>
-            The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
-            <span className="notranslate font-bold">
-              {area}{' '}
+          {JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === true && (
+            <>
+              <p className={WIDGET_SENTENCE_STYLE}>
+                The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
+                <span className="notranslate font-bold">
+                  {area}{' '}
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <span className={`${WIDGET_SELECT_STYLES}`}>
+                        {selectedUnitAreaExtent}
+                        <ARROW_SVG
+                          className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
+                          role="img"
+                          title="Arrow"
+                        />
+                      </span>
+                    </PopoverTrigger>
+                    <PopoverContent className="shadow-border rounded-2xl px-2">
+                      <ul className="z-20 max-h-32 space-y-0.5">
+                        {unitOptions?.map((u) => (
+                          <li key={u}>
+                            <button
+                              aria-label="select unit"
+                              className={cn({
+                                'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
+                                'hover:text-brand-800': selectedUnitAreaExtent !== u,
+                                'pointer-events-none opacity-50': selectedUnitAreaExtent === u,
+                              })}
+                              type="button"
+                              onClick={() => setUnitAreaExtent(u)}
+                              disabled={selectedUnitAreaExtent === u}
+                            >
+                              {u}
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </PopoverContent>
+                  </Popover>
+                </span>{' '}
+                in <span className="font-bold">{currentYear}</span>, this represents a linear
+                coverage of <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of
+                the
+                <span className="notranslate font-bold">
+                  {' '}
+                  {totalLength} {defaultUnitLinearCoverage}
+                </span>{' '}
+                of the coastline.
+              </p>
+
+              <div className="py-4">
+                {sortedYears.length > 1 && (
+                  <TimelineSlider
+                    years={sortedYears}
+                    currentYear={currentYear}
+                    isPlaying={isPlaying}
+                    onYearChange={handleYearChange}
+                    onTogglePlay={handleTogglePlay}
+                  />
+                )}
+              </div>
+            </>
+          )}
+          {(JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').timeline_slider === false ||
+            metadata.location_id === 'custom-area') && (
+            <p className={WIDGET_SENTENCE_STYLE}>
+              The area of mangrove habitat in <span className="font-bold"> {location}</span> was{' '}
+              <span className="notranslate font-bold">
+                {area}{' '}
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <span className={`${WIDGET_SELECT_STYLES}`}>
+                      {selectedUnitAreaExtent}
+                      <ARROW_SVG
+                        className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
+                        role="img"
+                        title="Arrow"
+                      />
+                    </span>
+                  </PopoverTrigger>
+                  <PopoverContent className="shadow-border rounded-2xl px-2">
+                    <ul className="z-20 max-h-32 space-y-0.5">
+                      {unitOptions?.map((u) => (
+                        <li key={u}>
+                          <button
+                            aria-label="select unit"
+                            className={cn({
+                              'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
+                              'hover:text-brand-800': selectedUnitAreaExtent !== u,
+                              'pointer-events-none opacity-50': selectedUnitAreaExtent === u,
+                            })}
+                            type="button"
+                            onClick={() => setUnitAreaExtent(u)}
+                            disabled={selectedUnitAreaExtent === u}
+                          >
+                            {u}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </PopoverContent>
+                </Popover>
+              </span>{' '}
+              in{' '}
               <Popover>
                 <PopoverTrigger asChild>
                   <span className={`${WIDGET_SELECT_STYLES}`}>
-                    {selectedUnitAreaExtent}
+                    {year || defaultYear}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
@@ -172,47 +273,43 @@ const HabitatExtent = () => {
                   </span>
                 </PopoverTrigger>
                 <PopoverContent className="shadow-border rounded-2xl px-2">
-                  <ul className="z-20 max-h-32 space-y-0.5">
-                    {unitOptions?.map((u) => (
-                      <li key={u}>
+                  <ul className="z-20 max-h-56 space-y-0.5">
+                    {years?.map((y) => (
+                      <li key={y} className="last-of-type:pb-4">
                         <button
-                          aria-label="select unit"
+                          aria-label="select year"
                           className={cn({
-                            'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
-                            'hover:text-brand-800': selectedUnitAreaExtent !== u,
-                            'pointer-events-none opacity-50': selectedUnitAreaExtent === u,
+                            'hover:bg-brand-800/20 rounded-lg px-2 py-1': true,
+                            'text-brand-800 font-semibold': y === year || y === defaultYear,
                           })}
                           type="button"
-                          onClick={() => setUnitAreaExtent(u)}
-                          disabled={selectedUnitAreaExtent === u}
+                          onClick={() => {
+                            // Google Analytics tracking
+                            trackEvent('Widget iteration - date change in habitat extent', {
+                              category: 'Widget iteration',
+                              action: 'Select',
+                              label: `Widget iteration - change date in habitat extent to ${y}`,
+                              value: y,
+                            });
+                            handleYearChange(y);
+                          }}
                         >
-                          {u}
+                          {y || defaultYear}
                         </button>
                       </li>
                     ))}
                   </ul>
                 </PopoverContent>
               </Popover>
-            </span>{' '}
-            in <span className="font-bold">{currentYear}</span>, this represents a linear coverage
-            of <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of the
-            <span className="notranslate font-bold">
-              {' '}
-              {totalLength} {defaultUnitLinearCoverage}
-            </span>{' '}
-            of the coastline.
-          </p>
-          <div className="py-4">
-            {sortedYears.length > 1 && (
-              <TimelineSlider
-                years={sortedYears}
-                currentYear={currentYear}
-                isPlaying={isPlaying}
-                onYearChange={handleYearChange}
-                onTogglePlay={handleTogglePlay}
-              />
-            )}
-          </div>
+              , this represents a linear coverage of{' '}
+              <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of the
+              <span className="notranslate font-bold">
+                {' '}
+                {totalLength} {defaultUnitLinearCoverage}
+              </span>{' '}
+              of the coastline.
+            </p>
+          )}
           <div className="-mx-2">
             <ContextualLayersWrapper
               origin="mangrove_alerts"

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { trackEvent } from '@/lib/analytics/ga';
 import cn from '@/lib/classnames';
 
 import { analysisAtom } from '@/store/analysis';
-import { habitatExtentSettings } from '@/store/widgets/habitat-extent';
+import { habitatExtentIsPlaying, habitatExtentSettings } from '@/store/widgets/habitat-extent';
 
 import { useQueryClient } from '@tanstack/react-query';
 import type { PrimitiveAtom } from 'jotai';
@@ -16,6 +16,7 @@ import NoData from '@/containers/widgets/no-data';
 
 import Loading from '@/components/ui/loading';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import TimelineSlider from '@/components/ui/timeline-slider';
 import {
   WIDGET_CARD_WRAPPER_STYLE,
   WIDGET_SELECT_ARROW_STYLES,
@@ -31,6 +32,7 @@ import { useMangroveHabitatExtent, widgetSlug } from './hooks';
 const HabitatExtent = () => {
   const queryClient = useQueryClient();
   const [year, setYear] = useAtom(habitatExtentSettings as unknown as PrimitiveAtom<number | null>);
+  const [isPlaying, setIsPlaying] = useAtom(habitatExtentIsPlaying);
   const [selectedUnitAreaExtent, setUnitAreaExtent] = useState('km²');
   const [isCanceled, setIsCanceled] = useState(false);
 
@@ -72,8 +74,41 @@ const HabitatExtent = () => {
     noData,
   } = data;
 
-  const handleClick = useCallback(
-    (y) => {
+  const sortedYears = useMemo(() => [...(years || [])].sort((a, b) => a - b), [years]);
+  const currentYear = year || defaultYear;
+
+  const yearRef = useRef(currentYear);
+  useEffect(() => {
+    yearRef.current = currentYear;
+  }, [currentYear]);
+
+  useEffect(() => {
+    if (!isPlaying || !sortedYears.length) return;
+    const intervalId = setInterval(() => {
+      const idx = sortedYears.indexOf(yearRef.current ?? sortedYears[sortedYears.length - 1]);
+      const next = (idx + 1) % sortedYears.length;
+      setYear(sortedYears[next]);
+    }, 1200);
+    return () => clearInterval(intervalId);
+  }, [isPlaying, sortedYears, setYear]);
+
+  const handleTogglePlay = useCallback(() => {
+    trackEvent('Widget iteration - timeline playback in habitat extent', {
+      category: 'Widget iteration',
+      action: isPlaying ? 'Pause' : 'Play',
+      label: 'Widget iteration - timeline playback in habitat extent',
+    });
+    setIsPlaying(!isPlaying);
+  }, [isPlaying, setIsPlaying]);
+
+  const handleYearChange = useCallback(
+    (y: number) => {
+      trackEvent('Widget iteration - date change in habitat extent', {
+        category: 'Widget iteration',
+        action: 'Select',
+        label: `Widget iteration - change date in habitat extent to ${y}`,
+        value: y,
+      });
       setYear(y);
     },
     [setYear]
@@ -159,55 +194,23 @@ const HabitatExtent = () => {
                 </PopoverContent>
               </Popover>
             </span>{' '}
-            in{' '}
-            <Popover>
-              <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
-                  {year || defaultYear}
-                  <ARROW_SVG
-                    className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
-                    title="Arrow"
-                  />
-                </span>
-              </PopoverTrigger>
-              <PopoverContent className="shadow-border rounded-2xl px-2">
-                <ul className="z-20 max-h-56 space-y-0.5">
-                  {years?.map((y) => (
-                    <li key={y} className="last-of-type:pb-4">
-                      <button
-                        aria-label="select year"
-                        className={cn({
-                          'hover:bg-brand-800/20 rounded-lg px-2 py-1': true,
-                          'text-brand-800 font-semibold': y === year || y === defaultYear,
-                        })}
-                        type="button"
-                        onClick={() => {
-                          // Google Analytics tracking
-                          trackEvent('Widget iteration - date change in habitat extent', {
-                            category: 'Widget iteration',
-                            action: 'Select',
-                            label: `Widget iteration - change date in habitat extent to ${y}`,
-                            value: y,
-                          });
-                          handleClick(y);
-                        }}
-                      >
-                        {y || defaultYear}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </PopoverContent>
-            </Popover>
-            , this represents a linear coverage of{' '}
-            <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of the
+            in <span className="font-bold">{currentYear}</span>, this represents a linear coverage
+            of <span className="font-bold">{mangroveCoastCoveragePercentage}%</span> of the
             <span className="notranslate font-bold">
               {' '}
               {totalLength} {defaultUnitLinearCoverage}
             </span>{' '}
             of the coastline.
           </p>
+          {sortedYears.length > 1 && (
+            <TimelineSlider
+              years={sortedYears}
+              currentYear={currentYear}
+              isPlaying={isPlaying}
+              onYearChange={handleYearChange}
+              onTogglePlay={handleTogglePlay}
+            />
+          )}
           <div className="-mx-2">
             <ContextualLayersWrapper
               origin="mangrove_alerts"

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -125,7 +125,7 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
           >
             <Slider
               className="w-[150px] pt-2"
-              defaultValue={[layer.opacity]}
+              defaultValue={[parseFloat(layer.opacity)]}
               onValueChange={(op: number[]) => changeOpacity(op[0])}
             />
           </PopoverContent>

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -160,7 +160,9 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
   }, [map, tmpCamera]);
 
   const handleMoveEnd = useCallback(() => {
-    if (map) setURLBounds(map.getBounds().toArray());
+    if (map) {
+      setURLBounds(map.getBounds().toArray());
+    }
     setTmpCamera(null);
   }, [map, setURLBounds, setTmpCamera]);
 

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -160,9 +160,7 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
   }, [map, tmpCamera]);
 
   const handleMoveEnd = useCallback(() => {
-    if (map) {
-      setURLBounds(map.getBounds().toArray());
-    }
+    if (map) setURLBounds(map.getBounds().toArray());
     setTmpCamera(null);
   }, [map, setURLBounds, setTmpCamera]);
 

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -219,7 +219,7 @@ const LegendControls = ({
           >
             <Slider
               className="w-[150px] pt-2"
-              defaultValue={[l.opacity]}
+              defaultValue={[parseFloat(l.opacity)]}
               onValueChange={(op: number[]) => onChangeOpacity(op[0], l.id)}
             />
           </PopoverContent>

--- a/src/containers/navigation/mobile/map-toggle/index.tsx
+++ b/src/containers/navigation/mobile/map-toggle/index.tsx
@@ -29,9 +29,7 @@ const MapToggle = () => {
               'bg-white': mapView,
             })}
           >
-            {mapView && (
-              <CLOSE_SVG className="fill-brand-600 h-4 w-4 fill-current" role="img" title="Close" />
-            )}
+            {mapView && <CLOSE_SVG className="text-brand-800 h-4 w-4" role="img" title="Close" />}
             {!mapView && (
               <span className="font-sans text-sm text-white">{activeLayers?.length}</span>
             )}

--- a/src/containers/widget/header.tsx
+++ b/src/containers/widget/header.tsx
@@ -29,7 +29,7 @@ const WidgetHeader = ({ title, id, children }: PropsWithChildren<HeaderProps>) =
     <header className="flex items-center justify-between">
       <h2
         onClick={handleWidgetCollapsed}
-        className="flex-1 cursor-pointer py-5 text-xs font-bold -tracking-tighter text-black/85 uppercase"
+        className="flex-1 cursor-pointer text-xs font-bold -tracking-tighter text-black/85 uppercase"
       >
         {title}
       </h2>

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -87,11 +87,11 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
 
           {/* content layer */}
           <div className="relative z-10 min-w-0">
-            <div className="min-w-0 px-9 py-3" data-testid={`widget-${id}`}>
+            <div className="min-w-0 px-10 py-6" data-testid={`widget-${id}`}>
               <Helper
                 className={{
                   button: id === 'widgets_deck_tool' ? 'top-0 -right-6 z-20' : 'hidden',
-                  tooltip: 'max-w-[400px]',
+                  tooltip: 'max-w-100',
                 }}
                 tooltipPosition={{ top: -50, left: 0 }}
                 message="Opens deck to select which widgets and map layers are displayed on the left side of the screen. Widgets provide information and statistics about a selected geography, protected area, or user-inputted polygon. Most widgets also come with a map layer that can be toggled on and off. Users can select groups of widgets organized by theme or customize their own combination of widgets and map layers. Some layers and widgets are not available for certain locations. Select applicable geography to enable layer."

--- a/src/store/widgets/habitat-extent.ts
+++ b/src/store/widgets/habitat-extent.ts
@@ -1,3 +1,4 @@
 import { atom } from 'jotai';
 
 export const habitatExtentSettings = atom(null);
+export const habitatExtentIsPlaying = atom(false);

--- a/src/styles/widgets.js
+++ b/src/styles/widgets.js
@@ -1,4 +1,4 @@
-export const WIDGET_CARD_WRAPPER_STYLE = 'pt-3 pb-6 font-light text-black/85 space-y-4';
+export const WIDGET_CARD_WRAPPER_STYLE = 'pb-6 font-light text-black/85 space-y-4';
 export const WIDGET_SENTENCE_STYLE =
   'first-letter:uppercase text-black/85 text-lg font-light leading-7';
 export const WIDGET_SUBTITLE_STYLE = 'm-0 text-xs font-semibold tracking-[0.0625rem] uppercase';

--- a/src/svgs/ui/pause.tsx
+++ b/src/svgs/ui/pause.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const SvgPause = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 320 512"
+    fill="currentColor"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path d="M48 64C21.5 64 0 85.5 0 112L0 400c0 26.5 21.5 48 48 48l32 0c26.5 0 48-21.5 48-48l0-288c0-26.5-21.5-48-48-48L48 64zm192 0c-26.5 0-48 21.5-48 48l0 288c0 26.5 21.5 48 48 48l32 0c26.5 0 48-21.5 48-48l0-288c0-26.5-21.5-48-48-48l-32 0z" />
+  </svg>
+);
+export default SvgPause;

--- a/src/svgs/ui/play.tsx
+++ b/src/svgs/ui/play.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const SvgPlay = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 384 512"
+    fill="currentColor"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path d="M73 39c-14.8-9.1-33.4-9.4-48.5-.9S0 62.6 0 80L0 432c0 17.4 9.4 33.4 24.5 41.9s33.7 8.1 48.5-.9L361 297c14.3-8.7 23-24.2 23-41s-8.7-32.2-23-41L73 39z" />
+  </svg>
+);
+export default SvgPlay;


### PR DESCRIPTION
## Summary
- Add timeline slider with animated playback to habitat extent widget
- Refactor shared `Slider` component and reuse it inside `TimelineSlider`
- Improve a11y: aria-label/aria-valuetext on thumb, aria-pressed on play/pause, focus-visible rings, aria-hidden on decorative icons and year markers
- Replace `TimelineSlider` with new tick-based `Timeline` component in the habitat extent widget
- Render per-year habitat extent vector sources with cross-fade transition on year change (respects `prefers-reduced-motion`)
- Replace `react-icons` play/pause imports with local SVGs (`svgs/ui/play`, `svgs/ui/pause`)
- Minor cleanup in `MapContainer.handleMoveEnd`
- Adjust widget paddings and tooltip max width

## Test plan
- [ ] Habitat extent widget renders the new `Timeline` component
- [ ] Play/pause animation steps through years
- [ ] Clicking ticks updates selected year + map layer
- [ ] Layer cross-fade is smooth between years
- [ ] `prefers-reduced-motion` disables the cross-fade
- [ ] Keyboard navigation works on ticks (arrow keys, Home, End) and play/pause button
- [ ] Screen reader announces year change and play/pause state
- [ ] Map `moveend` still syncs URL bounds
- [ ] No regressions on desktop + mobile layouts