### PR TITLE
fix: restore location modal click and clean dashboard layout

### DIFF
--- a/src/components/contextual-layers/controls.tsx
+++ b/src/components/contextual-layers/controls.tsx
@@ -64,7 +64,7 @@ const Controls = ({ id, origin }: ControlTypes) => {
         </DialogContent>
       </Dialog>
 
-      <SwitchWrapper id={id}>
+      <SwitchWrapper id={id} label="Toggle contextual layer">
         <SwitchRoot onClick={handleClick} defaultChecked={isActive} checked={isActive}>
           <SwitchThumb />
         </SwitchRoot>

--- a/src/components/ui/dialog/index.tsx
+++ b/src/components/ui/dialog/index.tsx
@@ -128,7 +128,7 @@ const DialogClose = ({
     <button
       type="button"
       className={cn({
-        'md:shadow-card absolute top-4 right-4 z-10 flex h-11 w-10 cursor-pointer items-center justify-end focus:ring-1 focus:ring-slate-400 focus:ring-offset-1 focus:outline-none sm:-top-2 sm:-right-10 sm:rounded-r-[20px] md:top-9 md:bg-white/70 md:backdrop-blur-sm':
+        'md:shadow-card absolute top-4 right-4 z-10 flex h-11 w-10 cursor-pointer items-center justify-end focus:ring-1 focus:ring-slate-400 focus:ring-offset-1 focus:outline-none sm:-top-2 sm:-right-10 sm:rounded-r-[20px] md:top-7 md:bg-white/70 md:backdrop-blur-sm':
           true,
         [className || '']: !!className,
       })}

--- a/src/components/ui/switch/index.tsx
+++ b/src/components/ui/switch/index.tsx
@@ -7,6 +7,7 @@ import * as SwitchRadix from '@radix-ui/react-switch';
 type WrapperProps = Readonly<{
   'data-testid'?: string;
   id: string;
+  label: string;
   children: ReactNode;
   className?: string;
 }>;
@@ -66,7 +67,7 @@ const SwitchThumb = ({
   </SwitchRadix.Thumb>
 );
 
-const SwitchWrapper = ({ id, children, className }: WrapperProps) => (
+const SwitchWrapper = ({ id, label, children, className }: WrapperProps) => (
   <div className="flex items-center">
     <label
       className={cn(className, {
@@ -74,7 +75,7 @@ const SwitchWrapper = ({ id, children, className }: WrapperProps) => (
       })}
       htmlFor={id}
     >
-      {id}
+      {label}
     </label>
     {children}
   </div>

--- a/src/components/widget-controls/layer-toggle.tsx
+++ b/src/components/widget-controls/layer-toggle.tsx
@@ -57,7 +57,7 @@ const LayerToggle = ({ id }: WidgetControlsType) => {
       tooltipPosition={{ top: -35, left: 0 }}
       message="Use this icon to toggle the map layer on or off. If a widget does not have this icon, it means that there is no associated map layer."
     >
-      <SwitchWrapper id={id as string}>
+      <SwitchWrapper id={id as string} label="Toggle map layer">
         <SwitchRoot
           data-testid={id}
           onClick={handleClick}

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -158,7 +158,7 @@ const FloodProtection = ({
           <header className="flex justify-between">
             <h3 className={WIDGET_SUBTITLE_STYLE}>{indicator}</h3>
             <div className="flex items-start space-x-2">
-              <SwitchWrapper id="planet_medres_visual_monthly">
+              <SwitchWrapper id="planet_medres_visual_monthly" label="Planet monthly mosaic">
                 <SwitchRoot
                   data-testid={id}
                   onClick={handleClick}

--- a/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
@@ -12,25 +12,18 @@ const UNIT_ARIA = {
 
 const IndicatorExtent = ({ unit, dataSource }: IndicatorExtentProps) => {
   if (!dataSource?.value) {
-    return (
-      <div className="flex flex-col space-y-2">
-        <h5 className="text-sm font-normal">Extent</h5>
-      </div>
-    );
+    return <span />;
   }
   const displayUnit = unit ? LABEL_UNITS[unit] || unit : '';
   const ariaUnit = unit ? UNIT_ARIA[unit] || unit : '';
   return (
-    <div className="flex flex-col space-y-2">
-      <h5 className="text-sm font-normal">Extent</h5>
-      <span
-        className="whitespace-nowrap"
-        aria-label={`${numberFormat(dataSource.value)} ${ariaUnit}`.trim()}
-      >
-        <span className="notranslate">{numberFormat(dataSource.value)}</span>
-        {displayUnit && <span> {displayUnit}</span>}
-      </span>
-    </div>
+    <span
+      className="whitespace-nowrap"
+      aria-label={`${numberFormat(dataSource.value)} ${ariaUnit}`.trim()}
+    >
+      <span className="notranslate">{numberFormat(dataSource.value)}</span>
+      {displayUnit && <span> {displayUnit}</span>}
+    </span>
   );
 };
 

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -25,6 +25,7 @@ const IndicatorSources = ({
   unit,
   data_source,
   color,
+  className,
 }: IndicatorSourcesProps) => {
   const [activeLayers, setActiveLayers] = useSyncActiveLayers();
   const [yearSelected, setYearSelected] = useState<number>(years?.[years.length - 1]);
@@ -126,7 +127,7 @@ const IndicatorSources = ({
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
   return (
-    <div className="flex w-full items-start justify-between space-x-4 py-4">
+    <div className={className}>
       <IndicatorSource source={source} color={color} />
       <IndicatorYear yearSelected={yearSelected} setYearSelected={setYearSelected} years={years} />
       <IndicatorExtent unit={unit} dataSource={dataSource} />
@@ -139,7 +140,7 @@ const IndicatorSources = ({
             name: source,
           }}
         />
-        <SwitchWrapper id={layerId}>
+        <SwitchWrapper id={layerId} label={`Toggle ${source} ${indicator} layer`}>
           <SwitchRoot
             id={layerId}
             onClick={handleClick}

--- a/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
@@ -1,18 +1,15 @@
 import type { IndicatorSourceProps } from './types';
 
 const IndicatorSource = ({ source, color }: IndicatorSourceProps) => (
-  <div className="flex max-w-[140px] flex-col space-y-2">
-    <h5 className="text-sm font-normal">Source</h5>
-    <div className="flex w-full items-start space-x-2" aria-label={source}>
-      <div
-        style={{ backgroundColor: color }}
-        className="mt-1 h-4 w-2 shrink-0 rounded-md"
-        aria-hidden="true"
-      />
-      <span className="truncate" title={source}>
-        {source}
-      </span>
-    </div>
+  <div className="flex w-full items-start space-x-2" aria-label={source}>
+    <div
+      style={{ backgroundColor: color }}
+      className="mt-1 h-4 w-2 shrink-0 rounded-md"
+      aria-hidden="true"
+    />
+    <span className="truncate" title={source}>
+      {source}
+    </span>
   </div>
 );
 

--- a/src/containers/datasets/national-dashboard/indicator-layers/types.ts
+++ b/src/containers/datasets/national-dashboard/indicator-layers/types.ts
@@ -23,6 +23,7 @@ export type IndicatorSourcesProps = {
   data_source: DataSourceType[];
 
   color: string;
+  className?: string;
 };
 
 export type IndicatorSourceProps = {

--- a/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
@@ -9,53 +9,50 @@ import type { IndicatorYearProps } from './types';
 
 const IndicatorYear = ({ years, yearSelected, setYearSelected }: IndicatorYearProps) => {
   return (
-    <div className="flex max-w-fit flex-col space-y-2">
-      <h5 className="text-sm font-normal">Year</h5>
-      <div>
-        {years?.length === 1 && <span>{years?.[0]}</span>}
-        {years?.length > 1 && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <button
-                type="button"
-                aria-haspopup="listbox"
-                aria-label={`Select year, current ${yearSelected}`}
-                className={`${WIDGET_SELECT_STYLES}`}
-              >
-                {yearSelected}
-                <ARROW_SVG
-                  className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                  aria-hidden="true"
-                />
-              </button>
-            </PopoverTrigger>
+    <div>
+      {years?.length === 1 && <span>{years?.[0]}</span>}
+      {years?.length > 1 && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-haspopup="listbox"
+              aria-label={`Select year, current ${yearSelected}`}
+              className={`${WIDGET_SELECT_STYLES}`}
+            >
+              {yearSelected}
+              <ARROW_SVG
+                className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
+                aria-hidden="true"
+              />
+            </button>
+          </PopoverTrigger>
 
-            <PopoverContent className="shadow-border rounded-2xl px-2">
-              <ul role="listbox" className="max-h-32 space-y-0.5">
-                {years?.map((u) => (
-                  <li key={u}>
-                    <button
-                      key={u}
-                      role="option"
-                      aria-selected={yearSelected === u}
-                      className={cn({
-                        'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
-                        'hover:text-brand-800': yearSelected !== u,
-                        'pointer-events-none opacity-50': yearSelected === u,
-                      })}
-                      type="button"
-                      onClick={() => setYearSelected(u)}
-                      disabled={yearSelected === u}
-                    >
-                      {u}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </PopoverContent>
-          </Popover>
-        )}
-      </div>
+          <PopoverContent className="shadow-border rounded-2xl px-2">
+            <ul role="listbox" className="max-h-32 space-y-0.5">
+              {years?.map((u) => (
+                <li key={u}>
+                  <button
+                    key={u}
+                    role="option"
+                    aria-selected={yearSelected === u}
+                    className={cn({
+                      'hover:bg-brand-800/20 w-full rounded-lg px-2 py-1 text-left': true,
+                      'hover:text-brand-800': yearSelected !== u,
+                      'pointer-events-none opacity-50': yearSelected === u,
+                    })}
+                    type="button"
+                    onClick={() => setYearSelected(u)}
+                    disabled={yearSelected === u}
+                  >
+                    {u}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      )}
     </div>
   );
 };

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -23,10 +23,17 @@ const Sources = ({ data, iso }) => {
     .scale(COLORS)
     .colors(sourceColorMap.size > COLORS.length ? sourceColorMap.size : COLORS.length);
 
+  const gridCols = 'grid grid-cols-[140px_max-content_1fr_max-content] items-center gap-x-4';
   return (
     <section className="space-y-6.25">
       {data?.map(({ indicator, sources }) => (
         <div key={indicator}>
+          <div className={`${gridCols} py-2`}>
+            <h5 className="text-sm font-normal">Source</h5>
+            <h5 className="text-sm font-normal">Year</h5>
+            <h5 className="text-sm font-normal">Extent</h5>
+            <span />
+          </div>
           {sources.map(({ source, years, unit, data_source }) => {
             const colorIndex = sourceColorMap.get(source) ?? 0;
             const color = palette[colorIndex % palette.length];
@@ -44,6 +51,7 @@ const Sources = ({ data, iso }) => {
                 unit={unit}
                 data_source={data_source}
                 color={color}
+                className={`${gridCols} py-3`}
               />
             );
           })}

--- a/src/containers/help/index.tsx
+++ b/src/containers/help/index.tsx
@@ -68,7 +68,7 @@ const HelpContainer = ({ theme = 'light', hasArrow = false, className }: HelpCon
           <div className="flex space-x-2">
             <span>Navigation help</span>
 
-            <SwitchWrapper id="guide-intro" className="h-2 w-4">
+            <SwitchWrapper id="guide-intro" label="Navigation help" className="h-2 w-4">
               <SwitchRoot
                 data-testid="guide-switch"
                 onClick={handleClick}

--- a/src/containers/location-widget/index.tsx
+++ b/src/containers/location-widget/index.tsx
@@ -14,10 +14,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 import AnalysisAlert from '@/containers/alert';
 import { useLocation } from '@/containers/datasets/locations/hooks';
 import type { LocationTypes } from '@/containers/datasets/locations/types';
-import LocationDialogContent from '@/containers/location-dialog-content';
 import MenuTools from '@/containers/navigation/menu-tools';
-
-import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 
 const LocationWidget = () => {
   const { type, id } = useSyncLocation();
@@ -30,12 +27,11 @@ const LocationWidget = () => {
 
   const [{ enabled: isAnalysisEnabled }] = useAtom(analysisAtom);
 
-  const [isAnalysisAlertOpen, setAnalysisAlert] = useAtom(analysisAlertAtom);
+  const setAnalysisAlert = useSetAtom(analysisAlertAtom);
   const [locationsModalIsOpen, setLocationsModalIsOpen] = useAtom(locationsModalAtom);
   const skipAnalysisAlert = useAtomValue(skipAnalysisAlertAtom);
   const saveLocationTool = useSetAtom(locationToolAtom);
 
-  const [isOpen, setIsOpen] = useState<boolean>(false);
   const [width, setWidth] = useState<number>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
 
@@ -48,10 +44,6 @@ const LocationWidget = () => {
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
-
-  const closeMenu = useCallback(() => {
-    if (!isAnalysisAlertOpen) setIsOpen(false);
-  }, [isAnalysisAlertOpen]);
 
   const locationName = useMemo(() => {
     if (locationType === 'custom-area') {
@@ -89,39 +81,34 @@ const LocationWidget = () => {
   return (
     <>
       <div className="bg-brand-600 shadow-control relative flex h-52 flex-col justify-between rounded-3xl bg-[url(/images/location-bg.svg)] bg-cover bg-center text-center">
-        <Dialog open={isOpen} onOpenChange={setIsOpen}>
-          <DialogTrigger asChild>
-            <button
-              type="button"
-              onClick={handleOnClickTitle}
-              disabled={isGuideActive || !locationName}
-            >
-              {!!locationName ? (
-                <div
-                  className={cn({
-                    'inline-block flex-1 grow cursor-pointer px-10 pt-8 text-6xl font-light text-black/85 first-letter:uppercase':
-                      true,
-                    'text-2.75xl': width >= 540,
+        <button
+          type="button"
+          onClick={handleOnClickTitle}
+          disabled={isGuideActive || !locationName}
+        >
+          {!!locationName ? (
+            <div
+              className={cn({
+                'inline-block flex-1 grow cursor-pointer px-10 pt-8 text-6xl font-light text-black/85 first-letter:uppercase':
+                  true,
+                'text-2.75xl': width >= 540,
 
-                    'text-5xl': locationName.length > 10,
-                    'text-3xl': locationName.length > 30 && locationName.length <= 55,
-                    'text-2xl': locationName.length > 55 && locationName.length <= 120,
-                    'text-base break-all': locationName.length > 120,
-                  })}
-                >
-                  <h1 className="cursor-pointer text-white" ref={titleRef}>
-                    {locationName}
-                  </h1>
-                </div>
-              ) : (
-                !locationName && (
-                  <div className="bg-secondary-900 h-[20px] w-[100px] animate-pulse rounded-md" />
-                )
-              )}
-            </button>
-          </DialogTrigger>
-          <LocationDialogContent close={closeMenu} />
-        </Dialog>
+                'text-5xl': locationName.length > 10,
+                'text-3xl': locationName.length > 30 && locationName.length <= 55,
+                'text-2xl': locationName.length > 55 && locationName.length <= 120,
+                'text-base break-all': locationName.length > 120,
+              })}
+            >
+              <h1 className="cursor-pointer text-white" ref={titleRef}>
+                {locationName}
+              </h1>
+            </div>
+          ) : (
+            !locationName && (
+              <div className="bg-secondary-900 h-[20px] w-[100px] animate-pulse rounded-md" />
+            )
+          )}
+        </button>
         <MenuTools />
       </div>
       <AnalysisAlert />

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -178,7 +178,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
   };
 
   return (
-    <div className="space-y-4 overflow-hidden pt-8 after:bg-linear-to-b after:from-white/20 after:to-white after:content-[''] md:pt-0">
+    <div className="relative space-y-4 overflow-hidden pt-8 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:z-10 after:h-16 after:bg-linear-to-b after:from-white/0 after:to-white after:content-[''] md:pt-0">
       <div className="relative box-border w-full px-1 pt-0.5">
         <Helper
           className={{

--- a/src/containers/navigation/menu/profile/subscriptions.tsx
+++ b/src/containers/navigation/menu/profile/subscriptions.tsx
@@ -95,7 +95,7 @@ const SubscriptionsContent = () => {
                     </p>
                   </div>
 
-                  <SwitchWrapper id="alerts">
+                  <SwitchWrapper id="alerts" label="Alerts notification">
                     <SwitchRoot
                       checked={!!effective?.location_alerts}
                       disabled={isDisabled}
@@ -130,7 +130,7 @@ const SubscriptionsContent = () => {
               </p>
             </div>
 
-            <SwitchWrapper id="newsletter">
+            <SwitchWrapper id="newsletter" label="Newsletter">
               <SwitchRoot
                 checked={!!effective?.newsletter}
                 disabled={isSaving}


### PR DESCRIPTION
- Remove duplicate Dialog from location-widget; rely on FindLocations global atom flow so title click opens the modal exactly once
- Add bottom fade to locations list via positioned ::after pseudo
- National-dashboard sources render single Source/Year/Extent header with grid rows; drop repeated per-row labels
- SwitchWrapper takes a label prop; replace raw layer slugs with human-readable labels across all call sites
