### PR TITLE
fix: national dashboard multi-source rendering (GMW-1020)

### DIFF
--- a/src/components/map/legend/sortable/item.tsx
+++ b/src/components/map/legend/sortable/item.tsx
@@ -10,6 +10,7 @@ import { SortableItemProps } from '@/components/map/legend/types';
 const SortableItem: React.FC<SortableItemProps> = ({
   id,
   sortable,
+  divided = true,
   children,
   'data-testid': dataTestId,
 }: SortableItemProps) => {
@@ -32,8 +33,8 @@ const SortableItem: React.FC<SortableItemProps> = ({
     <div
       ref={setNodeRef}
       className={cn({
-        'w-full border-b border-gray-200 py-4 first:pt-0 nth-last-3:border-b-0 nth-last-3:pb-0':
-          true,
+        'w-full': true,
+        'border-b border-gray-200 py-4 first:pt-0 nth-last-3:border-b-0 nth-last-3:pb-0': divided,
         'opacity-0': isDragging,
       })}
       style={style}

--- a/src/components/map/legend/sortable/list.tsx
+++ b/src/components/map/legend/sortable/list.tsx
@@ -34,6 +34,7 @@ const SortableList: React.FC<SortableListProps> = ({
   children,
   sortable,
   onChangeOrder,
+  divided = true,
 }: SortableListProps) => {
   const uid = useId();
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -129,6 +130,7 @@ const SortableList: React.FC<SortableListProps> = ({
               <SortableItem
                 id={id}
                 sortable={sortable as SortableItemProps['sortable']}
+                divided={divided}
                 data-testid={`legend-item-${id}`}
               >
                 {cloneElement(Child as ReactElement, {

--- a/src/components/map/legend/types.ts
+++ b/src/components/map/legend/types.ts
@@ -24,10 +24,12 @@ export interface SortableListProps extends PropsWithChildren {
   className?: string;
   sortable?: Sortable;
   onChangeOrder: OnChangeOrder;
+  divided?: boolean;
 }
 
 export interface SortableItemProps extends PropsWithChildren {
   id: string;
   sortable: Sortable;
+  divided?: boolean;
   'data-testid'?: string;
 }

--- a/src/containers/datasets/national-dashboard/constants.ts
+++ b/src/containers/datasets/national-dashboard/constants.ts
@@ -1,1 +1,1 @@
-export const COLORS = ['#ECDA9A', '#00C5BD', '#FFADAD'];
+export const COLORS = ['#ECDA9A', '#7F8DEB', '#FFADAD'];

--- a/src/containers/datasets/national-dashboard/hooks.tsx
+++ b/src/containers/datasets/national-dashboard/hooks.tsx
@@ -19,8 +19,6 @@ import type { DataResponse, LayerSettingsType } from './types';
 
 type NationalDashboardResult = DataResponse & { locationIso: string };
 
-const colorsScale = chroma.scale(COLORS).colors(COLORS.length);
-
 // widget data
 export function useNationalDashboard(
   params?: UseParamsOptions,
@@ -61,8 +59,10 @@ export function useNationalDashboard(
 }
 
 export function useSource({
+  id,
   settings,
 }: {
+  id: LayerProps['id'];
   settings: LayerSettingsType;
 }): (SourceProps & { url: string }) | null {
   if (!settings?.source) return null;
@@ -72,7 +72,7 @@ export function useSource({
     : `mapbox://${settings.source}`;
 
   return {
-    id: 'national-dashboard-sources',
+    id: `${id}-source`,
     type: 'vector',
     url,
   };
@@ -91,11 +91,12 @@ export function useLayers({
 }): LayerProps | null {
   if (!settings?.source_layer || settings.layerIndex == null) return null;
 
-  const color = colorsScale[settings.layerIndex] ?? colorsScale[0];
+  const palette = chroma.scale(COLORS).colors(Math.max(settings.layerIndex + 1, COLORS.length));
+  const color = palette[settings.layerIndex] ?? palette[0];
 
   return {
     id,
-    source: 'national-dashboard-sources',
+    source: `${id}-source`,
     'source-layer': settings.source_layer,
     type: 'fill',
     paint: {

--- a/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
@@ -6,16 +6,32 @@ const LABEL_UNITS = {
   km2: 'km²',
 };
 
-const IndicatorExtent = ({ unit, dataSource }: IndicatorExtentProps) => (
-  <div className="flex flex-col space-y-2">
-    <h5 className="text-sm font-normal">Extent</h5>
-    {dataSource?.value && (
-      <span className="whitespace-nowrap">
-        {numberFormat(dataSource.value)}
-        {unit && <span> {LABEL_UNITS[unit] || unit}</span>}
+const UNIT_ARIA = {
+  km2: 'square kilometres',
+};
+
+const IndicatorExtent = ({ unit, dataSource }: IndicatorExtentProps) => {
+  if (!dataSource?.value) {
+    return (
+      <div className="flex flex-col space-y-2">
+        <h5 className="text-sm font-normal">Extent</h5>
+      </div>
+    );
+  }
+  const displayUnit = unit ? LABEL_UNITS[unit] || unit : '';
+  const ariaUnit = unit ? UNIT_ARIA[unit] || unit : '';
+  return (
+    <div className="flex flex-col space-y-2">
+      <h5 className="text-sm font-normal">Extent</h5>
+      <span
+        className="whitespace-nowrap"
+        aria-label={`${numberFormat(dataSource.value)} ${ariaUnit}`.trim()}
+      >
+        <span className="notranslate">{numberFormat(dataSource.value)}</span>
+        {displayUnit && <span> {displayUnit}</span>}
       </span>
-    )}
-  </div>
-);
+    </div>
+  );
+};
 
 export default IndicatorExtent;

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { trackEvent } from '@/lib/analytics/ga';
 
@@ -19,18 +19,25 @@ const IndicatorSources = ({
   source,
   locationIso,
   layerIndex,
+  layerKey,
+  indicator,
   years,
   unit,
-  dataSource,
+  data_source,
   color,
-  yearSelected,
-  setYearSelected,
 }: IndicatorSourcesProps) => {
   const [activeLayers, setActiveLayers] = useSyncActiveLayers();
+  const [yearSelected, setYearSelected] = useState<number>(years?.[years.length - 1]);
+
+  const dataSource = useMemo(
+    () => data_source.find((d) => d.year === yearSelected) ?? data_source[data_source.length - 1],
+    [data_source, yearSelected]
+  );
 
   const layerId = useMemo(
-    () => `${NATIONAL_LAYER_ID}_${locationIso}` as `mangrove_national_dashboard_layer_${string}`,
-    [locationIso]
+    () =>
+      `${NATIONAL_LAYER_ID}_${locationIso}_${layerKey}` as `mangrove_national_dashboard_layer_${string}`,
+    [locationIso, layerKey]
   );
 
   const isNationalLayerActive = useMemo(
@@ -47,8 +54,8 @@ const IndicatorSources = ({
         name: source,
         location: locationIso,
         layerIndex,
-        source: dataSource.layer_link,
-        source_layer: dataSource.source_layer,
+        source: dataSource?.layer_link,
+        source_layer: dataSource?.source_layer,
         year: yearSelected,
       },
     }),
@@ -57,24 +64,10 @@ const IndicatorSources = ({
       source,
       locationIso,
       layerIndex,
-      dataSource.layer_link,
-      dataSource.source_layer,
+      dataSource?.layer_link,
+      dataSource?.source_layer,
       yearSelected,
     ]
-  );
-
-  const isNationalLayer = useCallback((id: Layer['id']) => {
-    return typeof id === 'string' && id.startsWith(`${NATIONAL_LAYER_ID}_`);
-  }, []);
-
-  const replaceNationalLayer = useCallback(
-    (layers: Layer[] = []): Layer[] => {
-      const nextLayer = buildLayer();
-      const withoutNationalLayers = layers.filter((layer) => !isNationalLayer(layer.id));
-
-      return [nextLayer, ...withoutNationalLayers];
-    },
-    [buildLayer, isNationalLayer]
   );
 
   const updateCurrentLayer = useCallback(
@@ -88,8 +81,8 @@ const IndicatorSources = ({
                 name: source,
                 location: locationIso,
                 layerIndex,
-                source: dataSource.layer_link,
-                source_layer: dataSource.source_layer,
+                source: dataSource?.layer_link,
+                source_layer: dataSource?.source_layer,
                 year: yearSelected,
               },
             }
@@ -100,8 +93,8 @@ const IndicatorSources = ({
       source,
       locationIso,
       layerIndex,
-      dataSource.layer_link,
-      dataSource.source_layer,
+      dataSource?.layer_link,
+      dataSource?.source_layer,
       yearSelected,
     ]
   );
@@ -120,17 +113,17 @@ const IndicatorSources = ({
         return prevLayers.filter((layer) => layer.id !== layerId);
       }
 
-      return replaceNationalLayer(prevLayers);
+      return [buildLayer(), ...prevLayers];
     });
 
     if (!isNationalLayerActive) {
       trackEvent(`Add mangrove national dashboard indicator layer - ${locationIso}`, {
         category: 'Layers',
         action: 'Toggle',
-        label: `Add mangrove national dashboard indicator layer - ${locationIso}`,
+        label: `Add mangrove national dashboard indicator layer - ${locationIso} - ${source}`,
       });
     }
-  }, [setActiveLayers, layerId, replaceNationalLayer, isNationalLayerActive, locationIso]);
+  }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
   return (
     <div className="flex w-full items-start justify-between space-x-4 py-4">
@@ -141,13 +134,18 @@ const IndicatorSources = ({
       <div className="flex min-h-min justify-end space-x-2">
         <WidgetControls
           content={{
-            link: dataSource.download_link ?? undefined,
-            description: dataSource.layer_info,
+            link: dataSource?.download_link ?? undefined,
+            description: dataSource?.layer_info ?? '',
             name: source,
           }}
         />
         <SwitchWrapper id={layerId}>
-          <SwitchRoot id={layerId} onClick={handleClick} checked={isNationalLayerActive}>
+          <SwitchRoot
+            id={layerId}
+            onClick={handleClick}
+            checked={isNationalLayerActive}
+            aria-label={`Toggle ${source} ${indicator} layer`}
+          >
             <SwitchThumb />
           </SwitchRoot>
         </SwitchWrapper>

--- a/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
@@ -3,8 +3,12 @@ import type { IndicatorSourceProps } from './types';
 const IndicatorSource = ({ source, color }: IndicatorSourceProps) => (
   <div className="flex max-w-[140px] flex-col space-y-2">
     <h5 className="text-sm font-normal">Source</h5>
-    <div className="flex w-full items-start space-x-2">
-      <div style={{ backgroundColor: color }} className="mt-1 h-4 w-2 shrink-0 rounded-md" />
+    <div className="flex w-full items-start space-x-2" aria-label={source}>
+      <div
+        style={{ backgroundColor: color }}
+        className="mt-1 h-4 w-2 shrink-0 rounded-md"
+        aria-hidden="true"
+      />
       <span className="truncate" title={source}>
         {source}
       </span>

--- a/src/containers/datasets/national-dashboard/indicator-layers/types.ts
+++ b/src/containers/datasets/national-dashboard/indicator-layers/types.ts
@@ -13,16 +13,16 @@ export type IndicatorSourcesProps = {
   id: WidgetSlugType;
   locationIso: string;
   layerIndex: number;
+  layerKey: string;
+  indicator: string;
 
   source: string;
   years: number[];
   unit: string;
 
-  dataSource: DataSourceType;
+  data_source: DataSourceType[];
 
   color: string;
-  yearSelected: number;
-  setYearSelected: (year: number) => void;
 };
 
 export type IndicatorSourceProps = {
@@ -38,5 +38,5 @@ export type IndicatorYearProps = {
 
 export type IndicatorExtentProps = {
   unit: string;
-  dataSource: DataSourceType;
+  dataSource: DataSourceType | undefined;
 };

--- a/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
@@ -16,23 +16,28 @@ const IndicatorYear = ({ years, yearSelected, setYearSelected }: IndicatorYearPr
         {years?.length > 1 && (
           <Popover>
             <PopoverTrigger asChild>
-              <span className={`${WIDGET_SELECT_STYLES}`}>
+              <button
+                type="button"
+                aria-haspopup="listbox"
+                aria-label={`Select year, current ${yearSelected}`}
+                className={`${WIDGET_SELECT_STYLES}`}
+              >
                 {yearSelected}
                 <ARROW_SVG
                   className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                  role="img"
-                  title="Arrow"
+                  aria-hidden="true"
                 />
-              </span>
+              </button>
             </PopoverTrigger>
 
             <PopoverContent className="shadow-border rounded-2xl px-2">
-              <ul className="max-h-32 space-y-0.5">
+              <ul role="listbox" className="max-h-32 space-y-0.5">
                 {years?.map((u) => (
                   <li key={u}>
                     <button
                       key={u}
-                      aria-label="set year"
+                      role="option"
+                      aria-selected={yearSelected === u}
                       className={cn({
                         'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
                         'hover:text-brand-800': yearSelected !== u,

--- a/src/containers/datasets/national-dashboard/layer.tsx
+++ b/src/containers/datasets/national-dashboard/layer.tsx
@@ -10,12 +10,12 @@ const MangrovesNationalDashboardLayer = ({ beforeId, id }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
 
-  const SOURCE = useSource({ settings: activeLayer.settings });
+  const SOURCE = useSource({ id: activeLayer?.id, settings: activeLayer?.settings });
   const LAYER = useLayers({
-    id: activeLayer.id,
-    opacity: parseFloat(activeLayer.opacity),
-    visibility: activeLayer.visibility,
-    settings: activeLayer.settings,
+    id: activeLayer?.id,
+    opacity: activeLayer ? parseFloat(activeLayer.opacity) : 1,
+    visibility: activeLayer?.visibility,
+    settings: activeLayer?.settings,
   });
 
   if (!SOURCE || !LAYER) return null;

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -2,6 +2,10 @@ import { useSyncActiveLayers } from '@/store/layers';
 
 import chroma from 'chroma-js';
 
+import LegendControls from '@/containers/map/legend/legend-controls';
+
+import type { Layer } from 'types/layers';
+
 import { COLORS } from './constants';
 
 const NATIONAL_LAYER_PREFIX = 'mangrove_national_dashboard_layer_';
@@ -31,15 +35,16 @@ const NationalDashboardMapLegend = () => {
         const color = palette[layerIndex] ?? palette[0];
         const name = (layer.settings?.name as string) ?? '';
         return (
-          <li key={layer.id} className="flex items-start">
-            <div
-              style={{ backgroundColor: color }}
-              className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
-              aria-hidden="true"
-            />
-            <div className="flex flex-col items-start text-sm">
-              <p>{name}</p>
+          <li key={layer.id} className="flex w-full items-center justify-between gap-x-2">
+            <div className="flex min-w-0 items-start">
+              <div
+                style={{ backgroundColor: color }}
+                className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+                aria-hidden="true"
+              />
+              <p className="truncate text-sm">{name}</p>
             </div>
+            <LegendControls id={layer.id} l={layer as Layer} hideInfo />
           </li>
         );
       })}

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -33,7 +33,7 @@ const SortableList = dynamic(() => import('@/components/map/legend/sortable/list
 });
 
 const iconBtn =
-  'inline-flex h-5 w-5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+  'inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
 
 type SourceRowProps = {
   id: string;
@@ -86,11 +86,11 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
   );
 
   return (
-    <div className="flex w-full items-center justify-between gap-x-2">
+    <div className="flex w-full items-center justify-between gap-2">
       <button
         type="button"
         aria-label={`Reorder source ${name}`}
-        className="flex h-5 w-3 shrink-0 cursor-grab items-center justify-center text-black/42"
+        className="flex shrink-0 cursor-grab items-center justify-center text-black/42"
       >
         <DRAG_SVG role="img" aria-hidden={true} />
       </button>
@@ -109,7 +109,7 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
             <TooltipTrigger asChild>
               <PopoverTrigger asChild>
                 <button type="button" aria-label="Layer opacity" className={iconBtn}>
-                  <OPACITY_SVG aria-hidden="true" className="h-4 w-4" />
+                  <OPACITY_SVG aria-hidden="true" className="h-6.5 w-6.5" />
                 </button>
               </PopoverTrigger>
             </TooltipTrigger>
@@ -140,9 +140,9 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
               className={iconBtn}
             >
               {isVisible ? (
-                <SHOW_SVG aria-hidden="true" className="h-5 w-5" />
+                <SHOW_SVG aria-hidden="true" className="h-7 w-7" />
               ) : (
-                <HIDE_SVG aria-hidden="true" className="h-5 w-5" />
+                <HIDE_SVG aria-hidden="true" className="h-7 w-7" />
               )}
             </button>
           </TooltipTrigger>
@@ -161,7 +161,7 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
               aria-label="Remove layer"
               className={iconBtn}
             >
-              <CLOSE_SVG role="img" aria-hidden={true} className="h-3 w-3" />
+              <CLOSE_SVG role="img" aria-hidden={true} />
             </button>
           </TooltipTrigger>
           <TooltipPortal>
@@ -205,10 +205,11 @@ const NationalDashboardMapLegend = () => {
   const palette = chroma.scale(COLORS).colors(Math.max(maxIndex + 1, COLORS.length));
 
   return (
-    <div className="w-full font-sans text-black/60">
+    <div className="w-full space-y-2 font-sans text-black/60">
       <SortableList
         onChangeOrder={handleChangeOrder}
         sortable={{ handle: true, enabled: nationalLayers.length > 1 }}
+        divided={false}
       >
         {nationalLayers.map((layer) => {
           const layerIndex = (layer.settings?.layerIndex as number) ?? 0;

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -1,20 +1,199 @@
+import { useCallback } from 'react';
+
+import dynamic from 'next/dynamic';
+
+import { trackEvent } from '@/lib/analytics/ga';
+import cn from '@/lib/classnames';
+
+import { activeGuideAtom } from '@/store/guide';
 import { useSyncActiveLayers } from '@/store/layers';
 
 import chroma from 'chroma-js';
+import { useAtomValue } from 'jotai';
 
-import LegendControls from '@/containers/map/legend/legend-controls';
-
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import Slider from '@/components/ui/slider';
+import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Layer } from 'types/layers';
+
+import CLOSE_SVG from '@/svgs/legend/close-legend';
+import DRAG_SVG from '@/svgs/legend/drag';
+import HIDE_SVG from '@/svgs/legend/hide';
+import OPACITY_SVG from '@/svgs/legend/opacity';
+import SHOW_SVG from '@/svgs/legend/show';
 
 import { COLORS } from './constants';
 
 const NATIONAL_LAYER_PREFIX = 'mangrove_national_dashboard_layer_';
 
+// Dynamic import breaks a circular-import chain through the datasets barrel
+// that the static-import bundler graph could not resolve cleanly.
+const SortableList = dynamic(() => import('@/components/map/legend/sortable/list'), {
+  ssr: false,
+});
+
+const iconBtn =
+  'inline-flex h-5 w-5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+
+type SourceRowProps = {
+  id: string;
+  layer: Layer;
+  color: string;
+  name: string;
+};
+
+const SourceRow = ({ layer, color, name }: SourceRowProps) => {
+  const [, setActiveLayers] = useSyncActiveLayers();
+  const guideIsActive = useAtomValue(activeGuideAtom);
+  const isVisible = layer.visibility === 'visible';
+
+  const toggleVisibility = useCallback(() => {
+    const nextVisibility = isVisible ? 'none' : 'visible';
+    trackEvent('Legend - Layer visibility', {
+      category: 'Layers - legend',
+      action: 'click',
+      label: `Legend - ${nextVisibility === 'visible' ? 'enable' : 'disable'} layer visibility`,
+    });
+    setActiveLayers((prev) =>
+      (prev ?? []).map((l) => (l.id === layer.id ? { ...l, visibility: nextVisibility } : l))
+    );
+  }, [isVisible, layer.id, setActiveLayers]);
+
+  const removeLayer = useCallback(() => {
+    trackEvent('Legend - Remove layer', {
+      category: 'Layers - legend',
+      action: 'Click',
+      label: `Legend - remove layer ${layer.id}`,
+    });
+    setActiveLayers((prev) => (prev ?? []).filter((l) => l.id !== layer.id));
+  }, [layer.id, setActiveLayers]);
+
+  const changeOpacity = useCallback(
+    (op: number) => {
+      setActiveLayers((prev) => {
+        const target = prev?.find((l) => l.id === layer.id);
+        if (!target) return prev;
+        trackEvent('Legend - Change opacity', {
+          category: 'Layers - legend',
+          action: 'Slider',
+          label: `Legend - change opacity ${layer.id} from ${target.opacity} to ${op}`,
+          value: op,
+        });
+        return (prev ?? []).map((l) => (l.id === layer.id ? { ...l, opacity: op.toString() } : l));
+      });
+    },
+    [layer.id, setActiveLayers]
+  );
+
+  return (
+    <div className="flex w-full items-center justify-between gap-x-2">
+      <button
+        type="button"
+        aria-label={`Reorder source ${name}`}
+        className="flex h-5 w-3 shrink-0 cursor-grab items-center justify-center text-black/42"
+      >
+        <DRAG_SVG role="img" aria-hidden={true} />
+      </button>
+      <div className="flex min-w-0 flex-1 items-start">
+        <div
+          style={{ backgroundColor: color }}
+          className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+          aria-hidden="true"
+        />
+        <p className="truncate text-sm">{name}</p>
+      </div>
+
+      <div className="ml-auto flex items-center justify-end gap-x-0.5">
+        <Popover>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button type="button" aria-label="Layer opacity" className={iconBtn}>
+                  <OPACITY_SVG aria-hidden="true" className="h-4 w-4" />
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipPortal>
+              <TooltipContent className="bg-gray-600 px-2 text-white">Opacity</TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
+          <PopoverContent
+            sideOffset={2}
+            side="top"
+            align="end"
+            className={cn('rounded-none shadow-md!', { hidden: guideIsActive })}
+          >
+            <Slider
+              className="w-[150px] pt-2"
+              defaultValue={[layer.opacity]}
+              onValueChange={(op: number[]) => changeOpacity(op[0])}
+            />
+          </PopoverContent>
+        </Popover>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={toggleVisibility}
+              aria-label={isVisible ? 'Hide layer' : 'Show layer'}
+              className={iconBtn}
+            >
+              {isVisible ? (
+                <SHOW_SVG aria-hidden="true" className="h-5 w-5" />
+              ) : (
+                <HIDE_SVG aria-hidden="true" className="h-5 w-5" />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent className="bg-gray-600 px-2 text-white">
+              {isVisible ? 'Hide' : 'Show'}
+            </TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={removeLayer}
+              aria-label="Remove layer"
+              className={iconBtn}
+            >
+              <CLOSE_SVG role="img" aria-hidden={true} className="h-3 w-3" />
+            </button>
+          </TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent className="bg-gray-600 px-2 text-white">Remove layer</TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};
+
 const NationalDashboardMapLegend = () => {
-  const [activeLayers] = useSyncActiveLayers();
+  const [activeLayers, setActiveLayers] = useSyncActiveLayers();
 
   const nationalLayers = (activeLayers ?? []).filter(
     (layer) => typeof layer.id === 'string' && layer.id.startsWith(NATIONAL_LAYER_PREFIX)
+  );
+
+  const handleChangeOrder = useCallback(
+    (order: string[]) => {
+      setActiveLayers((prev) => {
+        const current = prev ?? [];
+        const byId = new Map<string, Layer>(current.map((l) => [l.id as string, l]));
+        let cursor = 0;
+        return current.map((l) => {
+          if (!l.id.startsWith(NATIONAL_LAYER_PREFIX)) return l;
+          const nextId = order[cursor++];
+          return byId.get(nextId) ?? l;
+        });
+      });
+    },
+    [setActiveLayers]
   );
 
   if (nationalLayers.length === 0) return null;
@@ -26,29 +205,27 @@ const NationalDashboardMapLegend = () => {
   const palette = chroma.scale(COLORS).colors(Math.max(maxIndex + 1, COLORS.length));
 
   return (
-    <ul
-      role="list"
-      className="flex w-full flex-col justify-between space-y-2 font-sans text-black/60"
-    >
-      {nationalLayers.map((layer) => {
-        const layerIndex = (layer.settings?.layerIndex as number) ?? 0;
-        const color = palette[layerIndex] ?? palette[0];
-        const name = (layer.settings?.name as string) ?? '';
-        return (
-          <li key={layer.id} className="flex w-full items-center justify-between gap-x-2">
-            <div className="flex min-w-0 items-start">
-              <div
-                style={{ backgroundColor: color }}
-                className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
-                aria-hidden="true"
-              />
-              <p className="truncate text-sm">{name}</p>
-            </div>
-            <LegendControls id={layer.id} l={layer as Layer} hideInfo />
-          </li>
-        );
-      })}
-    </ul>
+    <div className="w-full font-sans text-black/60">
+      <SortableList
+        onChangeOrder={handleChangeOrder}
+        sortable={{ handle: true, enabled: nationalLayers.length > 1 }}
+      >
+        {nationalLayers.map((layer) => {
+          const layerIndex = (layer.settings?.layerIndex as number) ?? 0;
+          const color = palette[layerIndex] ?? palette[0];
+          const name = (layer.settings?.name as string) ?? '';
+          return (
+            <SourceRow
+              id={layer.id as string}
+              key={layer.id}
+              layer={layer as Layer}
+              color={color}
+              name={name}
+            />
+          );
+        })}
+      </SortableList>
+    </div>
   );
 };
 

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -3,34 +3,47 @@ import { useSyncActiveLayers } from '@/store/layers';
 import chroma from 'chroma-js';
 
 import { COLORS } from './constants';
-import { useNationalDashboard } from './hooks';
 
-const colorsScale = chroma.scale(COLORS).colors(COLORS.length);
+const NATIONAL_LAYER_PREFIX = 'mangrove_national_dashboard_layer_';
 
 const NationalDashboardMapLegend = () => {
   const [activeLayers] = useSyncActiveLayers();
-  const { data } = useNationalDashboard();
-  const ISO = data?.locationIso;
-  const layer = activeLayers?.find(({ id }) => id === `mangrove_national_dashboard_layer_${ISO}`);
-  const sources = data?.data[0]?.sources;
-  const color = colorsScale.filter((c, i) => i === layer?.settings?.layerIndex) as string[];
+
+  const nationalLayers = (activeLayers ?? []).filter(
+    (layer) => typeof layer.id === 'string' && layer.id.startsWith(NATIONAL_LAYER_PREFIX)
+  );
+
+  if (nationalLayers.length === 0) return null;
+
+  const maxIndex = nationalLayers.reduce(
+    (max, l) => Math.max(max, (l.settings?.layerIndex as number) ?? 0),
+    0
+  );
+  const palette = chroma.scale(COLORS).colors(Math.max(maxIndex + 1, COLORS.length));
 
   return (
-    <div className="flex w-full flex-col justify-between space-y-2 font-sans text-black/60">
-      {sources?.map(({ source }) => {
+    <ul
+      role="list"
+      className="flex w-full flex-col justify-between space-y-2 font-sans text-black/60"
+    >
+      {nationalLayers.map((layer) => {
+        const layerIndex = (layer.settings?.layerIndex as number) ?? 0;
+        const color = palette[layerIndex] ?? palette[0];
+        const name = (layer.settings?.name as string) ?? '';
         return (
-          <div key={source} className="flex items-start">
+          <li key={layer.id} className="flex items-start">
             <div
-              style={{ backgroundColor: color[0] }}
+              style={{ backgroundColor: color }}
               className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+              aria-hidden="true"
             />
             <div className="flex flex-col items-start text-sm">
-              <p>{source}</p>
+              <p>{name}</p>
             </div>
-          </div>
+          </li>
         );
       })}
-    </div>
+    </ul>
   );
 };
 

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -1,52 +1,49 @@
-import { useState } from 'react';
-
-import flatten from 'lodash-es/flatten';
-
 import chroma from 'chroma-js';
 
 import { COLORS } from './constants';
 import IndicatorSource from './indicator-layers';
 
-const Sources = ({ data, iso }) => {
-  const [yearSelected, setYearSelected] = useState<number>(data?.sources?.years?.[0] || null);
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 
-  const sources = flatten(
-    data?.map(({ sources }) =>
-      flatten(
-        sources.map(({ data_source }) =>
-          data_source.map(({ layer_link }) => `mapbox://${layer_link}`)
-        )
-      )
-    )
-  );
-  const colorsScale = chroma
+const Sources = ({ data, iso }) => {
+  const sourceColorMap = new Map<string, number>();
+  data?.forEach(({ sources }) => {
+    sources?.forEach(({ source }) => {
+      if (!sourceColorMap.has(source)) {
+        sourceColorMap.set(source, sourceColorMap.size);
+      }
+    });
+  });
+
+  const palette = chroma
     .scale(COLORS)
-    .colors(sources.length > COLORS.length ? sources.length : COLORS.length);
-  const years = data?.[0]?.sources[0]?.years;
-  const currentYear = yearSelected || years?.[years?.length - 1];
+    .colors(sourceColorMap.size > COLORS.length ? sourceColorMap.size : COLORS.length);
 
   return (
     <section className="space-y-6.25">
-      {data?.map(({ indicator, sources }, index) => (
+      {data?.map(({ indicator, sources }) => (
         <div key={indicator}>
-          {/* <h3 className={WIDGET_SUBTITLE_STYLE}>{indicator}</h3> */}
           {sources.map(({ source, years, unit, data_source }) => {
-            const dataSource = data_source.find((d) => d.year === currentYear);
-
-            const color = colorsScale.filter((c, i) => i === index);
+            const colorIndex = sourceColorMap.get(source) ?? 0;
+            const color = palette[colorIndex % palette.length];
+            const layerKey = slugify(`${indicator}__${source}`);
             return (
               <IndicatorSource
                 id={`mangrove_national_dashboard_layer_${iso}`}
                 locationIso={iso}
-                layerIndex={index}
-                key={source}
+                layerIndex={colorIndex}
+                layerKey={layerKey}
+                key={layerKey}
+                indicator={indicator}
                 source={source}
                 years={years}
                 unit={unit}
-                dataSource={dataSource}
+                data_source={data_source}
                 color={color}
-                yearSelected={currentYear}
-                setYearSelected={setYearSelected}
               />
             );
           })}

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -37,7 +37,7 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
   const { data: locationData } = useLocation(locationId, locationType);
   const iso = locationData?.iso;
 
-  const currentNationalLayerId = iso ? `${NATIONAL_DASHBOARD_PREFIX}${iso}` : null;
+  const nationalLayerIdPrefix = iso ? `${NATIONAL_DASHBOARD_PREFIX}${iso}` : null;
 
   const filterLayersByLocationType = useCallback(
     (widgetsConfig: WidgetTypes[], currentLocationType: string): string[] => {
@@ -62,15 +62,25 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
   );
 
   const filteredLayers = useMemo(() => {
-    return (activeLayers ?? []).filter((layer) => {
+    const matched = (activeLayers ?? []).filter((layer) => {
       const isStandardLayer = filteredLayersIds.includes(layer.id);
 
       const isCurrentNationalLayer =
-        !!currentNationalLayerId && layer.id === currentNationalLayerId;
+        !!nationalLayerIdPrefix &&
+        (layer.id === nationalLayerIdPrefix || layer.id.startsWith(`${nationalLayerIdPrefix}_`));
 
       return isStandardLayer || isCurrentNationalLayer;
     }) as Layer[];
-  }, [activeLayers, filteredLayersIds, currentNationalLayerId]);
+
+    // Collapse all active national-dashboard layers under a single LegendItem;
+    // the WidgetLegend component lists each source row.
+    const firstNationalIdx = matched.findIndex((layer) =>
+      layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX)
+    );
+    return matched.filter(
+      (layer, idx) => !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) || idx === firstNationalIdx
+    );
+  }, [activeLayers, filteredLayersIds, nationalLayerIdPrefix]);
 
   const [isOpen, setIsOpen] = useState(true);
 

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { trackEvent } from '@/lib/analytics/ga';
 import cn from '@/lib/classnames';
@@ -38,6 +38,23 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
   const iso = locationData?.iso;
 
   const nationalLayerIdPrefix = iso ? `${NATIONAL_DASHBOARD_PREFIX}${iso}` : null;
+
+  // When the user navigates to another country, drop any national-dashboard
+  // layers belonging to the previous ISO so the URL state stays in sync and
+  // we don't try to render Mapbox sources from a different country.
+  useEffect(() => {
+    if (!iso) return;
+    setActiveLayers((prev) => {
+      const current = prev ?? [];
+      const next = current.filter(
+        (layer) =>
+          !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) ||
+          layer.id.startsWith(`${NATIONAL_DASHBOARD_PREFIX}${iso}_`) ||
+          layer.id === `${NATIONAL_DASHBOARD_PREFIX}${iso}`
+      );
+      return next.length === current.length ? prev : next;
+    });
+  }, [iso, setActiveLayers]);
 
   const filterLayersByLocationType = useCallback(
     (widgetsConfig: WidgetTypes[], currentLocationType: string): string[] => {

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -24,11 +24,20 @@ import DRAG_SVG from '@/svgs/legend/drag';
 
 import LegendControls from '../legend-controls';
 
+const NATIONAL_DASHBOARD_PREFIX = 'mangrove_national_dashboard_layer_';
+
 const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolean; l: Layer }) => {
   const [statisticsDialogVisibility, setStatisticsDialogVisibility] = useState(false);
   const [activeLayers] = useSyncActiveLayers();
   const guideIsActive = useAtomValue(activeGuideAtom);
   const widget = widgets.find((w) => w.slug === l.id);
+  const isNationalDashboard =
+    typeof l.id === 'string' && l.id.startsWith(NATIONAL_DASHBOARD_PREFIX);
+  const nationalDashboardLayerIds = isNationalDashboard
+    ? (activeLayers ?? [])
+        .filter((layer) => layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX))
+        .map((layer) => layer.id)
+    : undefined;
 
   const nationalDashboardLayerName = activeLayers?.find((l) =>
     l.id?.includes('mangrove_national_dashboard_layer')
@@ -125,7 +134,12 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
             tooltipPosition={{ top: -40, left: 210 }}
             message="Use the settings of each layer to obtain detailed information, manage the opacity, hide or show it or to remove it from the map."
           >
-            <LegendControls id={id} l={l} />
+            <LegendControls
+              id={id}
+              l={l}
+              hideOpacity={isNationalDashboard}
+              targetLayerIds={nationalDashboardLayerIds}
+            />
           </Helper>
         )}
       </div>

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -145,7 +145,12 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
       </div>
 
       {WidgetLegend && (
-        <div className={cn('w-full pt-4', { 'pl-6': !isNationalDashboard })}>
+        <div
+          className={cn('w-full pt-4', {
+            'pl-6': !isNationalDashboard,
+            'pl-4 md:pl-5': isNationalDashboard,
+          })}
+        >
           <WidgetLegend />
         </div>
       )}

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -145,7 +145,7 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
       </div>
 
       {WidgetLegend && (
-        <div className="pt-4 pl-6">
+        <div className={cn('w-full pt-4', { 'pl-6': !isNationalDashboard })}>
           <WidgetLegend />
         </div>
       )}

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -24,26 +24,49 @@ import OPACITY_SVG from '@/svgs/legend/opacity';
 import SHOW_SVG from '@/svgs/legend/show';
 import INFO_SVG from '@/svgs/ui/info';
 
-const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => {
+type LegendControlsProps = {
+  id: string;
+  embedded?: boolean;
+  l: Layer;
+  hideOpacity?: boolean;
+  hideInfo?: boolean;
+  // When provided, visibility and remove act on every layer id in this list
+  // instead of only on `l.id`. Used for the national-dashboard parent legend
+  // item which controls all of its source layers at once.
+  targetLayerIds?: Layer['id'][];
+};
+
+const LegendControls = ({
+  l,
+  hideOpacity = false,
+  hideInfo = false,
+  targetLayerIds,
+}: LegendControlsProps) => {
   const [infoDialogVisibility, setInfoDialogVisibility] = useState(false);
   const [activeLayers, setActiveLayers] = useSyncActiveLayers();
   const guideIsActive = useAtomValue(activeGuideAtom);
 
   const onChangeVisibility = useCallback(
     (layerId: Layer['id']) => {
-      const targetLayer = activeLayers?.find((l) => l.id === layerId);
+      const ids = targetLayerIds && targetLayerIds.length > 0 ? targetLayerIds : [layerId];
+      const referenceLayer = activeLayers?.find((layer) => ids.includes(layer.id));
 
-      if (!targetLayer) return;
+      if (!referenceLayer) return;
 
-      const nextVisibility = targetLayer.visibility === 'visible' ? 'none' : 'visible';
+      // Mixed-state semantics: if anything in the group is visible, hide all;
+      // otherwise show all. The button icon reflects "any visible".
+      const anyVisible = activeLayers?.some(
+        (layer) => ids.includes(layer.id) && layer.visibility === 'visible'
+      );
+      const nextVisibility = anyVisible ? 'none' : 'visible';
 
       const layersWithVisibility = activeLayers
-        ?.map((l) => {
-          if (l.id === 'custom-area') return null;
-          if (l.id !== layerId) return l;
+        ?.map((layer) => {
+          if (layer.id === 'custom-area') return null;
+          if (!ids.includes(layer.id)) return layer;
 
           return {
-            ...l,
+            ...layer,
             visibility: nextVisibility,
           };
         })
@@ -57,16 +80,14 @@ const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => 
 
       setActiveLayers(layersWithVisibility);
     },
-    [activeLayers, setActiveLayers]
+    [activeLayers, setActiveLayers, targetLayerIds]
   );
 
   const removeLayer = useCallback(
     (layer: string) => {
-      const updatedLayers = activeLayers?.filter((l) => {
-        return l.id !== layer;
-      });
+      const ids = targetLayerIds && targetLayerIds.length > 0 ? targetLayerIds : [layer];
+      const updatedLayers = activeLayers?.filter((entry) => !ids.includes(entry.id));
 
-      // Google Analytics tracking
       trackEvent(`Legend - Remove layer`, {
         category: 'Layers - legend',
         action: 'Click',
@@ -74,7 +95,7 @@ const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => 
       });
       setActiveLayers(updatedLayers);
     },
-    [activeLayers, setActiveLayers]
+    [activeLayers, setActiveLayers, targetLayerIds]
   );
 
   const layerName = (label) => {
@@ -105,7 +126,12 @@ const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => 
     ? 'mangrove_national_dashboard'
     : l.id;
 
-  const visibility = l.visibility === 'visible';
+  const visibility =
+    targetLayerIds && targetLayerIds.length > 0
+      ? (activeLayers ?? []).some(
+          (layer) => targetLayerIds.includes(layer.id) && layer.visibility === 'visible'
+        )
+      : l.visibility === 'visible';
 
   const layerNameToDisplay = layerName(l.id);
   if (layerNameToDisplay === undefined && !l.id.includes('mangrove_national_dashboard_layer'))
@@ -120,7 +146,7 @@ const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => 
 
   return (
     <div className="ml-2 flex items-center gap-x-0.5">
-      {WidgetInfo && (
+      {!hideInfo && WidgetInfo && (
         <Dialog open={infoDialogVisibility}>
           <DialogTrigger asChild>
             <Tooltip>
@@ -166,34 +192,36 @@ const LegendControls = ({ l }: { id: string; embedded?: boolean; l: Layer }) => 
         </Dialog>
       )}
 
-      <Popover>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <PopoverTrigger asChild>
-              <button type="button" aria-label="Layer opacity" className={iconBtn}>
-                <OPACITY_SVG aria-hidden="true" className="h-6.5 w-6.5" />
-              </button>
-            </PopoverTrigger>
-          </TooltipTrigger>
+      {!hideOpacity && (
+        <Popover>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <button type="button" aria-label="Layer opacity" className={iconBtn}>
+                  <OPACITY_SVG aria-hidden="true" className="h-6.5 w-6.5" />
+                </button>
+              </PopoverTrigger>
+            </TooltipTrigger>
 
-          <TooltipPortal>
-            <TooltipContent className="bg-gray-600 px-2 text-white">Opacity</TooltipContent>
-          </TooltipPortal>
-        </Tooltip>
+            <TooltipPortal>
+              <TooltipContent className="bg-gray-600 px-2 text-white">Opacity</TooltipContent>
+            </TooltipPortal>
+          </Tooltip>
 
-        <PopoverContent
-          sideOffset={2}
-          side="top"
-          align="end"
-          className={cn('rounded-none shadow-md!', { hidden: guideIsActive })}
-        >
-          <Slider
-            className="w-[150px] pt-2"
-            defaultValue={[l.opacity]}
-            onValueChange={(op: number[]) => onChangeOpacity(op[0], l.id)}
-          />
-        </PopoverContent>
-      </Popover>
+          <PopoverContent
+            sideOffset={2}
+            side="top"
+            align="end"
+            className={cn('rounded-none shadow-md!', { hidden: guideIsActive })}
+          >
+            <Slider
+              className="w-[150px] pt-2"
+              defaultValue={[l.opacity]}
+              onValueChange={(op: number[]) => onChangeOpacity(op[0], l.id)}
+            />
+          </PopoverContent>
+        </Popover>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <button

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -30,6 +30,7 @@ type LegendControlsProps = {
   l: Layer;
   hideOpacity?: boolean;
   hideInfo?: boolean;
+  compact?: boolean;
   // When provided, visibility and remove act on every layer id in this list
   // instead of only on `l.id`. Used for the national-dashboard parent legend
   // item which controls all of its source layers at once.
@@ -40,6 +41,7 @@ const LegendControls = ({
   l,
   hideOpacity = false,
   hideInfo = false,
+  compact = false,
   targetLayerIds,
 }: LegendControlsProps) => {
   const [infoDialogVisibility, setInfoDialogVisibility] = useState(false);
@@ -141,11 +143,19 @@ const LegendControls = ({
 
   if (l.id === 'custom-area') return null;
 
-  const iconBtn =
-    'inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+  const iconBtn = compact
+    ? 'inline-flex h-5 w-5 items-center justify-center rounded-full text-black/42 hover:bg-black/5'
+    : 'inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+  const opacityIconCls = compact ? 'h-4 w-4' : 'h-6.5 w-6.5';
+  const showHideIconCls = compact ? 'h-5 w-5' : 'h-7 w-7';
+  const closeIconCls = compact ? 'h-3 w-3' : '';
+  const infoBtnCls = compact
+    ? 'mr-1 flex h-4 w-4 items-center justify-center rounded-full border-[1.5px] border-black/42 text-black/42'
+    : 'mr-1 flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-black/42 text-black/42';
+  const infoIconCls = compact ? 'h-2 w-2 fill-current' : 'h-3 w-3 fill-current';
 
   return (
-    <div className="ml-2 flex items-center gap-x-0.5">
+    <div className="ml-auto flex items-center justify-end gap-x-0.5">
       {!hideInfo && WidgetInfo && (
         <Dialog open={infoDialogVisibility}>
           <DialogTrigger asChild>
@@ -154,13 +164,9 @@ const LegendControls = ({
                 asChild
                 onClick={() => setInfoDialogVisibility(!infoDialogVisibility)}
               >
-                <button
-                  type="button"
-                  aria-label="Layer info"
-                  className="mr-1 flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-black/42 text-black/42"
-                >
+                <button type="button" aria-label="Layer info" className={infoBtnCls}>
                   <INFO_SVG
-                    className="h-3 w-3 fill-current"
+                    className={infoIconCls}
                     role="img"
                     aria-hidden={true}
                     aria-label="Info layer"
@@ -198,7 +204,7 @@ const LegendControls = ({
             <TooltipTrigger asChild>
               <PopoverTrigger asChild>
                 <button type="button" aria-label="Layer opacity" className={iconBtn}>
-                  <OPACITY_SVG aria-hidden="true" className="h-6.5 w-6.5" />
+                  <OPACITY_SVG aria-hidden="true" className={opacityIconCls} />
                 </button>
               </PopoverTrigger>
             </TooltipTrigger>
@@ -231,9 +237,9 @@ const LegendControls = ({
             className={iconBtn}
           >
             {visibility ? (
-              <SHOW_SVG aria-hidden="true" className="h-7 w-7" />
+              <SHOW_SVG aria-hidden="true" className={showHideIconCls} />
             ) : (
-              <HIDE_SVG aria-hidden="true" className="h-7 w-7" />
+              <HIDE_SVG aria-hidden="true" className={showHideIconCls} />
             )}
           </button>
         </TooltipTrigger>
@@ -257,7 +263,7 @@ const LegendControls = ({
             aria-label="Remove layer"
             className={iconBtn}
           >
-            <CLOSE_SVG role="img" aria-hidden={true} />
+            <CLOSE_SVG role="img" aria-hidden={true} className={closeIconCls} />
           </button>
         </TooltipTrigger>
         <TooltipPortal>

--- a/src/hooks/layers/index.ts
+++ b/src/hooks/layers/index.ts
@@ -5,33 +5,15 @@ import { Layer } from 'types/layers';
 export function updateLayers(newLayer: Layer, activeLayers: Layer[]): Layer[] {
   const { id } = newLayer;
   const index = activeLayers?.findIndex((layer) => layer.id === id);
-  const hasNationalDashboard = id.includes('national_dashboard');
-  const nationalDashboardIndex = activeLayers?.findIndex((layer) =>
-    layer.id.includes('national_dashboard')
-  );
 
   if (index !== -1) {
-    // Delete the layer if it already exists by creating a new array without that layer
     return [...activeLayers?.slice(0, index), ...activeLayers?.slice(index + 1)];
-  } else if (hasNationalDashboard && nationalDashboardIndex !== -1) {
-    // Google Analytics tracking
-    trackEvent(`Replace national dashboard layer - ${id}`, {
-      category: 'Layers',
-      action: 'Toggle',
-      label: `Replace national dashboard layer - ${id}`,
-    });
-
-    // Replace the national_dashboard layer with the new layer by creating a new array
-    return activeLayers?.map((layer, idx) => (idx === nationalDashboardIndex ? newLayer : layer));
-  } else {
-    // Adds the new layer to the list by creating a new array with the new layer
-
-    // Google Analytics tracking
-    trackEvent(`Add national dashboard layer - ${id}`, {
-      category: 'Layers',
-      action: 'Toggle',
-      label: `Add national dashboard layer - ${id}`,
-    });
-    return [newLayer, ...activeLayers];
   }
+
+  trackEvent(`Add layer - ${id}`, {
+    category: 'Layers',
+    action: 'Toggle',
+    label: `Add layer - ${id}`,
+  });
+  return [newLayer, ...activeLayers];
 }

--- a/src/hooks/layers/index.ts
+++ b/src/hooks/layers/index.ts
@@ -10,10 +10,10 @@ export function updateLayers(newLayer: Layer, activeLayers: Layer[]): Layer[] {
     return [...activeLayers?.slice(0, index), ...activeLayers?.slice(index + 1)];
   }
 
-  trackEvent(`Add layer - ${id}`, {
+  trackEvent(`Add national dashboard layer - ${id}`, {
     category: 'Layers',
     action: 'Toggle',
-    label: `Add layer - ${id}`,
+    label: `Add national dashboard layer - ${id}`,
   });
   return [newLayer, ...activeLayers];
 }

--- a/src/svgs/legend/drag.tsx
+++ b/src/svgs/legend/drag.tsx
@@ -7,20 +7,20 @@ interface SVGRProps {
 const SvgDrag = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
+    width="12"
+    height="20"
+    viewBox="0 0 12 20"
     fill="none"
     {...props}
   >
     {title ? <title id={titleId}>{title}</title> : null}
 
-    <circle cx="9.5" cy="7.5" r="1.5" fill="black" fillOpacity="0.42" />
-    <circle cx="9.5" cy="12.5" r="1.5" fill="black" fillOpacity="0.42" />
-    <circle cx="9.5" cy="17.5" r="1.5" fill="black" fillOpacity="0.42" />
-    <circle cx="14.5" cy="7.5" r="1.5" fill="black" fillOpacity="0.42" />
-    <circle cx="14.5" cy="12.5" r="1.5" fill="black" fillOpacity="0.42" />
-    <circle cx="14.5" cy="17.5" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="3.5" cy="3.5" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="3.5" cy="10" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="3.5" cy="16.5" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="8.5" cy="3.5" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="8.5" cy="10" r="1.5" fill="black" fillOpacity="0.42" />
+    <circle cx="8.5" cy="16.5" r="1.5" fill="black" fillOpacity="0.42" />
   </svg>
 );
 export default SvgDrag;

--- a/tests/fixtures/national-dashboard.json
+++ b/tests/fixtures/national-dashboard.json
@@ -1,0 +1,53 @@
+{
+  "data": [
+    {
+      "indicator": "Habitat extent area",
+      "sources": [
+        {
+          "source": "CONABIO",
+          "unit": "km2",
+          "years": [2015, 2020],
+          "data_source": [
+            {
+              "year": 2015,
+              "value": 7755.55,
+              "layer_link": "globalmangrovewatch.conabio_2015",
+              "download_link": "https://example.com/conabio_2015.zip",
+              "layer_info": "CONABIO 2015 mangrove extent",
+              "source_layer": "conabio_2015"
+            },
+            {
+              "year": 2020,
+              "value": 7647.74,
+              "layer_link": "globalmangrovewatch.conabio_2020",
+              "download_link": "https://example.com/conabio_2020.zip",
+              "layer_info": "CONABIO 2020 mangrove extent",
+              "source_layer": "conabio_2020"
+            }
+          ]
+        },
+        {
+          "source": "TEST",
+          "unit": "km2",
+          "years": [2025],
+          "data_source": [
+            {
+              "year": 2025,
+              "value": 999,
+              "layer_link": "globalmangrovewatch.test_2025",
+              "download_link": null,
+              "layer_info": "TEST 2025 mangrove extent",
+              "source_layer": "test_2025"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "location_id": "MEX",
+    "legal_status_options": [],
+    "other_resources": [],
+    "note": null
+  }
+}

--- a/tests/national-dashboard.spec.ts
+++ b/tests/national-dashboard.spec.ts
@@ -1,0 +1,85 @@
+import fixture from './fixtures/national-dashboard.json';
+import { test, expect } from './fixtures/test';
+
+const WIDGET_TESTID = 'widget-mangrove_national_dashboard-content';
+
+// Real platform URL format. National Dashboard is included as a default widget
+// for certain categories on the country view; we list it explicitly in
+// active-widgets so the test is robust against changes to category defaults.
+const PAGE_URL =
+  '/country/MEX?active-widgets=mangrove_national_dashboard,mangrove_net_change,mangrove_habitat_change,mangrove_alerts,mangrove_species_location,mangrove_species_distribution,mangrove_species_threatened,widgets_deck_tool&category=all_datasets';
+
+// page.route intercepts the backend API call (NEXT_PUBLIC_API_URL/widgets/national_dashboard?...)
+// and replies with our fixture. The Next page route is unchanged.
+async function mockNationalDashboardAPI(page: import('@playwright/test').Page) {
+  await page.route('**/widgets/national_dashboard*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(fixture),
+    });
+  });
+}
+
+test.describe('National Dashboard multi-source', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockNationalDashboardAPI(page);
+    await page.goto(PAGE_URL);
+    await page.getByTestId(WIDGET_TESTID).waitFor();
+  });
+
+  test('renders both sources with distinct rows', async ({ page }) => {
+    const widget = page.getByTestId(WIDGET_TESTID);
+    await expect(widget.getByText('CONABIO', { exact: true })).toBeVisible();
+    await expect(widget.getByText('TEST', { exact: true })).toBeVisible();
+    await expect(widget.getByText(/7,647\.74/)).toBeVisible();
+    await expect(widget.getByText(/999/)).toBeVisible();
+  });
+
+  test('each switch has a unique aria-label', async ({ page }) => {
+    const conabioSwitch = page.getByRole('button', {
+      name: /Toggle CONABIO Habitat extent area layer/,
+    });
+    const testSwitch = page.getByRole('button', {
+      name: /Toggle TEST Habitat extent area layer/,
+    });
+    await expect(conabioSwitch).toBeVisible();
+    await expect(testSwitch).toBeVisible();
+  });
+
+  test('both layers can be active at once on the map', async ({ page }) => {
+    const conabioSwitch = page.getByRole('button', {
+      name: /Toggle CONABIO Habitat extent area layer/,
+    });
+    const testSwitch = page.getByRole('button', {
+      name: /Toggle TEST Habitat extent area layer/,
+    });
+
+    await conabioSwitch.click();
+    await expect(conabioSwitch).toHaveAttribute('data-state', 'checked');
+
+    await testSwitch.click();
+    await expect(testSwitch).toHaveAttribute('data-state', 'checked');
+    await expect(conabioSwitch).toHaveAttribute('data-state', 'checked');
+
+    // Map legend on the bottom-right lists both sources under one entry.
+    const legend = page.getByTestId('legend-content');
+    await expect(legend.getByText('CONABIO', { exact: true })).toBeVisible();
+    await expect(legend.getByText('TEST', { exact: true })).toBeVisible();
+
+    await conabioSwitch.click();
+    await expect(conabioSwitch).toHaveAttribute('data-state', 'unchecked');
+    await expect(testSwitch).toHaveAttribute('data-state', 'checked');
+  });
+
+  test('year picker is per-source', async ({ page }) => {
+    const widget = page.getByTestId(WIDGET_TESTID);
+
+    const yearTrigger = widget.getByRole('button', { name: /Select year, current 2020/ }).first();
+    await yearTrigger.click();
+    await page.getByRole('option', { name: '2015' }).click();
+
+    await expect(widget.getByText(/7,755\.55/)).toBeVisible();
+    await expect(widget.getByText(/999/)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Closes [GMW-1020](https://vizzuality.atlassian.net/browse/GMW-1020) — *FE - National Dashboard should be able to render multiple sources*.

Fixes the National Dashboard widget so that an indicator with more than one source (e.g. `habitat_extent_area` with both CONABIO and TEST) renders every source independently on the widget, on the map, and in the legend.

### What changed

- **Per-source color** — each source name maps to one color via `Map<sourceName, idx>`, stable across years and across indicators. The same source under two indicators now shares one swatch.
- **Per-source unique layer id** — `mangrove_national_dashboard_layer_${iso}_${layerKey}` (where `layerKey = slug(${indicator}__${source})`). Each source gets its own active layer.
- **Per-source year selector** — year state lives inside each source row; one row's year change no longer affects siblings, and a missing-year case falls back to the last available year instead of crashing.
- **Per-source Mapbox `<Source>` id** — was hardcoded `'national-dashboard-sources'`, which made Mapbox dedupe two distinct vector tile URLs into one. Now derives from the layer id.
- **Both layers coexist on the map** — `updateLayers` no longer has the "replace national_dashboard layer" branch, and the per-source toggle no longer strips siblings. Toggling source B keeps source A active.
- **Map legend reflects active sources** — `map-legend.tsx` iterates active national-dashboard layers and renders one row per source with its matching color. `legend/index.tsx` dedupes multiple national-dashboard layers into a single `LegendItem` so the list is not duplicated.
- **Location-change cleanup** — `legend/index.tsx` runs an effect that drops national-dashboard layers from `activeLayers` (and the URL) when their ISO does not match the current country. Going from MEX → BRA now clears the stale MEX layers.
- **Accessibility** — year trigger is a focusable `<button>` with `aria-haspopup="listbox"` and a descriptive `aria-label`; year options use `role="option"` + `aria-selected`; source swatch is `aria-hidden`; each per-source switch has a unique `aria-label="Toggle ${source} ${indicator} layer"`; the extent value has an `aria-label` combining the number and unit.

### Out of scope

- Backend payload changes.
- `legal-status` / `mangrove-breakthrough` dev-only blocks.
- `types.d.ts` `DataResponse.data: any` cleanup.
- Per-source legend title in `containers/map/legend/item/index.tsx` (remains the generic "National Dashboard").

## Test plan

- [ ] `/country/MEX` — open the National Dashboard widget; two source rows render with distinct swatches and extent values.
- [ ] Toggle source A → fill polygon appears on the map; legend lists A. Toggle source B → fill for B also appears; legend lists both with their respective colors.
- [ ] Toggle A off → B persists on both the map and the legend.
- [ ] Change the year on source A → only A's extent value updates; B is unchanged.
- [ ] If a source has no entry for the currently-selected year, the widget falls back to its latest available year (no console error).
- [ ] Navigate MEX → BRA → confirm the URL `layers=` param no longer contains the MEX-specific national-dashboard layer ids.
- [ ] Tab through the widget — year trigger and switches are focusable; Enter/Space activates them.
- [ ] VoiceOver — each row announces source name, current year, and value+unit.
- [ ] Playwright suite for this widget passes:
  ```
  npx playwright test tests/national-dashboard.spec.ts
  ```

[GMW-1020]: https://vizzuality.atlassian.net/browse/GMW-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ