### PR TITLE
Feat/mobile 1200px breakpoint

### DIFF
--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -79,15 +79,17 @@ const DialogContent = forwardRef<
           })}
           {...props}
         >
-          <div className="pointer-events-auto relative mx-auto w-full sm:max-w-135 xl:mx-0 xl:mt-10 xl:ml-6">
+          <div className="pointer-events-auto relative mx-auto w-full sm:max-w-135 xl:mx-0 xl:mt-4 xl:ml-6">
             <div
               className={cn({
-                'sm:shadow-card flex max-h-screen w-full shrink-0 flex-col overflow-y-auto border-none bg-white p-6 sm:max-h-[calc(100vh-2rem)] sm:p-8 md:rounded-3xl':
+                'sm:shadow-card flex max-h-screen w-full shrink-0 flex-col overflow-y-auto border-none bg-white p-6 sm:max-h-[calc(100vh-4rem)] sm:p-8 md:rounded-3xl':
                   true,
                 [className || '']: !!className,
               })}
             >
+              <div className="pointer-events-none sticky -top-6 z-20 -mx-6 -mt-6 -mb-2 h-8 shrink-0 bg-gradient-to-b from-white to-transparent sm:-top-8 sm:-mx-8 sm:-mt-8 sm:mb-0" />
               {restChildren}
+              <div className="pointer-events-none sticky -bottom-6 z-20 -mx-6 -mt-2 -mb-6 h-8 shrink-0 bg-gradient-to-t from-white to-transparent sm:-bottom-8 sm:-mx-8 sm:mt-0 sm:-mb-8" />
             </div>
             {closeButton}
           </div>

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -214,11 +214,11 @@ export function useMangroveHabitatExtent(
   }, [data, isFetching, isError, refetch, DATA]);
 }
 
-export function useSource(): SourceProps {
+export function useSource({ year }: { year: number }): SourceProps {
   return {
-    id: 'habitat_extent',
+    id: `habitat_extent_${year}`,
     type: 'vector',
-    url: 'mapbox://globalmangrovewatch.20cshxs9,globalmangrovewatch.b1wlg2x7,globalmangrovewatch.2cws6y26,globalmangrovewatch.bgrhiwte,globalmangrovewatch.aokkuxu7,globalmangrovewatch.0l7s8iga,globalmangrovewatch.a08vpx09,globalmangrovewatch.7kyxxf0e,globalmangrovewatch.1cu4rmy9,globalmangrovewatch.6st408jz,globalmangrovewatch.1clkx4nk',
+    url: `mapbox://globalmangrovewatch.gmw-v4-extent-${year}`,
   };
 }
 
@@ -236,10 +236,10 @@ export function useLayers({
   return year
     ? [
         {
-          id: `${id}_${year}_line`,
+          id: `${id}_${year}_fill`,
           type: 'fill',
-          source: 'habitat_extent',
-          'source-layer': `mng_mjr_${year}`,
+          source: `habitat_extent_${year}`,
+          'source-layer': `gmw_v4_extent_${year}`,
           paint: {
             'fill-color': '#06C4BD',
             'fill-opacity': ['interpolate', ['linear'], ['zoom'], 0, opacity * 1.2, 12, opacity],
@@ -249,10 +249,10 @@ export function useLayers({
           },
         },
         {
-          id: `${id}_${year}_fill`,
+          id: `${id}_${year}_line`,
           type: 'line',
-          source: 'habitat_extent',
-          'source-layer': `mng_mjr_${year}`,
+          source: `habitat_extent_${year}`,
+          'source-layer': `gmw_v4_extent_${year}`,
           paint: {
             'line-color': '#06C4BD',
             'line-opacity': opacity,

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -18,7 +18,7 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
 
   const currentYear = year || years[years.length - 1];
 
-  const SOURCE = useSource();
+  const SOURCE = useSource({ year: currentYear });
   const LAYERS = useLayers({
     year: currentYear,
     id,

--- a/src/containers/welcome-message/index.tsx
+++ b/src/containers/welcome-message/index.tsx
@@ -33,7 +33,7 @@ const WelcomeIntroMessage = () => {
       <DialogTrigger className="sr-only">Welcome message</DialogTrigger>
       <DialogContent
         classNameContent="animate-none duration-0 min-h-fit"
-        className="fixed top-0 right-0 bottom-0 left-0 min-h-fit w-screen max-w-screen space-y-6 p-0 text-black/85 shadow-sm sm:top-1/2 sm:left-1/2 sm:-translate-x-1/2 sm:-translate-y-1/2 sm:p-8 md:max-w-3xl md:p-0"
+        className="fixed top-0 right-0 bottom-0 left-0 min-h-fit w-screen max-w-screen space-y-6 p-0 text-black/85 shadow-sm sm:top-1/2 sm:left-1/2 sm:w-auto sm:max-w-xl sm:-translate-x-1/2 sm:-translate-y-1/2 sm:overflow-visible sm:p-8 md:max-w-3xl md:p-0"
       >
         <div className="relative m-0 flex h-full w-full flex-col sm:static sm:grid sm:grid-cols-12">
           <div className="relative h-[calc(100vh/2)] w-full overflow-hidden sm:col-span-6 sm:h-full sm:rounded-tl-3xl sm:rounded-bl-3xl">
@@ -66,8 +66,8 @@ const WelcomeIntroMessage = () => {
               </Button>
             </div>
           </div>
+          <DialogClose onClose={handleClose} />
         </div>
-        <DialogClose onClose={handleClose} />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
This pull request updates the mangrove habitat extent dataset layer to support year-specific Mapbox vector sources and improves the dialog UI components for better usability and appearance. The most important changes are grouped below:

**Mangrove Habitat Extent Layer Improvements:**

* The `useSource` hook now requires a `year` parameter and generates a year-specific `id` and Mapbox URL, enabling dynamic loading of different years of mangrove extent data. (`src/containers/datasets/habitat-extent/hooks.tsx`)
* The `useLayers` hook updates layer IDs, sources, and source-layers to match the new year-specific dataset structure, ensuring correct rendering of fill and line layers for each year. (`src/containers/datasets/habitat-extent/hooks.tsx`) [[1]](diffhunk://#diff-ade39f541cf0ea7ab8dc59221f79b0dff865876ccc10eb34ae1f5ecbc91ca998L239-R242) [[2]](diffhunk://#diff-ade39f541cf0ea7ab8dc59221f79b0dff865876ccc10eb34ae1f5ecbc91ca998L252-R255)
* The `MangrovesHabitatExtentLayer` component now passes the current year to the `useSource` hook, aligning with the new API. (`src/containers/datasets/habitat-extent/layer.tsx`)

**Dialog and Welcome Message UI Improvements:**

* The dialog content component (`DialogContent`) now includes sticky gradient overlays at the top and bottom to improve visual separation and scrolling cues, and adjusts margins/padding for better layout on extra-large screens. (`src/components/ui/dialog/index.tsx`)
* The welcome message dialog’s layout is improved for medium and larger screens, with better sizing, overflow handling, and placement, enhancing the user experience. (`src/containers/welcome-message/index.tsx`) [[1]](diffhunk://#diff-b861f356a21d014c241cc2aa8d1fcb71057c47775f95cf34f1427ff194f957afL36-R36) [[2]](diffhunk://#diff-b861f356a21d014c241cc2aa8d1fcb71057c47775f95cf34f1427ff194f957afL69-R70)