### PR TITLE
test: drive planet date select via URL layer state to bypass map-load…

### DIFF
--- a/tests/planet-date-select.spec.ts
+++ b/tests/planet-date-select.spec.ts
@@ -12,6 +12,11 @@ const MOCK_MOSAICS = {
   }),
 };
 
+const ACTIVE_LAYERS = JSON.stringify([
+  { id: PLANET_LAYER, opacity: '1', visibility: 'visible' },
+  { id: 'mangrove_habitat_extent', opacity: '1', visibility: 'visible' },
+]);
+
 test.describe('Planet date select popup', () => {
   test('caps popup height and scrolls to reach all dates', async ({ page, browserName }) => {
     test.fixme(browserName === 'firefox', 'Firefox: flaky popup rendering');
@@ -20,17 +25,11 @@ test.describe('Planet date select popup', () => {
       route.fulfill({ status: 200, json: MOCK_MOSAICS })
     );
 
-    await page.goto('/');
+    await page.goto(`/?layers=${encodeURIComponent(ACTIVE_LAYERS)}`);
     await page.getByTestId('widgets-wrapper').waitFor();
-    await page.waitForLoadState('networkidle');
-
-    const settingsButton = page.getByTestId('basemap-settings-button');
-    await settingsButton.waitFor({ timeout: 90000 });
-    await settingsButton.click();
-    await page.getByTestId(PLANET_LAYER).click();
 
     const trigger = page.getByLabel('Select period');
-    await expect(trigger).toBeVisible();
+    await expect(trigger).toBeVisible({ timeout: 30000 });
     await trigger.click();
 
     const popup = page.getByRole('listbox');
@@ -43,14 +42,17 @@ test.describe('Planet date select popup', () => {
     const items = page.getByRole('option');
     await expect(items).toHaveCount(MOCK_MOSAICS.mosaics.length);
 
-    const lastItem = items.last();
-    await expect(lastItem).not.toBeInViewport();
+    // Radix auto-scrolls the popup to the selected item (oldest mosaic, last
+    // in DOM order after desc sort), so the newest mosaic (first in DOM) is
+    // off-screen on open and only reachable by scrolling up.
+    const firstItem = items.first();
+    await expect(firstItem).not.toBeInViewport();
 
     const scrollViewport = popup.locator('[data-slot="select-viewport"]').first();
     await scrollViewport.evaluate((el) => {
-      el.scrollTop = el.scrollHeight;
+      el.scrollTop = 0;
     });
 
-    await expect(lastItem).toBeInViewport();
+    await expect(firstItem).toBeInViewport();
   });
 });


### PR DESCRIPTION
This pull request updates the test for the Planet date select popup to better reflect the current UI behavior and improve test reliability. The test setup is changed to load specific active layers, and the assertions are updated to match the new scrolling logic where the newest mosaic is initially off-screen.

**Test setup improvements:**

* The test now loads the page with a specific set of active layers by adding a `layers` query parameter to the URL. (`tests/planet-date-select.spec.ts` [[1]](diffhunk://#diff-e42e4b1ad1f59176f03c8f54a9328cd50064a13bbe5913f28e5d9dc15adfbc5bR15-R19) [[2]](diffhunk://#diff-e42e4b1ad1f59176f03c8f54a9328cd50064a13bbe5913f28e5d9dc15adfbc5bL23-R32)

**Test logic updates:**

* The test assertion is updated to check that the first (newest) mosaic is initially off-screen and only becomes visible after scrolling, reflecting the UI's auto-scroll behavior. (`tests/planet-date-select.spec.ts` [tests/planet-date-select.spec.tsL46-R56](diffhunk://#diff-e42e4b1ad1f59176f03c8f54a9328cd50064a13bbe5913f28e5d9dc15adfbc5bL46-R56))
* Increased the timeout for the visibility check of the trigger to improve test stability. (`tests/planet-date-select.spec.ts` [tests/planet-date-select.spec.tsL23-R32](diffhunk://#diff-e42e4b1ad1f59176f03c8f54a9328cd50064a13bbe5913f28e5d9dc15adfbc5bL23-R32))