### PR TITLE
clone GEE assets from legacy project

### DIFF
--- a/cloud-functions/analysis/src/geeAssets/AboveGroundDataAssets.ts
+++ b/cloud-functions/analysis/src/geeAssets/AboveGroundDataAssets.ts
@@ -7,7 +7,7 @@ export interface IHansenDataAsset extends IDataAsset {
 
 export const AbovegroundBiomassDataAsset: IHansenDataAsset = {
   assetPath: {
-    default: "projects/global-mangrove-watch/mangrove-properties/mangrove_aboveground_biomass-v3"
+    default: "projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_aboveground_biomass-v3"
   },
   numYears: 20,
   getEEAsset(){

--- a/cloud-functions/analysis/src/geeAssets/BlueCarbonDataAssets.ts
+++ b/cloud-functions/analysis/src/geeAssets/BlueCarbonDataAssets.ts
@@ -7,7 +7,7 @@ export interface IHansenDataAsset extends IDataAsset {
 
 export const BlueCarbonDataAsset: IHansenDataAsset = {
   assetPath: {
-    default: "projects/global-mangrove-watch/mangrove-properties/mangrove_blue_carbon-v2_1"
+    default: "projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_blue_carbon-v2_1"
   },
   numYears: 1,
   getEEAsset(){

--- a/cloud-functions/analysis/src/geeAssets/CoastalExtentDataAsset.ts
+++ b/cloud-functions/analysis/src/geeAssets/CoastalExtentDataAsset.ts
@@ -7,7 +7,7 @@ export interface IExtentDataAsset extends IDataAsset {
 
 export const CoastalExtentDataAsset: IExtentDataAsset = {
   assetPath: {
-    default: "projects/global-mangrove-watch/physical-environment/coastlines-v3"
+    default: "projects/mangrove-atlas-246414/assets/physical-environment/coastlines-v3"
   },
   numYears: 11,
   getEEAsset(){

--- a/cloud-functions/analysis/src/geeAssets/TreeHeightDataAsset.ts
+++ b/cloud-functions/analysis/src/geeAssets/TreeHeightDataAsset.ts
@@ -7,7 +7,7 @@ export interface IHansenDataAsset extends IDataAsset {
 
 export const TreeHeightDataAsset: IHansenDataAsset = {
   assetPath: {
-    default: "projects/global-mangrove-watch/mangrove-properties/mangrove_canopy_height-v3"
+    default: "projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_canopy_height-v3"
   },
   numYears: 11,
   getEEAsset(){

--- a/data/notebooks/Lab/data_processing/GEE/clone_gee_assets.ipynb
+++ b/data/notebooks/Lab/data_processing/GEE/clone_gee_assets.ipynb
@@ -1,0 +1,723 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-0",
+   "metadata": {},
+   "source": [
+    "# Clone GEE Image Collections between projects\n",
+    "\n",
+    "Copies image collections from the following source folders into `projects/mangrove-atlas-246414/assets/`:\n",
+    "\n",
+    "| Source folder | Destination folder |\n",
+    "|---|---|\n",
+    "| `projects/global-mangrove-watch/land-cover/` | `…/assets/land-cover` |\n",
+    "| `projects/global-mangrove-watch/mangrove-properties/` | `…/assets/mangrove-properties` |\n",
+    "| `projects/global-mangrove-watch/physical-environment/` | `…/assets/physical-environment` |\n",
+    "\n",
+    "Steps:\n",
+    "1. List all image collections in the source folder.\n",
+    "2. For each collection, create a matching image collection in the destination.\n",
+    "3. List all images inside the source collection.\n",
+    "4. Copy each image asset to the destination collection.\n",
+    "\n",
+    "> **Requirements**: You must have read access to the source project and write access to the destination project."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-1",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ee\n",
+    "import logging\n",
+    "from typing import List, Dict, Optional\n",
+    "\n",
+    "logging.basicConfig(level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Authenticate and initialise Earth Engine\n",
+    "ee.Authenticate()\n",
+    "ee.Initialize()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-2",
+   "metadata": {},
+   "source": [
+    "## Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SOURCE_FOLDER = 'projects/global-mangrove-watch/land-cover'\n",
+    "DEST_FOLDER   = 'projects/mangrove-atlas-246414/assets/land-cover'\n",
+    "\n",
+    "# Set to a list of collection names (without path) to restrict which collections\n",
+    "# are copied. Leave as None to copy everything found in SOURCE_FOLDER.\n",
+    "# Example: COLLECTION_FILTER = ['mangrove_extent-v3', 'mangrove_height-v3']\n",
+    "COLLECTION_FILTER: Optional[List[str]] = None\n",
+    "\n",
+    "# Set to True to overwrite assets that already exist in the destination.\n",
+    "ALLOW_OVERWRITE = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-3",
+   "metadata": {},
+   "source": [
+    "## Helper functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "cell-4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def list_all_assets(parent: str) -> List[Dict]:\n",
+    "    \"\"\"List every asset under `parent`, handling pagination automatically.\"\"\"\n",
+    "    assets = []\n",
+    "    page_token = None\n",
+    "    while True:\n",
+    "        params = {'parent': parent}\n",
+    "        if page_token:\n",
+    "            params['pageToken'] = page_token\n",
+    "        response = ee.data.listAssets(params)\n",
+    "        assets.extend(response.get('assets', []))\n",
+    "        page_token = response.get('nextPageToken')\n",
+    "        if not page_token:\n",
+    "            break\n",
+    "    return assets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def asset_name(asset_id: str) -> str:\n",
+    "    \"\"\"Return the last path component of an asset id.\"\"\"\n",
+    "    return asset_id.split('/')[-1]\n",
+    "\n",
+    "\n",
+    "def dest_id(source_name: str, source_parent: str, dest_parent: str) -> str:\n",
+    "    \"\"\"Rebase `source_name` from `source_parent` to `dest_parent`.\n",
+    "\n",
+    "    Asset names returned by the API may carry a legacy prefix\n",
+    "    (``projects/earthengine-legacy/assets/``).  Strip it first so the\n",
+    "    rebasing works for any source project path.\n",
+    "    \"\"\"\n",
+    "    canonical = source_name.removeprefix('projects/earthengine-legacy/assets/')\n",
+    "    relative = canonical[len(source_parent):].lstrip('/')\n",
+    "    return f'{dest_parent}/{relative}'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "cell-6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def ensure_image_collection(path: str, source_properties: Dict) -> None:\n",
+    "    \"\"\"Create an ImageCollection at `path` if it does not already exist.\n",
+    "\n",
+    "    Copies the top-level properties from the source collection so that\n",
+    "    metadata (name, keywords, etc.) is preserved.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        ee.data.getAsset(path)\n",
+    "        logging.info(f'Collection already exists, skipping creation: {path}')\n",
+    "    except Exception:\n",
+    "        # getAsset raises when the asset does not exist\n",
+    "        properties = source_properties.get('properties', {})\n",
+    "        ee.data.createAsset({'type': 'ImageCollection', **({'properties': properties} if properties else {})}, path)\n",
+    "        logging.info(f'Created image collection: {path}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def copy_image(source_id: str, dest_image_id: str, allow_overwrite: bool = False) -> None:\n",
+    "    \"\"\"Copy a single image asset from `source_id` to `dest_image_id`.\"\"\"\n",
+    "    try:\n",
+    "        ee.data.copyAsset(source_id, dest_image_id, allowOverwrite=allow_overwrite)\n",
+    "        logging.info(f'  Copied: {source_id} -> {dest_image_id}')\n",
+    "    except ee.EEException as exc:\n",
+    "        if 'already exists' in str(exc):\n",
+    "            logging.warning(f'  Already exists (skipped): {dest_image_id}')\n",
+    "        else:\n",
+    "            logging.error(f'  Failed to copy {source_id}: {exc}')\n",
+    "            raise"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "acbf43a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Asset types that are copied as-is (not recursed into)\n",
+    "DIRECT_COPY_TYPES = {'IMAGE', 'TABLE', 'FEATURE_VIEW', 'CLASSIFIER', 'ARRAY'}\n",
+    "\n",
+    "\n",
+    "def clone_folder(\n",
+    "    source_folder: str,\n",
+    "    dest_folder: str,\n",
+    "    collection_filter: Optional[List[str]] = None,\n",
+    "    allow_overwrite: bool = False,\n",
+    ") -> None:\n",
+    "    \"\"\"Clone every ImageCollection and direct asset under *source_folder* into *dest_folder*.\n",
+    "\n",
+    "    - ``IMAGE_COLLECTION``: the collection is recreated and all contained images are copied.\n",
+    "    - ``IMAGE``, ``TABLE``, and other direct types: copied straight to *dest_folder*.\n",
+    "\n",
+    "    Args:\n",
+    "        source_folder: GEE asset path of the source folder.\n",
+    "        dest_folder: GEE asset path of the destination folder.\n",
+    "        collection_filter: If given, only assets whose bare name is in this list are\n",
+    "            processed.  ``None`` processes everything.\n",
+    "        allow_overwrite: Passed through to copy calls.\n",
+    "    \"\"\"\n",
+    "    all_assets = list_all_assets(source_folder)\n",
+    "    collections   = [a for a in all_assets if a.get('type') == 'IMAGE_COLLECTION']\n",
+    "    direct_assets = [a for a in all_assets if a.get('type') in DIRECT_COPY_TYPES]\n",
+    "\n",
+    "    if collection_filter is not None:\n",
+    "        collections   = [c for c in collections   if asset_name(c['name']) in collection_filter]\n",
+    "        direct_assets = [a for a in direct_assets if asset_name(a['name']) in collection_filter]\n",
+    "\n",
+    "    print(f'Found in {source_folder}:')\n",
+    "    print(f'  {len(collections)} image collection(s)')\n",
+    "    print(f'  {len(direct_assets)} direct asset(s)')\n",
+    "\n",
+    "    # -- image collections -------------------------------------------------------\n",
+    "    for collection in collections:\n",
+    "        src_col = collection['name']\n",
+    "        dst_col = dest_id(src_col, source_folder, dest_folder)\n",
+    "\n",
+    "        logging.info(f'\\n=== Collection: {src_col} ===')\n",
+    "        source_meta = ee.data.getAsset(src_col)\n",
+    "        ensure_image_collection(dst_col, source_meta)\n",
+    "\n",
+    "        images = list_all_assets(src_col)\n",
+    "        logging.info(f'Copying {len(images)} image(s)...')\n",
+    "        for img in images:\n",
+    "            dst_img = dest_id(img['name'], source_folder, dest_folder)\n",
+    "            copy_image(img['name'], dst_img, allow_overwrite)\n",
+    "\n",
+    "        logging.info(f'Done: {dst_col}')\n",
+    "\n",
+    "    # -- direct assets -----------------------------------------------------------\n",
+    "    for asset in direct_assets:\n",
+    "        src_asset = asset['name']\n",
+    "        dst_asset = dest_id(src_asset, source_folder, dest_folder)\n",
+    "\n",
+    "        logging.info(f'\\n=== Asset [{asset[\"type\"]}]: {src_asset} ===')\n",
+    "        copy_image(src_asset, dst_asset, allow_overwrite)   # copy_image works for any asset type\n",
+    "        logging.info(f'Done: {dst_asset}')\n",
+    "\n",
+    "    # -- verify ------------------------------------------------------------------\n",
+    "    result = list_all_assets(dest_folder)\n",
+    "    result_cols   = [a for a in result if a.get('type') == 'IMAGE_COLLECTION']\n",
+    "    result_direct = [a for a in result if a.get('type') in DIRECT_COPY_TYPES]\n",
+    "\n",
+    "    print(f'\\nDestination {dest_folder} now has:')\n",
+    "    print(f'  {len(result_cols)} collection(s):')\n",
+    "    for c in result_cols:\n",
+    "        imgs = list_all_assets(c['name'])\n",
+    "        print(f'    {c[\"name\"]}  ({len(imgs)} image(s))')\n",
+    "    print(f'  {len(result_direct)} direct asset(s):')\n",
+    "    for a in result_direct:\n",
+    "        print(f'    {a[\"name\"]}  [{a[\"type\"]}]')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-4",
+   "metadata": {},
+   "source": [
+    "## 1 — List source image collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 12 image collection(s) to copy:\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent-distance_version-2-0_1996--2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent-gain\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent-gain_version-2-0_1996--2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent-loss\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent-loss_version-2-0_1996--2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove-extent_version-2-0_1996--2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_version_2-0_gain_1996-2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_version_2-0_loss_1996-2016\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_source_assets = list_all_assets(SOURCE_FOLDER)\n",
+    "source_collections = [\n",
+    "    a for a in all_source_assets\n",
+    "    if a.get('type') == 'IMAGE_COLLECTION'\n",
+    "]\n",
+    "\n",
+    "if COLLECTION_FILTER is not None:\n",
+    "    source_collections = [\n",
+    "        c for c in source_collections\n",
+    "        if asset_name(c['name']) in COLLECTION_FILTER\n",
+    "    ]\n",
+    "\n",
+    "print(f'Found {len(source_collections)} image collection(s) to copy:')\n",
+    "for c in source_collections:\n",
+    "    print(f'  {c[\"name\"]}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "0c3d63ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'type': 'IMAGE_COLLECTION',\n",
+       "  'name': 'projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3',\n",
+       "  'id': 'projects/global-mangrove-watch/land-cover/mangrove_extent-v3',\n",
+       "  'updateTime': '2022-08-10T14:39:17.414305Z'},\n",
+       " {'type': 'IMAGE_COLLECTION',\n",
+       "  'name': 'projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3',\n",
+       "  'id': 'projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3',\n",
+       "  'updateTime': '2022-08-11T14:50:33.135199Z'},\n",
+       " {'type': 'IMAGE_COLLECTION',\n",
+       "  'name': 'projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3',\n",
+       "  'id': 'projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3',\n",
+       "  'updateTime': '2022-08-11T15:23:02.437679Z'}]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Keep only v3 assets\n",
+    "source_collections = [c for c in source_collections    if 'v3' in asset_name(c['name'])]\n",
+    "source_collections"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-5",
+   "metadata": {},
+   "source": [
+    "## 2 — Preview destination paths\n",
+    "\n",
+    "Review this before running the copy cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3  (11 image(s))\n",
+      "  -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3\n",
+      "projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3  (10 image(s))\n",
+      "  -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3\n",
+      "projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3  (10 image(s))\n",
+      "  -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3\n"
+     ]
+    }
+   ],
+   "source": [
+    "for c in source_collections:\n",
+    "    src = c['name']\n",
+    "    dst = dest_id(src, SOURCE_FOLDER, DEST_FOLDER)\n",
+    "    images = list_all_assets(src)\n",
+    "    print(f'{src}  ({len(images)} image(s))')\n",
+    "    print(f'  -> {dst}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-6",
+   "metadata": {},
+   "source": [
+    "## 3 — Copy collections\n",
+    "\n",
+    "For each source collection:\n",
+    "- Creates the destination `ImageCollection` (preserving collection-level properties).\n",
+    "- Copies every image inside it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "cell-10",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:\n",
+      "=== Processing collection: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3 ===\n",
+      "INFO:root:Created image collection: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3\n",
+      "INFO:root:Copying 11 image(s)...\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_1996 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_1996\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2007 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2007\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2008 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2008\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2009 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2009\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2010 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2010\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2015 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2015\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2016 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2016\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2017 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2017\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2018 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2018\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2019 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2019\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent-v3/gmw_v3_2020 -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3/gmw_v3_2020\n",
+      "INFO:root:Done: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3\n",
+      "INFO:root:\n",
+      "=== Processing collection: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3 ===\n",
+      "INFO:root:Created image collection: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3\n",
+      "INFO:root:Copying 10 image(s)...\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_1996_2007_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_1996_2007_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2007_2008_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2007_2008_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2008_2009_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2008_2009_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2009_2010_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2009_2010_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2010_2015_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2010_2015_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2015_2016_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2015_2016_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2016_2017_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2016_2017_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2017_2018_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2017_2018_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2018_2019_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2018_2019_gain\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_gain-v3/gl_2019_2020_gain -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3/gl_2019_2020_gain\n",
+      "INFO:root:Done: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3\n",
+      "INFO:root:\n",
+      "=== Processing collection: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3 ===\n",
+      "INFO:root:Created image collection: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3\n",
+      "INFO:root:Copying 10 image(s)...\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_1996_2007_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_1996_2007_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2007_2008_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2007_2008_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2008_2009_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2008_2009_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2009_2010_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2009_2010_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2010_2015_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2010_2015_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2015_2016_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2015_2016_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2016_2017_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2016_2017_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2017_2018_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2017_2018_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2018_2019_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2018_2019_loss\n",
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/land-cover/mangrove_extent_loss-v3/gl_2019_2020_loss -> projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3/gl_2019_2020_loss\n",
+      "INFO:root:Done: projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3\n"
+     ]
+    }
+   ],
+   "source": [
+    "for collection in source_collections:\n",
+    "    src_collection_id = collection['name']\n",
+    "    dst_collection_id = dest_id(src_collection_id, SOURCE_FOLDER, DEST_FOLDER)\n",
+    "\n",
+    "    logging.info(f'\\n=== Processing collection: {src_collection_id} ===')\n",
+    "\n",
+    "    # Fetch source collection metadata to preserve properties\n",
+    "    source_meta = ee.data.getAsset(src_collection_id)\n",
+    "\n",
+    "    # Create destination collection if needed\n",
+    "    ensure_image_collection(dst_collection_id, source_meta)\n",
+    "\n",
+    "    # List and copy each image\n",
+    "    images = list_all_assets(src_collection_id)\n",
+    "    logging.info(f'Copying {len(images)} image(s)...')\n",
+    "\n",
+    "    for img in images:\n",
+    "        src_img_id = img['name']\n",
+    "        dst_img_id = dest_id(src_img_id, SOURCE_FOLDER, DEST_FOLDER)\n",
+    "        copy_image(src_img_id, dst_img_id, allow_overwrite=ALLOW_OVERWRITE)\n",
+    "\n",
+    "    logging.info(f'Done: {dst_collection_id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-md-7",
+   "metadata": {},
+   "source": [
+    "## 4 — Verify\n",
+    "\n",
+    "List what ended up in the destination folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Destination folder contains 3 image collection(s):\n",
+      "  projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent-v3  (11 image(s))\n",
+      "  projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_gain-v3  (10 image(s))\n",
+      "  projects/mangrove-atlas-246414/assets/land-cover/mangrove_extent_loss-v3  (10 image(s))\n"
+     ]
+    }
+   ],
+   "source": [
+    "dest_assets = list_all_assets(DEST_FOLDER)\n",
+    "dest_collections = [a for a in dest_assets if a.get('type') == 'IMAGE_COLLECTION']\n",
+    "\n",
+    "print(f'Destination folder contains {len(dest_collections)} image collection(s):')\n",
+    "for c in dest_collections:\n",
+    "    images = list_all_assets(c['name'])\n",
+    "    print(f'  {c[\"name\"]}  ({len(images)} image(s))')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "201b82bb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c7e8094",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## mangrove-properties\n",
+    "\n",
+    "Clones image collections from `projects/global-mangrove-watch/mangrove-properties/` into `projects/mangrove-atlas-246414/assets/mangrove-properties`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "dc5222dc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 7 collection(s) to clone:\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_aboveground_biomass-v3  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_aboveground_biomass-v3\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_aboveground_biomass_1996-2016  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_aboveground_biomass_1996-2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_basal-area_weighted_height_2000_v1-2  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_basal-area_weighted_height_2000_v1-2\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_blue_carbon-v2_1  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_blue_carbon-v2_1\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_canopy_height-v3  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_canopy_height-v3\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_max_canopy_height_1996-2016  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_max_canopy_height_1996-2016\n",
+      "  projects/earthengine-legacy/assets/projects/global-mangrove-watch/mangrove-properties/mangrove_total_co2e_1996--2016  ->  projects/mangrove-atlas-246414/assets/mangrove-properties/mangrove_total_co2e_1996--2016\n"
+     ]
+    }
+   ],
+   "source": [
+    "MP_SOURCE = 'projects/global-mangrove-watch/mangrove-properties'\n",
+    "MP_DEST   = 'projects/mangrove-atlas-246414/assets/mangrove-properties'\n",
+    "\n",
+    "# Restrict to specific collections, or None to copy all.\n",
+    "MP_FILTER: Optional[List[str]] = None\n",
+    "\n",
+    "# Preview what will be cloned\n",
+    "all_mp = list_all_assets(MP_SOURCE)\n",
+    "mp_collections = [a for a in all_mp if a.get('type') == 'IMAGE_COLLECTION']\n",
+    "if MP_FILTER:\n",
+    "    mp_collections = [c for c in mp_collections if asset_name(c['name']) in MP_FILTER]\n",
+    "\n",
+    "print(f'Found {len(mp_collections)} collection(s) to clone:')\n",
+    "for c in mp_collections:\n",
+    "    print(f'  {c[\"name\"]}  ->  {dest_id(c[\"name\"], MP_SOURCE, MP_DEST)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe5720c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clone_folder(MP_SOURCE, MP_DEST, collection_filter=MP_FILTER, allow_overwrite=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "451ced94",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## physical-environment\n",
+    "\n",
+    "Clones image collections from `projects/global-mangrove-watch/physical-environment/` into `projects/mangrove-atlas-246414/assets/physical-environment`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "3bb090f6",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image collections (0):\n",
+      "\n",
+      "Direct assets (1):\n",
+      "  [TABLE]  projects/earthengine-legacy/assets/projects/global-mangrove-watch/physical-environment/coastlines-v3  ->  projects/mangrove-atlas-246414/assets/physical-environment/coastlines-v3\n"
+     ]
+    }
+   ],
+   "source": [
+    "PE_SOURCE = 'projects/global-mangrove-watch/physical-environment'\n",
+    "PE_DEST   = 'projects/mangrove-atlas-246414/assets/physical-environment'\n",
+    "\n",
+    "# Restrict to specific asset names, or None to copy all.\n",
+    "PE_FILTER: Optional[List[str]] = ['coastlines-v3']\n",
+    "\n",
+    "# Preview what will be cloned\n",
+    "all_pe      = list_all_assets(PE_SOURCE)\n",
+    "pe_cols     = [a for a in all_pe if a.get('type') == 'IMAGE_COLLECTION']\n",
+    "pe_direct   = [a for a in all_pe if a.get('type') in DIRECT_COPY_TYPES]\n",
+    "\n",
+    "if PE_FILTER:\n",
+    "    pe_cols   = [c for c in pe_cols   if asset_name(c['name']) in PE_FILTER]\n",
+    "    pe_direct = [a for a in pe_direct if asset_name(a['name']) in PE_FILTER]\n",
+    "\n",
+    "print(f'Image collections ({len(pe_cols)}):')\n",
+    "for c in pe_cols:\n",
+    "    print(f'  {c[\"name\"]}  ->  {dest_id(c[\"name\"], PE_SOURCE, PE_DEST)}')\n",
+    "\n",
+    "print(f'\\nDirect assets ({len(pe_direct)}):')\n",
+    "for a in pe_direct:\n",
+    "    print(f'  [{a[\"type\"]}]  {a[\"name\"]}  ->  {dest_id(a[\"name\"], PE_SOURCE, PE_DEST)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "c809a334",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:\n",
+      "=== Asset [TABLE]: projects/earthengine-legacy/assets/projects/global-mangrove-watch/physical-environment/coastlines-v3 ===\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found in projects/global-mangrove-watch/physical-environment:\n",
+      "  0 image collection(s)\n",
+      "  1 direct asset(s)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:root:  Copied: projects/earthengine-legacy/assets/projects/global-mangrove-watch/physical-environment/coastlines-v3 -> projects/mangrove-atlas-246414/assets/physical-environment/coastlines-v3\n",
+      "INFO:root:Done: projects/mangrove-atlas-246414/assets/physical-environment/coastlines-v3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Destination projects/mangrove-atlas-246414/assets/physical-environment now has:\n",
+      "  0 collection(s):\n",
+      "  1 direct asset(s):\n",
+      "    projects/mangrove-atlas-246414/assets/physical-environment/coastlines-v3  [TABLE]\n"
+     ]
+    }
+   ],
+   "source": [
+    "clone_folder(PE_SOURCE, PE_DEST, collection_filter=PE_FILTER, allow_overwrite=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ef019d1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "data (3.13.2)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Clone Google Earth Engine assets from legacy project into current project

### Overview

GEE assets in use for on-the-fly calculations were stored in a legacy project ( `global-mangrove-watch` ) and needed to be cloned into the one in use for this project ( `mangrove-atlas-246414` ).
This PR contains a notebook to clone those assets, and update the references to them for the cloud functions

