### PR TITLE
fix(deps): pin next>postcss override to exact version

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",
       "lint-staged>yaml": "2.8.3",
-      "next>postcss": ">=8.5.10"
+      "next>postcss": "8.5.10"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   minimatch>brace-expansion@^1: 1.1.14
   minimatch>brace-expansion@^5: 5.0.5
   lint-staged>yaml: 2.8.3
-  next>postcss: '>=8.5.10'
+  next>postcss: 8.5.10
 
 importers:
 


### PR DESCRIPTION
## Summary

- Audit found **0 vulnerabilities** across root (`pnpm audit`, 911 deps), 5 cloud-functions (`npm audit`), and Dependabot (0 open alerts).
- Hygiene fix: `next>postcss` override changed from semver range `">=8.5.10"` to exact pin `"8.5.10"` per fix-vulnerabilities guidelines §3 ("always pin to exact versions, no semver ranges").
- Resolved version unchanged — no behavioral diff, no new patches applied.

## Override review

Remaining entries in `pnpm.overrides` were verified via `pnpm why` and still required (parents still pull unpatched transitive versions): `braces`, `recharts>lodash`, `micromatch>picomatch`, `tinyglobby>picomatch`, `minimatch>brace-expansion@^1`, `minimatch>brace-expansion@^5`, `lint-staged>yaml`.

## Test plan

- [x] `pnpm install` — lockfile synced cleanly
- [x] `pnpm audit` — 0 vulnerabilities (info/low/moderate/high/critical all 0)
- [x] `pnpm check-types` — passes
- [ ] `pnpm lint` — pre-existing failure on develop (`react/jsx-props-no-spreading` plugin config), unrelated to this change
- [ ] Playwright smoke — runtime unchanged, defer to CI