### PR TITLE
fix: SSO calls /users/current_user, not /users/me (root cause of broken cross-app SSO)

### DIFF
--- a/src/app/api/auth/sso/authorize/route.ts
+++ b/src/app/api/auth/sso/authorize/route.ts
@@ -56,7 +56,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
+  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 

--- a/src/app/api/auth/sso/exchange/route.ts
+++ b/src/app/api/auth/sso/exchange/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Validate token with backend and get user info
-  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
+  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -41,7 +41,9 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const user = await userRes.json();
+  // Backend shape: { user: { name, email, organization } }
+  const payload = await userRes.json();
+  const user = payload?.user ?? payload;
 
   return NextResponse.json(
     {

--- a/src/app/api/auth/sso/restore/route.ts
+++ b/src/app/api/auth/sso/restore/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Validate token with backend
-  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
+  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
     headers: { Authorization: `Bearer ${token}` },
   });
 
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest) {
     return response;
   }
 
-  const user = await userRes.json();
+  // Backend shape: { user: { name, email, organization } }
+  const payload = await userRes.json();
+  const user = payload?.user ?? payload;
 
   // Build next-auth JWT payload (same shape as authOptions callbacks produce)
   const secret = process.env.NEXTAUTH_SECRET;

--- a/src/app/api/auth/sso/sync/route.ts
+++ b/src/app/api/auth/sso/sync/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Validate token with backend before trusting it
-  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
+  const userRes = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
     headers: { Authorization: `Bearer ${body.token}` },
   });
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -88,13 +88,14 @@ export const authOptions: NextAuthOptions = {
       async authorize(credentials) {
         if (!credentials?.token) return null;
 
-        const res = await fetch(`${process.env.AUTH_API_URL}/users/me`, {
+        const res = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
           headers: { Authorization: `Bearer ${credentials.token}` },
         });
 
         if (!res.ok) return null;
 
-        const data = await res.json();
+        const payload = await res.json();
+        const data = payload?.user ?? payload;
 
         return {
           id: data.email,


### PR DESCRIPTION
## Summary

**Root cause** of the GMW↔MRTT SSO sign-in failures in production.

Every SSO route that validates a bearer token does `fetch(\`\${AUTH_API_URL}/users/me\`, ...)`. The Rails backend (`mangrove-atlas-api`) does not expose that path — the authenticated-user lookup is at `/users/current_user` (confirmed against the production Swagger spec). So every call has been getting a 404, every handler's `if (!userRes.ok)` branch fires, and the consequence depends on the route:

- `authorize`: clears the `gmw-sso-token` cookie + 302s the silent-SSO iframe to `/auth/signin`. Result: MRTT iframe wipes the cookie on every page load and bounces. That's why the user "logs in on GMW, MRTT does nothing" — the iframe runs, finds the cookie, hits `/users/me` → 404 → wipes the cookie before the browser even shows MRTT's UI.
- `restore`: same 404 → returns `{ok:false}` + clears cookie. MRTT→GMW direction never restores the next-auth session.
- `sync`: returns 401, breaks MRTT→GMW even when MRTT posts a valid token.
- `exchange`: returns 401 to MRTT after a valid code, breaks the silent-SSO completion step.
- `auth.ts` (`shared-token` provider): returns null, never logs in.

Credentials sign-in (`/users/sign_in`) was unaffected because Devise mounts that route at the root. `users/current_user` is a custom controller scoped differently.

## Fix

All five callsites now hit `/users/current_user`. The backend payload shape is `{ user: { name, email, organization } }`, so handlers that read user fields unwrap with `payload?.user ?? payload` to stay tolerant of either shape.

Files changed:
- `src/app/api/auth/sso/authorize/route.ts`
- `src/app/api/auth/sso/restore/route.ts`
- `src/app/api/auth/sso/sync/route.ts`
- `src/app/api/auth/sso/exchange/route.ts`
- `src/lib/auth/auth.ts` (shared-token `CredentialsProvider`)

`/users/sign_out` (in `/api/auth/sso/logout`) is left as-is — Devise's default sign-out route mounted at root; user has confirmed logout works.

## Test plan

- [ ] Clear all `*.globalmangrovewatch.org` cookies + sessionStorage.
- [ ] Log in on GMW. Visit MRTT. Confirm:
  - `/api/auth/sso/authorize?...` iframe returns 302 → `mrtt.globalmangrovewatch.org/auth/sso-silent?code=...` (no signin bounce).
  - `__Secure-gmw-sso-token` cookie persists on `.globalmangrovewatch.org` after the iframe runs.
  - MRTT shows logged-in state.
- [ ] Log out everywhere. Log in on MRTT. Visit GMW. Confirm `/api/auth/sso/restore` returns 200 `{ok:true}` and GMW shows logged-in state without manual reload.
- [ ] Direct backend probe: `curl -i "https://mangrove-atlas-api.herokuapp.com/users/current_user" -H "Authorization: Bearer <valid-token>"` → 200 with `{user: {...}}`.