### PR TITLE
fix: SSO authorize uses public origin instead of Heroku dyno host

### DIFF
--- a/src/app/api/auth/sso/authorize/route.ts
+++ b/src/app/api/auth/sso/authorize/route.ts
@@ -7,12 +7,34 @@ import { clearSSOCookie, getSSOToken, setSSOCookie } from '@/lib/auth/sso-cookie
 
 import { getServerSession } from 'next-auth';
 
+// Heroku's router proxies to a dyno listening on an ephemeral $PORT and
+// rewrites the inbound Host header, so request.nextUrl.origin resolves to
+// something like https://localhost:41669 inside the route handler. Redirects
+// built from that origin send the browser to an unreachable address. Use the
+// configured public origin (NEXTAUTH_URL) and fall back to X-Forwarded-Host /
+// request origin only when it's missing.
+function getPublicOrigin(request: NextRequest): string {
+  if (process.env.NEXTAUTH_URL) return new URL(process.env.NEXTAUTH_URL).origin;
+
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const forwardedProto = request.headers.get('x-forwarded-proto') ?? 'https';
+  if (forwardedHost) return `${forwardedProto}://${forwardedHost}`;
+
+  return request.nextUrl.origin;
+}
+
 export async function GET(request: NextRequest) {
   const redirectUri = request.nextUrl.searchParams.get('redirect_uri');
 
   if (!redirectUri || !isAllowedRedirectUri(redirectUri)) {
     return NextResponse.json({ error: 'Invalid redirect_uri' }, { status: 400 });
   }
+
+  const publicOrigin = getPublicOrigin(request);
+  const publicRequestUrl = new URL(
+    `${request.nextUrl.pathname}${request.nextUrl.search}`,
+    publicOrigin
+  ).toString();
 
   let token = getSSOToken(request);
   let shouldPersistCookie = false;
@@ -29,9 +51,8 @@ export async function GET(request: NextRequest) {
   }
 
   if (!token) {
-    const loginUrl = new URL('/auth/signin', request.nextUrl.origin);
-    const returnUrl = new URL(request.url);
-    loginUrl.searchParams.set('callbackUrl', returnUrl.toString());
+    const loginUrl = new URL('/auth/signin', publicOrigin);
+    loginUrl.searchParams.set('callbackUrl', publicRequestUrl);
     return NextResponse.redirect(loginUrl);
   }
 
@@ -41,7 +62,7 @@ export async function GET(request: NextRequest) {
 
   if (!userRes.ok) {
     const response = NextResponse.redirect(
-      new URL(`/auth/signin?callbackUrl=${encodeURIComponent(request.url)}`, request.nextUrl.origin)
+      new URL(`/auth/signin?callbackUrl=${encodeURIComponent(publicRequestUrl)}`, publicOrigin)
     );
     clearSSOCookie(response);
     return response;


### PR DESCRIPTION
## Summary

Production GMW↔MRTT SSO was failing because the silent-SSO iframe got bounced to an unreachable redirect target.

When MRTT loads `https://www.globalmangrovewatch.org/api/auth/sso/authorize` in its silent-check iframe and the SSO cookie / next-auth session can't be resolved server-side, the handler builds a 307 redirect to `/auth/signin?callbackUrl=...`. Heroku's router rewrites the inbound `Host` to the dyno's ephemeral `localhost:\$PORT`, so `request.nextUrl.origin` inside the handler was resolving to `https://localhost:41669`. Browser received:

```
307 Location: https://localhost:41669/auth/signin?callbackUrl=https%3A%2F%2Flocalhost%3A41669%2F...
```

…and hit `ERR_CONNECTION_REFUSED`. Silent SSO never completed; MRTT stayed unauthenticated even though the SSO cookie was set.

Fix: derive a public origin for redirect construction. Prefer `process.env.NEXTAUTH_URL`, fall back to `X-Forwarded-Host` + `X-Forwarded-Proto`, finally `request.nextUrl.origin`. Both the `loginUrl` base and the `callbackUrl` query value are now built from this public origin.

## Heroku config requirement

`NEXTAUTH_URL` must be set on the GMW Heroku app to `https://www.globalmangrovewatch.org` (no trailing slash). NextAuth itself already needs this for its own redirect generation, so it should already be there — but worth confirming as part of verification.

```bash
heroku config:get NEXTAUTH_URL -a <gmw-prod-app>
```

## Test plan

- [ ] Clear all `*.globalmangrovewatch.org` cookies + `sessionStorage`.
- [ ] Visit `https://mrtt.globalmangrovewatch.org` while logged out. Confirm the silent-SSO iframe request to `/api/auth/sso/authorize?...` 307s to `https://www.globalmangrovewatch.org/auth/signin?callbackUrl=https%3A%2F%2Fwww.globalmangrovewatch.org%2Fapi%2Fauth%2Fsso%2Fauthorize%3F...` — note: `www.globalmangrovewatch.org` in the Location, NOT `localhost:\$PORT`.
- [ ] Log in on GMW. Visit MRTT — silent SSO iframe should 307 from `/authorize` directly to `mrtt.globalmangrovewatch.org/auth/sso-silent?code=...` (cookie / session path) and MRTT logs in within ~4s.
- [ ] Heroku log spot-check: `heroku logs --tail -a <gmw-prod-app>` while reproducing — no `localhost:` redirects.