### PR TITLE
fix(deps): prune redundant pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "recharts>lodash": "4.18.1",
       "micromatch>picomatch": "2.3.2",
       "tinyglobby>picomatch": "4.0.4",
       "minimatch>brace-expansion@^1": "1.1.14",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "tinyglobby>picomatch": "4.0.4",
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",
       "next>postcss": "8.5.10"

--- a/package.json
+++ b/package.json
@@ -120,8 +120,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "minimatch>brace-expansion@^1": "1.1.14",
-      "minimatch>brace-expansion@^5": "5.0.5",
       "next>postcss": "8.5.10"
     },
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
       "tinyglobby>picomatch": "4.0.4",
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",
-      "lint-staged>yaml": "2.8.3",
       "next>postcss": "8.5.10"
     },
     "onlyBuiltDependencies": [

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "micromatch>picomatch": "2.3.2",
       "tinyglobby>picomatch": "4.0.4",
       "minimatch>brace-expansion@^1": "1.1.14",
       "minimatch>brace-expansion@^5": "5.0.5",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
   "packageManager": "pnpm@10.33.0",
   "pnpm": {
     "overrides": {
-      "braces": "3.0.3",
       "recharts>lodash": "4.18.1",
       "micromatch>picomatch": "2.3.2",
       "tinyglobby>picomatch": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  recharts>lodash: 4.18.1
   micromatch>picomatch: 2.3.2
   tinyglobby>picomatch: 4.0.4
   minimatch>brace-expansion@^1: 1.1.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  braces: 3.0.3
   recharts>lodash: 4.18.1
   micromatch>picomatch: 2.3.2
   tinyglobby>picomatch: 4.0.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  micromatch>picomatch: 2.3.2
   tinyglobby>picomatch: 4.0.4
   minimatch>brace-expansion@^1: 1.1.14
   minimatch>brace-expansion@^5: 5.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ overrides:
   tinyglobby>picomatch: 4.0.4
   minimatch>brace-expansion@^1: 1.1.14
   minimatch>brace-expansion@^5: 5.0.5
-  lint-staged>yaml: 2.8.3
   next>postcss: 8.5.10
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  minimatch>brace-expansion@^1: 1.1.14
-  minimatch>brace-expansion@^5: 5.0.5
   next>postcss: 8.5.10
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  tinyglobby>picomatch: 4.0.4
   minimatch>brace-expansion@^1: 1.1.14
   minimatch>brace-expansion@^5: 5.0.5
   next>postcss: 8.5.10


### PR DESCRIPTION
## Summary

Override hygiene per `vizz-core:fix-vulnerabilities` guidelines §3. Root `pnpm audit` is clean (0 vulns / 911 deps); this PR shrinks `pnpm.overrides` from 8 → 1 by removing entries whose parents now declare dependency ranges that pull patched versions naturally.

- **Pin to exact**: `next>postcss` was `">=8.5.10"` (range) → `"8.5.10"` (exact). Guidelines §3 require exact pins.
- **Removed 7 redundant overrides** — locked versions unchanged in every case:
  - `lint-staged>yaml` — lint-staged@15.5.2 requests `yaml@^2.7.0` → 2.8.3 (patched) naturally
  - `braces` (blanket) — only consumer micromatch@4.0.8 requests `^3.0.3` → 3.0.3 (CVE-2024-4068 patched)
  - `recharts>lodash` — recharts@2.15.4 requests `^4.17.21` → 4.18.1 naturally
  - `micromatch>picomatch` — micromatch@4.0.8 requests `^2.3.1` → 2.3.2 (GHSA-952p-6rrq-rcjv patched)
  - `tinyglobby>picomatch` — tinyglobby@0.2.15 requests `^4.0.3` → 4.0.4 patched
  - `minimatch>brace-expansion@^1` and `@^5` — minimatch@3.1.5 + @10.2.5 request ranges that include the patched 1.1.14 / 5.0.5 (GHSA-v6h2-p8h4-qcjw / CVE-2025-5889)
- **Kept**: `next>postcss: "8.5.10"` — next@16.2.6 pins exact `postcss@8.4.31` (vulnerable to CVE-2026-41305); override still required.

Cloud-functions (`analysis`, `alerts-tiler`, `fetch-alerts`, `fetch-alerts-heatmap`, `upload-alerts`) all audit clean — no changes needed.

Each removal is its own atomic commit per guidelines §5; commits are independently revertable.

## Test plan

- [ ] CI: `pnpm audit` stays clean
- [ ] CI: `pnpm check-types` passes
- [ ] CI: Playwright suite green
- [ ] Spot-check Vercel preview: drawing tool, mangrove-extent widget (uses recharts/lodash), file-upload polygon (lint-staged path is dev-only, not runtime)