### PR TITLE
feat(mobile): switch to xl (1280px) breakpoint, redesign nav and legend

### DIFF
--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -1,148 +1,32 @@
 'use client';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
-import { trackEvent } from '@/lib/analytics/ga';
 import cn from '@/lib/classnames';
-
-import { useSyncActiveLayers } from '@/store/layers';
 
 import { AnimatePresence, motion } from 'motion/react';
 import { FaArrowDown, FaArrowUp } from 'react-icons/fa6';
 import { IconBaseProps } from 'react-icons/lib';
 
-import { useSyncLocation } from 'hooks/use-sync-location';
-
-import { useLocation } from '@/containers/datasets/locations/hooks';
-import { LocationTypes } from '@/containers/datasets/locations/types';
-import { NATIONAL_DASHBOARD_LOCATIONS } from '@/containers/layers/constants';
-import { widgets } from '@/containers/widgets/constants';
-
 import SortableList from '@/components/map/legend/sortable/list';
-import type { Layer } from 'types/layers';
-import type { WidgetTypes } from 'types/widget';
 
 import LegendItem from './item';
+import { useLegendLayers } from './use-legend-layers';
 
 const FaArrowDownIcon = FaArrowDown as unknown as (p: IconBaseProps) => JSX.Element;
 const FaArrowUpIcon = FaArrowUp as unknown as (p: IconBaseProps) => JSX.Element;
 
-const NATIONAL_DASHBOARD_PREFIX = 'mangrove_national_dashboard_layer_';
-
 const Legend = ({ embedded = false }: { embedded?: boolean }) => {
-  const [activeLayers, setActiveLayers] = useSyncActiveLayers();
-
-  const { type, id: locationId } = useSyncLocation();
-  const locationType = (type ?? 'worldwide') as LocationTypes;
-
-  const { data: locationData } = useLocation(locationId, locationType);
-  const iso = locationData?.iso;
-
-  const nationalLayerIdPrefix = iso ? `${NATIONAL_DASHBOARD_PREFIX}${iso}` : null;
-
-  // When the user navigates to another country, drop any national-dashboard
-  // layers belonging to the previous ISO so the URL state stays in sync and
-  // we don't try to render Mapbox sources from a different country.
-  useEffect(() => {
-    if (!iso) return;
-    setActiveLayers((prev) => {
-      const current = prev ?? [];
-      const next = current.filter(
-        (layer) =>
-          !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) ||
-          layer.id.startsWith(`${NATIONAL_DASHBOARD_PREFIX}${iso}_`) ||
-          layer.id === `${NATIONAL_DASHBOARD_PREFIX}${iso}`
-      );
-      return next.length === current.length ? prev : next;
-    });
-  }, [iso, setActiveLayers]);
-
-  const filterLayersByLocationType = useCallback(
-    (widgetsConfig: WidgetTypes[], currentLocationType: string): string[] => {
-      const filteredIds: string[] = [];
-
-      widgetsConfig.forEach((widget) => {
-        if (widget.locationType?.includes(currentLocationType)) {
-          if (widget.layersIds) filteredIds.push(...widget.layersIds);
-          if (widget.contextualLayersIds) filteredIds.push(...widget.contextualLayersIds);
-          if (widget.subLayersIds) filteredIds.push(...widget.subLayersIds);
-        }
-      });
-
-      return filteredIds;
-    },
-    []
-  );
-
-  const filteredLayersIds = useMemo(
-    () => filterLayersByLocationType(widgets, locationType),
-    [filterLayersByLocationType, locationType]
-  );
-
-  const filteredLayers = useMemo(() => {
-    const matched = (activeLayers ?? []).filter((layer) => {
-      const isStandardLayer = filteredLayersIds.includes(layer.id);
-
-      const isCurrentNationalLayer =
-        !!nationalLayerIdPrefix &&
-        (layer.id === nationalLayerIdPrefix || layer.id.startsWith(`${nationalLayerIdPrefix}_`));
-
-      return isStandardLayer || isCurrentNationalLayer;
-    }) as Layer[];
-
-    // Collapse all active national-dashboard layers under a single LegendItem;
-    // the WidgetLegend component lists each source row.
-    const firstNationalIdx = matched.findIndex((layer) =>
-      layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX)
-    );
-    return matched.filter(
-      (layer, idx) => !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) || idx === firstNationalIdx
-    );
-  }, [activeLayers, filteredLayersIds, nationalLayerIdPrefix]);
+  const { legendLayers, handleChangeOrder } = useLegendLayers();
 
   const [isOpen, setIsOpen] = useState(true);
 
   const openLegend = useCallback(() => {
-    if (activeLayers?.length) setIsOpen(true);
-  }, [activeLayers]);
+    if (legendLayers?.length) setIsOpen(true);
+  }, [legendLayers]);
 
   const closeLegend = useCallback(() => {
     setIsOpen(false);
   }, []);
-
-  const handleChangeOrder = useCallback(
-    (order: string[]) => {
-      const reorderedLayers = order
-        .map((layerId) => activeLayers?.find((layer) => layer.id === layerId))
-        .filter(Boolean) as Layer[];
-
-      const activePlanetLayers = activeLayers?.filter((layer) => layer.id.includes('planet')) ?? [];
-
-      trackEvent('Layers order', {
-        category: 'Layers',
-        action: 'Drag and drop',
-        label: `change layers order`,
-      });
-
-      setActiveLayers([...reorderedLayers, ...activePlanetLayers]);
-    },
-    [activeLayers, setActiveLayers]
-  );
-
-  const activeLayerNoPlanet = useMemo(
-    () =>
-      filteredLayers?.filter(
-        (layer) => !layer.id.includes('planet') && !layer.id.includes('custom-area')
-      ),
-    [filteredLayers]
-  );
-
-  const legendLayers = useMemo(() => {
-    const isNationalDashboardLocation = NATIONAL_DASHBOARD_LOCATIONS.includes(locationId);
-
-    if (isNationalDashboardLocation) return activeLayerNoPlanet;
-
-    return activeLayerNoPlanet?.filter((layer) => !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX));
-  }, [activeLayerNoPlanet, locationId]);
 
   return (
     <div>

--- a/src/containers/map/legend/mobile/index.tsx
+++ b/src/containers/map/legend/mobile/index.tsx
@@ -1,84 +1,49 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
-import cn from '@/lib/classnames';
-
-import { useSyncActiveLayers } from '@/store/layers';
-
-import { AnimatePresence, motion } from 'motion/react';
-import { FaArrowDown, FaArrowUp } from 'react-icons/fa6';
-import { IconBaseProps } from 'react-icons/lib';
+import SortableList from '@/components/map/legend/sortable/list';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 
 import LegendItem from '../item';
+import { useLegendLayers } from '../use-legend-layers';
 
-const FaArrowUpIcon = FaArrowUp as unknown as (p: IconBaseProps) => JSX.Element;
-const FaArrowDownIcon = FaArrowDown as unknown as (p: IconBaseProps) => JSX.Element;
+const PANEL_STYLE = 'shadow-medium rounded-3xl border border-black/10 bg-white';
 
 const Legend = () => {
-  const [activeLayers] = useSyncActiveLayers();
-
+  const { legendLayers, handleChangeOrder } = useLegendLayers();
   const [isOpen, setIsOpen] = useState(true);
 
-  const openLegend = useCallback(() => {
-    if (!!activeLayers?.length) setIsOpen(true);
-  }, [activeLayers]);
-
-  const closeLegend = useCallback(() => {
-    setIsOpen(false);
-  }, []);
-
-  const contentVariants = {
-    open: { y: '0%', opacity: 1 },
-    close: { y: '-200%', opacity: 0 },
-  };
+  if (!legendLayers?.length) return null;
 
   return (
-    <div className="flex w-screen justify-center">
-      {!!activeLayers?.length && (
-        <>
-          <button
-            onClick={openLegend}
-            className={cn({
-              'shadow-control flex h-11 w-[360px] cursor-pointer items-center justify-between rounded-3xl bg-white px-10 py-2':
-                true,
-              hidden: isOpen,
-            })}
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="flex w-screen flex-col items-center gap-2"
+    >
+      <CollapsibleTrigger
+        className={`${PANEL_STYLE} group hover:bg-grey-50 flex w-90 cursor-pointer items-center justify-between px-4 py-3 transition-colors`}
+      >
+        <p className="text-xs font-bold whitespace-nowrap text-black/85 uppercase opacity-85">
+          <span className="group-data-[state=open]:hidden">Show legend</span>
+          <span className="group-data-[state=closed]:hidden">Hide legend</span>
+        </p>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent
+        className={`${PANEL_STYLE} data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down w-90 overflow-hidden`}
+      >
+        <div className="box-content flex max-h-[calc(100vh-266px)] flex-col overflow-y-auto p-4">
+          <SortableList
+            onChangeOrder={handleChangeOrder}
+            sortable={{ handle: true, enabled: true }}
           >
-            <p className="text-xs font-bold whitespace-nowrap text-black/85 uppercase opacity-85">
-              Show legend
-            </p>
-
-            <FaArrowUpIcon className="mb-1" />
-          </button>
-
-          <AnimatePresence>
-            <motion.div
-              initial={false}
-              variants={contentVariants}
-              animate={isOpen ? 'open' : 'close'}
-              exit="close"
-              transition={{ type: 'spring', bounce: 0, duration: 0.8 }}
-              className="relative xl:fixed xl:right-[73px]"
-            >
-              <div className="shadow-medium animate-in data-[state=open]:fade-in-60 data-[state=close]:slide-in-from-bottom-0 data-[state=open]:slide-in-from-bottom-16 w-[360px] gap-4 rounded-3xl border bg-white duration-300">
-                <div className="box-content flex max-h-[70vh] flex-col space-y-1 divide-y divide-black/42 overflow-y-auto pt-4 md:px-4">
-                  <div className="box-content flex flex-col space-y-1 divide-y divide-black/42 overflow-y-auto px-4 pt-4 md:max-h-[55vh]">
-                    {activeLayers?.map((l) => {
-                      return <LegendItem id={l.id} key={l.id} l={l} />;
-                    })}
-                  </div>
-                </div>
-                <button
-                  onClick={closeLegend}
-                  className="absolute -top-[30px] right-5 z-50 rounded-t-3xl bg-white p-2"
-                >
-                  <FaArrowDownIcon />
-                </button>
-              </div>
-            </motion.div>
-          </AnimatePresence>
-        </>
-      )}
-    </div>
+            {legendLayers.map((layer) => (
+              <LegendItem id={layer.id} key={layer.id} l={layer} />
+            ))}
+          </SortableList>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 };
 

--- a/src/containers/map/legend/use-legend-layers.ts
+++ b/src/containers/map/legend/use-legend-layers.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { trackEvent } from '@/lib/analytics/ga';
+
+import { useSyncActiveLayers } from '@/store/layers';
+
+import { useSyncLocation } from 'hooks/use-sync-location';
+
+import { useLocation } from '@/containers/datasets/locations/hooks';
+import { LocationTypes } from '@/containers/datasets/locations/types';
+import { NATIONAL_DASHBOARD_LOCATIONS } from '@/containers/layers/constants';
+import { widgets } from '@/containers/widgets/constants';
+
+import type { Layer } from 'types/layers';
+import type { WidgetTypes } from 'types/widget';
+
+const NATIONAL_DASHBOARD_PREFIX = 'mangrove_national_dashboard_layer_';
+
+const filterLayersByLocationType = (
+  widgetsConfig: WidgetTypes[],
+  currentLocationType: string
+): string[] => {
+  const filteredIds: string[] = [];
+  widgetsConfig.forEach((widget) => {
+    if (widget.locationType?.includes(currentLocationType)) {
+      if (widget.layersIds) filteredIds.push(...widget.layersIds);
+      if (widget.contextualLayersIds) filteredIds.push(...widget.contextualLayersIds);
+      if (widget.subLayersIds) filteredIds.push(...widget.subLayersIds);
+    }
+  });
+  return filteredIds;
+};
+
+export const useLegendLayers = () => {
+  const [activeLayers, setActiveLayers] = useSyncActiveLayers();
+
+  const { type, id: locationId } = useSyncLocation();
+  const locationType = (type ?? 'worldwide') as LocationTypes;
+
+  const { data: locationData } = useLocation(locationId, locationType);
+  const iso = locationData?.iso;
+  const nationalLayerIdPrefix = iso ? `${NATIONAL_DASHBOARD_PREFIX}${iso}` : null;
+
+  useEffect(() => {
+    if (!iso) return;
+    setActiveLayers((prev) => {
+      const current = prev ?? [];
+      const next = current.filter(
+        (layer) =>
+          !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) ||
+          layer.id.startsWith(`${NATIONAL_DASHBOARD_PREFIX}${iso}_`) ||
+          layer.id === `${NATIONAL_DASHBOARD_PREFIX}${iso}`
+      );
+      return next.length === current.length ? prev : next;
+    });
+  }, [iso, setActiveLayers]);
+
+  const filteredLayersIds = useMemo(
+    () => filterLayersByLocationType(widgets, locationType),
+    [locationType]
+  );
+
+  const filteredLayers = useMemo(() => {
+    const matched = (activeLayers ?? []).filter((layer) => {
+      const isStandardLayer = filteredLayersIds.includes(layer.id);
+      const isCurrentNationalLayer =
+        !!nationalLayerIdPrefix &&
+        (layer.id === nationalLayerIdPrefix || layer.id.startsWith(`${nationalLayerIdPrefix}_`));
+      return isStandardLayer || isCurrentNationalLayer;
+    }) as Layer[];
+
+    const firstNationalIdx = matched.findIndex((layer) =>
+      layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX)
+    );
+    return matched.filter(
+      (layer, idx) => !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX) || idx === firstNationalIdx
+    );
+  }, [activeLayers, filteredLayersIds, nationalLayerIdPrefix]);
+
+  const activeLayerNoPlanet = useMemo(
+    () =>
+      filteredLayers?.filter(
+        (layer) => !layer.id.includes('planet') && !layer.id.includes('custom-area')
+      ),
+    [filteredLayers]
+  );
+
+  const legendLayers = useMemo(() => {
+    const isNationalDashboardLocation = NATIONAL_DASHBOARD_LOCATIONS.includes(locationId);
+    if (isNationalDashboardLocation) return activeLayerNoPlanet;
+    return activeLayerNoPlanet?.filter((layer) => !layer.id.startsWith(NATIONAL_DASHBOARD_PREFIX));
+  }, [activeLayerNoPlanet, locationId]);
+
+  const handleChangeOrder = useCallback(
+    (order: string[]) => {
+      const reorderedLayers = order
+        .map((layerId) => activeLayers?.find((layer) => layer.id === layerId))
+        .filter(Boolean) as Layer[];
+
+      const activePlanetLayers = activeLayers?.filter((layer) => layer.id.includes('planet')) ?? [];
+
+      trackEvent('Layers order', {
+        category: 'Layers',
+        action: 'Drag and drop',
+        label: `change layers order`,
+      });
+
+      setActiveLayers([...reorderedLayers, ...activePlanetLayers]);
+    },
+    [activeLayers, setActiveLayers]
+  );
+
+  return { legendLayers, handleChangeOrder };
+};

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -184,7 +184,7 @@ const WidgetsContainer: FC = () => {
         </Helper>
         <WidgetsDeckContent />
       </Dialog>
-      {!!widgetsAvailable.length && (
+      {!!widgetsAvailable.length && isCustomArea && (
         <div className="flex w-full justify-center py-4">
           <Helper
             className={{

--- a/src/containers/widgets/widgets-menu/index.tsx
+++ b/src/containers/widgets/widgets-menu/index.tsx
@@ -48,7 +48,8 @@ const WidgetsMenu: FC = () => {
     } else {
       setActiveWidgets(widgetsIds);
     }
-  }, [widgetsIds, setActiveWidgets, activeWidgets, widgets]);
+    setCategory('custom');
+  }, [widgetsIds, setActiveWidgets, activeWidgets, widgets, setCategory]);
 
   const handleAllLayers = useCallback(() => {
     if (activeLayers?.length <= LAYERS.length && activeLayers?.length > 0) {

--- a/src/layouts/widgets/index.tsx
+++ b/src/layouts/widgets/index.tsx
@@ -26,7 +26,7 @@ const WidgetsLayout = (props: PropsWithChildren) => {
           transition={{
             duration: 0.4,
           }}
-          className="scrollbar-hide pointer-events-auto mx-auto h-full w-screen max-w-155 px-2 py-14 xl:absolute xl:top-0 xl:left-0 xl:mx-0 xl:w-143 xl:max-w-none xl:overflow-y-auto xl:bg-transparent xl:px-5"
+          className="scrollbar-hide pointer-events-auto mx-auto h-full w-screen max-w-155 overflow-y-auto px-2 py-14 xl:absolute xl:top-0 xl:left-0 xl:mx-0 xl:w-143 xl:max-w-none xl:bg-transparent xl:px-5"
         >
           <LocationWidget />
           {children}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -82,9 +82,19 @@ const tailwindConfig = {
             left: '100px',
           },
         },
+        'collapsible-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-collapsible-content-height)' },
+        },
+        'collapsible-up': {
+          from: { height: 'var(--radix-collapsible-content-height)' },
+          to: { height: '0' },
+        },
       },
       animation: {
         'reverse-slide': 'reverse-slide 0.5s ease-in-out',
+        'collapsible-down': 'collapsible-down 300ms ease-out',
+        'collapsible-up': 'collapsible-up 300ms ease-out',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Switch mobile/desktop layout split to the **xl** breakpoint (1280px) across legend, map controls, sidebar, navigation
- Redesign mobile navigation bar (tooltips, shared `News` component, locations / language / map-toggle / configure cleanups)
- Rewrite mobile legend with Radix `Collapsible` + shared `useLegendLayers` hook (now used by desktop too)
- Responsive dialog: close button outside card on desktop, restored outside-click close
- Widgets: gate selector behind `isCustomArea`, force `custom` category on toggle-all, show active widgets regardless of category, mobile widths/padding/gap tweaks
- Hydration fix: wrap `useLocalStorage` to prevent React #418 in prod
- CI: bump GitHub Actions to Node 24, deploy-* workflows updated
- Stop tracking auto-generated `next-env.d.ts`

## Test plan
- [ ] Resize across `<1280px` (mobile) and `>=1280px` (desktop) — verify single legend renders per breakpoint
- [ ] Mobile nav: open/close tooltips, language selector, map toggle, locations, configure
- [ ] Mobile legend: open/close Collapsible, drag-reorder layers
- [ ] Custom area flow: widgets selector visible, toggle-all sets category to `custom`
- [ ] Non-custom-area views: widgets selector hidden
- [ ] Dialog: close on outside click, close button positioning on desktop
- [ ] Prod build smoke (`pnpm build && pnpm start`) — no hydration warnings
- [ ] Playwright suite green