### PR TITLE
fix: prevent WDPA 404 from useLocation placeholder

### DIFF
--- a/src/containers/datasets/locations/hooks.tsx
+++ b/src/containers/datasets/locations/hooks.tsx
@@ -73,11 +73,11 @@ export function useLocation(
     queryFn: () => fetchLocation(_id),
     placeholderData: {
       data: {
-        id: _id,
-        location_id: _id,
+        id: 0,
+        location_id: 'worldwide',
         name: '',
         iso: '',
-        location_type: locationType || 'worldwide',
+        location_type: 'worldwide',
         bounds: null,
       } as unknown as DataResponse['data'][0],
     },


### PR DESCRIPTION
## Summary
- Entering a WDPA (e.g. `/wdpa/555512151`) returned **404** on the first widget calls because `useLocation` placeholderData set `id` and `location_id` to the URL string (the WDPA code). Widget hooks read `data.id` as the numeric pk and sent it as `location_id` — sending the WDPA code string instead, which the widget endpoints reject.
- Fix is single-file: make the placeholder look like worldwide (`id: 0`, `location_id: 'worldwide'`, `location_type: 'worldwide'`) so the existing widget guard `location_id !== 'worldwide'` skips firing until real data hydrates.
- No widget-side refactor; ~30 widget hooks already guard correctly.

## Test plan
- [ ] `pnpm dev` → open Network tab, filter `widgets/`
- [ ] Click a WDPA in the locations list — no `widgets/*?location_id=<wdpa-string-code>` request; first widget request uses numeric `location_id`; no 404
- [ ] Direct URL: load `/wdpa/<known-wdpa-id>` in a fresh tab — same checks
- [ ] Sanity: `/` (worldwide) and `/country/<iso>` still work
- [ ] `pnpm check-types` clean