### PR TITLE
fix(deps): pin next-auth>uuid to 11.1.1 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,8 @@
   "pnpm": {
     "overrides": {
       "next>postcss": "8.5.10",
-      "minimatch@^10>brace-expansion": "5.0.6"
+      "minimatch@^10>brace-expansion": "5.0.6",
+      "next-auth>uuid": "11.1.1"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   next>postcss: 8.5.10
   minimatch@^10>brace-expansion: 5.0.6
+  next-auth>uuid: 11.1.1
 
 importers:
 
@@ -4685,9 +4686,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vfile-message@4.0.3:
@@ -8528,7 +8528,7 @@ snapshots:
       preact-render-to-string: 5.2.6(preact@10.29.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      uuid: 8.3.2
+      uuid: 11.1.1
     optionalDependencies:
       nodemailer: 8.0.5
 
@@ -9502,7 +9502,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@8.3.2: {}
+  uuid@11.1.1: {}
 
   vfile-message@4.0.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Pins `uuid` to `11.1.1` under `next-auth` via scoped pnpm override
- Resolves moderate advisory **GHSA-w5hq-g745-h8pq** (missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided)
- `next-auth@4.24.14` declares `uuid@^8.3.2` transitively. Strategy A (parent upgrade) not viable — `next-auth` v5 (auth.js) is a breaking major rewrite

## Verification
- `pnpm audit` → no known vulnerabilities
- `pnpm check-types` → pass

## Test plan
- [ ] CI green
- [ ] Sign-in / sign-out flow still works (next-auth uses uuid v4 for session IDs)