### PR TITLE
fix: SSO session fallback + cross-cookie logout cleanup

### DIFF
--- a/src/app/api/auth/sso/authorize/route.ts
+++ b/src/app/api/auth/sso/authorize/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { authOptions } from '@/lib/auth/auth';
 import { generateSSOCode } from '@/lib/auth/sso-code';
 import { isAllowedRedirectUri } from '@/lib/auth/sso-config';
-import { clearSSOCookie, getSSOToken } from '@/lib/auth/sso-cookie';
+import { clearSSOCookie, getSSOToken, setSSOCookie } from '@/lib/auth/sso-cookie';
+
+import { getServerSession } from 'next-auth';
 
 export async function GET(request: NextRequest) {
   const redirectUri = request.nextUrl.searchParams.get('redirect_uri');
@@ -11,23 +14,32 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid redirect_uri' }, { status: 400 });
   }
 
-  const token = getSSOToken(request);
+  let token = getSSOToken(request);
+  let shouldPersistCookie = false;
+
+  // Fallback: an active next-auth session without gmw-sso-token still proves
+  // the user is logged in on GMW. Adopt its accessToken and persist the cookie
+  // so subsequent silent SSO checks have it.
+  if (!token) {
+    const session = await getServerSession(authOptions);
+    if (session?.user?.accessToken) {
+      token = session.user.accessToken;
+      shouldPersistCookie = true;
+    }
+  }
 
   if (!token) {
-    // No SSO session — redirect to GMW login, then back here after login
     const loginUrl = new URL('/auth/signin', request.nextUrl.origin);
     const returnUrl = new URL(request.url);
     loginUrl.searchParams.set('callbackUrl', returnUrl.toString());
     return NextResponse.redirect(loginUrl);
   }
 
-  // Validate token with backend
   const userRes = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
   if (!userRes.ok) {
-    // Token expired/invalid — clear cookie, redirect to login
     const response = NextResponse.redirect(
       new URL(`/auth/signin?callbackUrl=${encodeURIComponent(request.url)}`, request.nextUrl.origin)
     );
@@ -35,11 +47,12 @@ export async function GET(request: NextRequest) {
     return response;
   }
 
-  // Generate short-lived authorization code
   const code = await generateSSOCode(token);
 
   const callbackUrl = new URL(redirectUri);
   callbackUrl.searchParams.set('code', code);
 
-  return NextResponse.redirect(callbackUrl);
+  const response = NextResponse.redirect(callbackUrl);
+  if (shouldPersistCookie) setSSOCookie(response, token);
+  return response;
 }

--- a/src/app/api/auth/sso/logout/route.ts
+++ b/src/app/api/auth/sso/logout/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSSOCorsHeaders, isAllowedRedirectUri } from '@/lib/auth/sso-config';
-import { clearSSOCookie, getSSOToken } from '@/lib/auth/sso-cookie';
+import { clearNextAuthCookies, clearSSOCookie, getSSOToken } from '@/lib/auth/sso-cookie';
 
 export async function POST(request: NextRequest) {
   const corsHeaders = getSSOCorsHeaders();
@@ -30,11 +30,13 @@ export async function POST(request: NextRequest) {
   if (redirectUri && isAllowedRedirectUri(redirectUri)) {
     const response = NextResponse.redirect(redirectUri);
     clearSSOCookie(response);
+    clearNextAuthCookies(response);
     return response;
   }
 
   const response = NextResponse.json({ ok: true }, { headers: corsHeaders });
   clearSSOCookie(response);
+  clearNextAuthCookies(response);
   return response;
 }
 

--- a/src/containers/auth/login-form.tsx
+++ b/src/containers/auth/login-form.tsx
@@ -86,7 +86,14 @@ function LoginForm() {
 
     // Set the shared httpOnly SSO cookie so MRTT can pick up the session.
     // Token stays server-side — this endpoint reads the next-auth JWT cookie.
-    await fetch('/api/auth/sso/set-from-session', { method: 'POST' }).catch(() => {});
+    try {
+      const ssoRes = await fetch('/api/auth/sso/set-from-session', { method: 'POST' });
+      if (!ssoRes.ok) {
+        console.error('SSO cookie sync returned non-OK status:', ssoRes.status);
+      }
+    } catch (err) {
+      console.error('SSO cookie sync failed:', err);
+    }
 
     router.replace(result.url ?? callbackUrl);
   }

--- a/src/lib/auth/sso-cookie.ts
+++ b/src/lib/auth/sso-cookie.ts
@@ -34,3 +34,26 @@ export function clearSSOCookie(response: NextResponse): void {
     maxAge: 0,
   });
 }
+
+// Next-auth cookie names mirror the `cookies` block in auth.ts. Clearing
+// requires the same Domain + Path attributes the cookie was set with,
+// otherwise browsers leave the original (subdomain-scoped) cookie in place.
+const NEXT_AUTH_COOKIE_NAMES = isProd
+  ? [
+      '__Secure-next-auth.session-token',
+      '__Secure-next-auth.csrf-token',
+      '__Secure-next-auth.callback-url',
+    ]
+  : ['next-auth.session-token', 'next-auth.csrf-token', 'next-auth.callback-url'];
+
+export function clearNextAuthCookies(response: NextResponse): void {
+  for (const name of NEXT_AUTH_COOKIE_NAMES) {
+    response.cookies.set(name, '', {
+      path: '/',
+      secure: isProd,
+      sameSite: 'lax',
+      maxAge: 0,
+      ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {}),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1509. Two behavioral fixes to the silent-SSO + logout pathways used by MRTT cross-domain auth.

- **`/api/auth/sso/authorize`** — when the `gmw-sso-token` cookie is missing but a valid next-auth session exists on GMW, adopt `session.user.accessToken` and persist it via `setSSOCookie` on the redirect response. Previously this case bounced users to `/auth/signin` even though they were already logged in.
- **`/api/auth/sso/logout`** — now clears the `next-auth.*` cookie family (session-token, csrf-token, callback-url) in addition to `gmw-sso-token`. New `clearNextAuthCookies` helper in `src/lib/auth/sso-cookie.ts` replays the same `Domain` + `Path` attributes used when next-auth sets them, otherwise the browser would leave the subdomain-scoped cookie in place.
- **`login-form.tsx`** — the `/api/auth/sso/set-from-session` call no longer swallows failures via `.catch(() => {})`. Non-OK status and thrown errors now log to `console.error` so cookie-sync regressions are visible.

## Test plan

- [ ] Sign in on GMW, then hit `/api/auth/sso/authorize?redirect_uri=<mrtt>` from a context without the `gmw-sso-token` cookie — confirm redirect carries `?code=...` and `Set-Cookie: gmw-sso-token` appears on the response.
- [ ] POST `/api/auth/sso/logout?redirect_uri=<mrtt>` — confirm response `Set-Cookie` headers expire both `gmw-sso-token` and `__Secure-next-auth.session-token` (prod) / `next-auth.session-token` (dev) with matching `Domain`.
- [ ] Trigger a `set-from-session` failure (e.g. block the endpoint in devtools) — confirm `console.error` fires with the status/error.
- [ ] Vercel preview Playwright run green.