### PR TITLE
fix: patch moderate audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,8 @@
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",
       "lint-staged>yaml": "2.8.3",
-      "axios>follow-redirects": "1.16.0"
+      "axios>follow-redirects": "1.16.0",
+      "next>postcss": ">=8.5.10"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@transifex/react": "^7.1.5",
     "@turf/bbox": "6.5.0",
     "@types/mdx": "2.0.13",
-    "axios": "1.15.2",
+    "axios": "1.16.0",
     "chroma-js": "^2.6.0",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
@@ -127,7 +127,6 @@
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",
       "lint-staged>yaml": "2.8.3",
-      "axios>follow-redirects": "1.16.0",
       "next>postcss": ">=8.5.10"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,6 @@ overrides:
   minimatch>brace-expansion@^1: 1.1.14
   minimatch>brace-expansion@^5: 5.0.5
   lint-staged>yaml: 2.8.3
-  axios>follow-redirects: 1.16.0
   next>postcss: '>=8.5.10'
 
 importers:
@@ -122,8 +121,8 @@ importers:
         specifier: 2.0.13
         version: 2.0.13
       axios:
-        specifier: 1.15.2
-        version: 1.15.2
+        specifier: 1.16.0
+        version: 1.16.0
       chroma-js:
         specifier: ^2.6.0
         version: 2.6.0
@@ -2388,8 +2387,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6797,7 +6796,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   minimatch>brace-expansion@^5: 5.0.5
   lint-staged>yaml: 2.8.3
   axios>follow-redirects: 1.16.0
+  next>postcss: '>=8.5.10'
 
 importers:
 
@@ -4026,10 +4027,6 @@ packages:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4131,8 +4128,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protocol-buffers-schema@3.6.0:
-    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -8552,7 +8549,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.8
       caniuse-lite: 1.0.30001780
-      postcss: 8.4.31
+      postcss: 8.5.10
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@18.2.0)
@@ -8739,12 +8736,6 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
   postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
@@ -8786,7 +8777,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protocol-buffers-schema@3.6.0: {}
+  protocol-buffers-schema@3.6.1: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -9034,7 +9025,7 @@ snapshots:
 
   resolve-protobuf-schema@2.1.0:
     dependencies:
-      protocol-buffers-schema: 3.6.0
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.11:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump `protocol-buffers-schema` 3.6.0 → 3.6.1 (CVE-2026-5758, prototype pollution) via lockfile re-resolution. `resolve-protobuf-schema`'s `^3.3.1` range already permits the patched version, so **no override** is needed.
- Add scoped `next>postcss: ">=8.5.10"` override (CVE-2026-41305, XSS via unescaped `</style>`). Next.js pins postcss exactly, so an override is the only path; the direct devDep was already on 8.5.10, so this aligns the whole tree.

`pnpm audit` → `No known vulnerabilities found`.

## Test plan

- [x] `pnpm audit` clean
- [x] `pnpm check-types` clean
- [x] `pnpm build` clean
- [ ] Smoke `/` in browser — base map renders (covers `pbf` / `protocol-buffers-schema` path)
- [ ] Smoke a few widgets — styles render correctly (covers `next > postcss` build path)
- [ ] CI / Playwright on PR

## Notes

- `pnpm lint` fails on this branch *and* on `develop` (pre-existing `react/jsx-props-no-spreading` plugin config issue) — unrelated to this change.