### PR TITLE
fix: harden cross-domain SSO between GMW and MRTT in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,34 @@ const nextConfig = {
       },
     ];
   },
+
+  async headers() {
+    // Allow MRTT to load the silent-SSO authorize endpoint in an iframe.
+    // Any default frame-blocking header (e.g. X-Frame-Options: DENY emitted
+    // by upstream middleware / hosting) would silently break the silent-SSO
+    // iframe and cause silentSsoCheck() to time out without diagnostic.
+    const mrttOrigin = (() => {
+      try {
+        return new URL(process.env.NEXT_PUBLIC_MRTT_SITE).origin;
+      } catch {
+        return null;
+      }
+    })();
+
+    if (!mrttOrigin) return [];
+
+    return [
+      {
+        source: '/api/auth/sso/authorize',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: `frame-ancestors 'self' ${mrttOrigin};`,
+          },
+        ],
+      },
+    ];
+  },
   turbopack: {
     rules: {
       '*.mdx': {

--- a/src/components/session-sync.tsx
+++ b/src/components/session-sync.tsx
@@ -24,17 +24,17 @@ export function SessionSync() {
     if (status !== 'unauthenticated' || attempted.current) return;
     attempted.current = true;
 
-    // Prevent rapid retries across navigations
+    // Prevent rapid retries across navigations. Only set the suppression flag
+    // on a successful or definitive negative response so that transient
+    // network/CORS failures don't lock the user out of retries for 60s.
     const lastAttempt = sessionStorage.getItem(SSO_RESTORE_KEY);
     if (lastAttempt && Date.now() - Number(lastAttempt) < SSO_RESTORE_TTL) return;
-
-    sessionStorage.setItem(SSO_RESTORE_KEY, String(Date.now()));
 
     fetch('/api/auth/sso/restore')
       .then((res) => res.json())
       .then((data) => {
+        sessionStorage.setItem(SSO_RESTORE_KEY, String(Date.now()));
         if (data.ok) {
-          // next-auth session cookie was set by the server — refresh client state
           update();
         }
       })

--- a/src/lib/auth/sso-config.ts
+++ b/src/lib/auth/sso-config.ts
@@ -1,22 +1,21 @@
+import { env } from '../../../env.mjs';
+
 /**
  * Allowed origins for SSO redirect URIs.
  * Prevents open-redirect attacks on authorize/sync/logout endpoints.
+ *
+ * Sourced from the Zod-validated env so a missing or malformed value fails
+ * at startup rather than degrading SSO silently.
  */
 export const SSO_ALLOWED_ORIGINS: string[] = [
-  process.env.NEXT_PUBLIC_MRTT_SITE,
-  process.env.NEXTAUTH_URL,
-].filter((v): v is string => Boolean(v));
+  new URL(env.NEXT_PUBLIC_MRTT_SITE).origin,
+  new URL(env.NEXTAUTH_URL).origin,
+];
 
-/**
- * Validate that a redirect URI belongs to an allowed origin.
- */
 export function isAllowedRedirectUri(uri: string): boolean {
   try {
     const parsed = new URL(uri);
-    return SSO_ALLOWED_ORIGINS.some((origin) => {
-      const allowed = new URL(origin);
-      return parsed.origin === allowed.origin;
-    });
+    return SSO_ALLOWED_ORIGINS.includes(parsed.origin);
   } catch {
     return false;
   }
@@ -26,18 +25,11 @@ export function isAllowedRedirectUri(uri: string): boolean {
  * CORS headers for SSO endpoints that MRTT calls directly (exchange, sync, logout).
  */
 export function getSSOCorsHeaders(): Record<string, string> {
-  const mrttOrigin = process.env.NEXT_PUBLIC_MRTT_SITE;
-  if (!mrttOrigin) return {};
-
-  try {
-    const origin = new URL(mrttOrigin).origin;
-    return {
-      'Access-Control-Allow-Origin': origin,
-      'Access-Control-Allow-Methods': 'POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      'Access-Control-Allow-Credentials': 'true',
-    };
-  } catch {
-    return {};
-  }
+  return {
+    'Access-Control-Allow-Origin': new URL(env.NEXT_PUBLIC_MRTT_SITE).origin,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Credentials': 'true',
+    Vary: 'Origin',
+  };
 }


### PR DESCRIPTION
## Summary

Hardens three failure modes in the GMW ↔ MRTT cross-domain SSO that surfaced as broken session sharing in production. The SSO architecture is unchanged — these are diagnostic and defensive fixes against silent failure modes.

- **`src/components/session-sync.tsx`** — the 60-second retry suppression flag was written before the `/api/auth/sso/restore` fetch resolved. A transient failure on first load (CORS, network) locked the user out of retries for 60s and looked like total SSO failure. Now the flag is set only after the response is received.

- **`src/lib/auth/sso-config.ts`** — `getSSOCorsHeaders` previously read `process.env.NEXT_PUBLIC_MRTT_SITE` directly and returned an empty object if the var was missing or malformed, producing silent CORS rejection of every MRTT → GMW call. Now reads from the Zod-validated `env` so a missing/malformed value fails at startup with a clear error. Adds `Vary: Origin` for cache correctness.

- **`next.config.js`** — adds `Content-Security-Policy: frame-ancestors 'self' ${MRTT_ORIGIN}` scoped to `/api/auth/sso/authorize`. Defends the silent-SSO iframe against any upstream `X-Frame-Options: DENY` from hosting middleware that would cause `silentSsoCheck` to time out at 4s with no diagnostic.

## Test plan

- [ ] Confirm Heroku config var `NEXT_PUBLIC_MRTT_SITE=https://mrtt.globalmangrovewatch.org` (no trailing slash) is set on the GMW app and that a fresh deploy has run after any change (Next.js inlines `NEXT_PUBLIC_*` at build).
- [ ] Confirm MRTT Heroku config vars (`REACT_APP_AUTH_URL`, `REACT_APP_API_URL`, `REACT_APP_GMW_URL`) point to prod and that MRTT has been redeployed after any change (CRA inlines `REACT_APP_*` at build).
- [ ] Clear all `*.globalmangrovewatch.org` cookies and sessionStorage. Sign in on MRTT → confirm POST `/api/auth/sso/sync` returns 200 with `Set-Cookie: __Secure-gmw-sso-token=...; Domain=.globalmangrovewatch.org; Secure; HttpOnly; SameSite=None`. Open new tab → `https://www.globalmangrovewatch.org`. `SessionSync` calls `/api/auth/sso/restore` → 200. Header shows logged-in state without manual reload.
- [ ] Sign out everywhere. Sign in on GMW → POST `/api/auth/sso/set-from-session` returns 200 + Set-Cookie. Open new tab → `https://mrtt.globalmangrovewatch.org`. Iframe loads `authorize` → 302 to `sso-silent?code=...` → postMessage → POST `exchange` 200 → user logged in within ~4s. No iframe-blocked console errors.
- [ ] OPTIONS preflight smoke: `curl -i -X OPTIONS https://www.globalmangrovewatch.org/api/auth/sso/exchange -H "Origin: https://mrtt.globalmangrovewatch.org" -H "Access-Control-Request-Method: POST"` returns 204 with `Access-Control-Allow-Origin: https://mrtt.globalmangrovewatch.org` and `Access-Control-Allow-Credentials: true`.
- [ ] Cross-browser: repeat in Safari (ITP on) and Chrome incognito. Silent SSO may degrade gracefully — confirm it does not loop or hang past the 4s timeout.
- [ ] Logout symmetry: logout from one app clears the shared cookie so the other is unauth on next load.