### PR TITLE
fix: patch axios and tmp vulnerabilities in cloud-functions

### DIFF
--- a/cloud-functions/alerts-tiler/package-lock.json
+++ b/cloud-functions/alerts-tiler/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/bigquery": "^5.0.0",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "concurrently": "^7.2.2",
         "vt-pbf": "3.1.3",
         "zlib": "^1.0.5"
@@ -553,12 +553,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/cloud-functions/alerts-tiler/package.json
+++ b/cloud-functions/alerts-tiler/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Vizzuality/mangrove-atlas#readme",
   "dependencies": {
     "@google-cloud/bigquery": "^5.0.0",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "concurrently": "^7.2.2",
     "vt-pbf": "3.1.3",
     "zlib": "^1.0.5"

--- a/cloud-functions/analysis/package-lock.json
+++ b/cloud-functions/analysis/package-lock.json
@@ -3777,16 +3777,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5043,16 +5033,13 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
       "engines": {
-        "node": ">=0.6.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/cloud-functions/analysis/package.json
+++ b/cloud-functions/analysis/package.json
@@ -27,5 +27,8 @@
     "@types/node": "^24.0.3",
     "@types/express": "^5.0.3",
     "@types/validator": "^13.15.2"
+  },
+  "overrides": {
+    "tmp": "0.2.5"
   }
 }

--- a/cloud-functions/fetch-alerts-heatmap/package-lock.json
+++ b/cloud-functions/fetch-alerts-heatmap/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/bigquery": "^5.0.0",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "concurrently": "^7.2.2",
         "nodemon": "3.1.14",
         "turf-reverse": "^1.0.0"
@@ -350,12 +350,12 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/cloud-functions/fetch-alerts-heatmap/package.json
+++ b/cloud-functions/fetch-alerts-heatmap/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/Vizzuality/mangrove-atlas-data#readme",
   "dependencies": {
     "@google-cloud/bigquery": "^5.0.0",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "concurrently": "^7.2.2",
     "nodemon": "3.1.14",
     "turf-reverse": "^1.0.0"

--- a/cloud-functions/fetch-alerts/package-lock.json
+++ b/cloud-functions/fetch-alerts/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@google-cloud/bigquery": "^8.1.1",
-        "axios": "1.15.0",
+        "axios": "1.16.0",
         "concurrently": "^7.2.2",
         "crypto": "^1.0.1",
         "mapshaper": "0.6.113",
@@ -308,12 +308,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/cloud-functions/fetch-alerts/package.json
+++ b/cloud-functions/fetch-alerts/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/Vizzuality/mangrove-atlas-data#readme",
   "dependencies": {
     "@google-cloud/bigquery": "^8.1.1",
-    "axios": "1.15.0",
+    "axios": "1.16.0",
     "concurrently": "^7.2.2",
     "crypto": "^1.0.1",
     "mapshaper": "0.6.113",


### PR DESCRIPTION
## Summary

Closes all 38 open Dependabot alerts (all live in `cloud-functions/*`; main Next.js app is clean).

- `axios` 1.15.0 → 1.16.0 in `fetch-alerts`, `fetch-alerts-heatmap`, `alerts-tiler` (direct dep). Covers patched ranges `>=1.15.1` and `>=1.15.2` for the 13 advisories.
- `tmp` 0.0.33 → 0.2.5 in `analysis` via npm `overrides` (transitive dev dep through `gts` → `inquirer@7.3.3` → `external-editor@3.1.0`; no upstream chain offers a patched `tmp`).

Existing Dependabot PR #1473 (axios in `fetch-alerts` only) is superseded by this PR.

## Test plan

- [x] `npm audit` reports 0 vulnerabilities in `cloud-functions/fetch-alerts`
- [x] `npm audit` reports 0 vulnerabilities in `cloud-functions/fetch-alerts-heatmap`
- [x] `npm audit` reports 0 vulnerabilities in `cloud-functions/alerts-tiler`
- [x] `npm audit` reports 0 vulnerabilities in `cloud-functions/analysis`
- [ ] CI passes
- [ ] After merge to `develop`, Dependabot alerts dashboard transitions all 38 alerts to `fixed`
- [ ] Close Dependabot PR #1473 as superseded