### PR TITLE
fix: auto-reload GMW after silent SSO restore

### DIFF
--- a/src/components/session-sync.tsx
+++ b/src/components/session-sync.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 
 const SSO_RESTORE_KEY = 'gmw-sso-restore-attempted';
 const SSO_RESTORE_TTL = 60 * 1000; // Don't retry for 60 seconds
+const SSO_RESTORE_RELOADED_KEY = 'gmw-sso-restore-reloaded';
 
 /**
  * Restores the next-auth session from the shared httpOnly SSO cookie.
@@ -14,7 +15,12 @@ const SSO_RESTORE_TTL = 60 * 1000; // Don't retry for 60 seconds
  * but the SSO cookie exists. This component calls the restore endpoint
  * which reads the cookie server-side and creates the next-auth session.
  *
- * Prevents loops via sessionStorage flag with TTL.
+ * On success it forces a single page reload so consumers that don't subscribe
+ * to next-auth's session context (Jotai atoms, server-rendered chunks, etc.)
+ * pick up the new identity without the user clicking refresh. A
+ * sessionStorage flag guards against reload loops.
+ *
+ * Prevents repeated /restore calls via a separate sessionStorage TTL flag.
  */
 export function SessionSync() {
   const { status, update } = useSession();
@@ -34,12 +40,29 @@ export function SessionSync() {
       .then((res) => res.json())
       .then((data) => {
         sessionStorage.setItem(SSO_RESTORE_KEY, String(Date.now()));
-        if (data.ok) {
+        if (!data.ok) return;
+
+        // Reload once so SSR-rendered content and non-next-auth subscribers
+        // (Jotai atoms, React Query caches keyed on the session token) refetch
+        // with the freshly-set next-auth cookie. The guard prevents looping if
+        // the reload somehow lands back here still unauthenticated.
+        if (sessionStorage.getItem(SSO_RESTORE_RELOADED_KEY)) {
           update();
+          return;
         }
+        sessionStorage.setItem(SSO_RESTORE_RELOADED_KEY, '1');
+        window.location.reload();
       })
       .catch(() => {});
   }, [status, update]);
+
+  // Once we observe an authenticated session, clear the reload guard so a
+  // future logout-and-back-in cycle can reload again.
+  useEffect(() => {
+    if (status === 'authenticated') {
+      sessionStorage.removeItem(SSO_RESTORE_RELOADED_KEY);
+    }
+  }, [status]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

After PR #1515 fixed the `/users/current_user` endpoint, cross-app SSO works in both directions — but the GMW page rendered before the restore completed still shows the unauthenticated state until the user manually refreshes. `SessionSync` only called next-auth's `update()`, which doesn't re-render consumers outside the next-auth `SessionContext` (Jotai atoms, SSR-rendered chunks, React Query caches keyed on the token).

This PR forces a single `window.location.reload()` after `/api/auth/sso/restore` returns `{ok: true}`, gated by a sessionStorage flag so a reload loop is impossible. The flag is cleared once the session reaches `authenticated`, so a future logout-and-back-in still triggers the reload.

## Test plan

- [ ] Clear all `*.globalmangrovewatch.org` cookies + sessionStorage.
- [ ] Log in on MRTT. Open GMW in a new tab — page should auto-refresh once and show logged-in state without manual reload.
- [ ] Log out everywhere. Confirm no reload loop in any combination.
- [ ] Log in fresh on GMW (no MRTT involvement) — confirm no reload triggered.

## Out of scope

GMW→MRTT direction needs the same auto-refresh on MRTT's side. MRTT-side code is in a separate repo.