### PR TITLE
fix: prevent restoration-sites filter dropdown from being clipped

### DIFF
--- a/src/containers/datasets/restoration-sites/widget.tsx
+++ b/src/containers/datasets/restoration-sites/widget.tsx
@@ -108,7 +108,14 @@ const RestorationSitesWidget = () => {
                 </button>
               )}
             </div>
-            <DialogContent>
+            {/* Let the card grow with content and the outer wrapper scroll, so an
+                expanded filter dropdown overlays instead of being clipped by the card's
+                overflow (see dialog default scroll box). */}
+            <DialogContent
+              className="max-h-none overflow-y-visible sm:max-h-none"
+              classNameContent="overflow-y-auto"
+              hideScrollFade
+            >
               <DialogTitle className="sr-only">Filter sites</DialogTitle>
               <FilterSites
                 open={open}


### PR DESCRIPTION
## Problem

In the **Mangrove Restoration Sites** widget, the *Filter sites* modal holds 6 `MultiSelect` dropdowns in a 2-column grid. Expanding a dropdown (e.g. **Organization**) cut its option list off at the card's bottom edge.

## Root cause (regression)

The mobile-responsive dialog change (`5d2eaf13`) moved scrolling from the outer wrapper onto the dialog **card** itself, adding `overflow-y-auto` + `max-h` to it. That turned the card into a clipping context. The option panel is absolutely positioned, so on expand it gets clipped at the card edge. Before that commit the card had no overflow/max-h, so the panel overflowed freely and showed.

## Fix

Restore the pre-regression scroll model **for this modal only**, via `DialogContent` class overrides — no component-wide change, no JS:

- Card: `max-h-none overflow-y-visible sm:max-h-none` — grows with content, stops clipping the dropdown.
- Outer wrapper: `classNameContent=\"overflow-y-auto\"` — scrolls if content exceeds the viewport.

`select-multi` is untouched (its own `max-h-60 overflow-y-auto` panel scroll is preserved).

## Test plan

- [ ] Open Restoration Sites widget → **Filter sites**
- [ ] Open **Organization** (bottom-left) dropdown → full list shows, not clipped; scrolls within its own max-height
- [ ] Top-row dropdowns still anchored correctly
- [ ] Checkbox select/deselect, count badge, **Clear all**, keyboard nav, outside-click close all work
- [ ] `pnpm lint` + `pnpm check-types` clean (verified locally)