### PR TITLE
 replace per-image reduceRegion with multi-band stacking in cloud analysis

### DIFF
--- a/cloud-functions/analysis/src/calculations/HabitatExtent.ts
+++ b/cloud-functions/analysis/src/calculations/HabitatExtent.ts
@@ -11,15 +11,31 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
     const geometry = feature.geometry();
     const coastline = this.coastalAsset.getEEAsset();
 
-    const habitatExtent =  this._getHabitatExtent(geometry);
-
-    const coastalExtent = this._getCoastalExtent(coastline, geometry);
-
+    // Adaptive scale: 30 m for small areas, capped at 120 m for large areas.
+    // Reaches 60 m at ~1 000 km², 90 m at ~4 000 km², 120 m at ~9 000 km².
+    const scale = ee.Number(geometry.area(1000))
+      .divide(1e9).sqrt().multiply(30).add(30).max(30).min(120);
 
     const totalCoastline = ee.Number(ee.FeatureCollection(coastline.filterBounds(geometry))
                             .map((f: ee.Feature) => f.set({distance: f.length(10)}))
                             .aggregate_sum('distance'))
                             .divide(1000);
+
+    // Combine extent (all years) and coastline into one image, single reduceRegion.
+    // Extent bands carry km² values; the 'coastline' band carries km values.
+    const reduced: ee.Dictionary = this._buildExtentImage()
+      .addBands(this._buildCoastlineImage(coastline))
+      .reduceRegion({
+        reducer: ee.Reducer.sum(),
+        geometry,
+        scale,
+        maxPixels: 1e12,
+        bestEffort: true,
+        tileScale: 4,
+      });
+
+    const habitatExtent = this._extractHabitatExtent(reduced);
+    const coastalExtent = this._extractCoastalExtent(reduced);
 
     return ee.Dictionary({
       "location_id": "custom-area",
@@ -34,53 +50,11 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
       });
   }
 
-  // Computes coastal coverage with a single reduceRegion. The maskedCoastline
-  // image is constant across years, so the reduction is done once and the
-  // value is replicated per year rather than firing N concurrent aggregations.
-  _getCoastalExtent(coast: ee.FeatureCollection, geo: ee.Geometry): ee.List {
-    const coastlineImage = ee.Image().toByte().paint(coast, 1, 1).rename('value');
-
-    const extentSample = ee.Image(this.extentAsset.getEEAsset().first());
-    const mask = extentSample.unmask()
-      .distance(ee.Kernel.euclidean(200, 'meters'), true)
-      .add(extentSample.unmask());
-
-    const maskedCoastline = coastlineImage.updateMask(mask)
-      .multiply(ee.Image.pixelArea()).sqrt().divide(1000);
-
-    // Single reduction — coastline geometry does not change by year
-    const coastlineLength: ee.Dictionary = maskedCoastline.reduceRegion({
-      reducer: ee.Reducer.sum(),
-      geometry: geo,
-      scale: 30,
-      bestEffort: true,
-      tileScale: 4,
-    });
-
-    // Replicate across years using the extent collection as the year source
-    const years = this.extentAsset.getEEAsset().sort('system:index').toList(10000)
-      .map((img: ee.ComputedObject) => {
-        // system:index format: "mangrove_extent-v3_YYYY" → year is last segment
-        return ee.String(ee.Image(img).get('system:index')).split('_').get(-1);
-      });
-
-    return years.map((yr: ee.ComputedObject) => {
-      return ee.Dictionary({
-        'value':     coastlineLength.get('value'),
-        'year':      ee.Number.parse(ee.String(yr)),
-        'indicator': 'linear_coverage',
-      });
-    });
-  }
-
-  // Stacks all extent images into a single multi-band image using toBands() (faster than iterate())
-  // and performs a single reduceRegion instead of one per year.
-  // Band names from toBands() are "{system:index}_extent_{year}"; year is the trailing 4 chars.
-  _getHabitatExtent(geo: ee.Geometry): ee.List {
-    const collection: ee.ImageCollection = this.extentAsset.getEEAsset();
-
+  // Stacks all extent images into a multi-band image.
+  // Bands are named "{system:index}_extent_{year}"; pixel area applied so sum() → km².
+  _buildExtentImage(): ee.Image {
     // system:index format: "mangrove_extent-v3_YYYY" → year is last segment
-    const stacked = collection.sort('system:index')
+    return this.extentAsset.getEEAsset().sort('system:index')
       .map((img: ee.ComputedObject) => {
         const image = ee.Image(img);
         const year = ee.String(image.get('system:index')).split('_').get(-1) as ee.String;
@@ -89,23 +63,46 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
       .toBands()
       .multiply(ee.Image.pixelArea())
       .divide(1000 * 1000);
+  }
 
-    const reduced: ee.Dictionary = stacked.reduceRegion({
-      reducer: ee.Reducer.sum(),
-      geometry: geo,
-      scale: 30,
-      maxPixels: 1e12,
-      bestEffort: true,
-      tileScale: 4,
-    });
+  // Paints the coastline FC, masks to within 200 m of mangroves, converts to km per pixel.
+  // Produces a single band 'coastline'; sum() over the geometry yields linear coverage in km.
+  _buildCoastlineImage(coast: ee.FeatureCollection): ee.Image {
+    const coastlineImage = ee.Image().toByte().paint(coast, 1, 1).rename('value');
+    const extentSample = ee.Image(this.extentAsset.getEEAsset().first());
+    const mask = extentSample.unmask()
+      .distance(ee.Kernel.euclidean(200, 'meters'), true)
+      .add(extentSample.unmask());
+    return coastlineImage.updateMask(mask)
+      .multiply(ee.Image.pixelArea()).sqrt().divide(1000)
+      .rename('coastline');
+  }
 
-    // Band names are "{system:index}_extent_{year}" → year is the trailing 4 chars.
-    return reduced.keys().sort().map((key: ee.ComputedObject) => {
+  // Extracts per-year habitat extent rows from the combined reduced dictionary.
+  // All keys except 'coastline' are extent bands; year is the trailing 4 chars.
+  _extractHabitatExtent(reduced: ee.Dictionary): ee.List {
+    const extentKeys = reduced.keys()
+      .filter(ee.Filter.neq('item', 'coastline')).sort();
+    return extentKeys.map((key: ee.ComputedObject) => {
       const k = ee.String(key);
       return ee.Dictionary({
         'value':     reduced.get(k),
         'year':      ee.Number.parse(k.slice(-4)),
         'indicator': 'habitat_extent_area',
+      });
+    });
+  }
+
+  // Replicates the single coastline length value across all extent years.
+  _extractCoastalExtent(reduced: ee.Dictionary): ee.List {
+    const coastlineLength = reduced.get('coastline');
+    const extentKeys = reduced.keys()
+      .filter(ee.Filter.neq('item', 'coastline')).sort();
+    return extentKeys.map((key: ee.ComputedObject) => {
+      return ee.Dictionary({
+        'value':     coastlineLength,
+        'year':      ee.Number.parse(ee.String(key).slice(-4)),
+        'indicator': 'linear_coverage',
       });
     });
   }

--- a/cloud-functions/analysis/src/calculations/HabitatExtent.ts
+++ b/cloud-functions/analysis/src/calculations/HabitatExtent.ts
@@ -7,7 +7,7 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
   extentAsset = ExtentDataAsset;
   coastalAsset = CoastalExtentDataAsset
 
-  calculate(feature: ee.Feature): ee.List {
+  calculate(feature: ee.Feature): ee.Dictionary {
     const geometry = feature.geometry();
     const coastline = this.coastalAsset.getEEAsset();
 
@@ -29,15 +29,17 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
           "habitat_extent_area": "km2",
           "linear_coverage": "km"
         },
-        'year':ee.List(habitatExtent.map((f: ee.Dictionary) => ee.Dictionary(f).get('year'))),
+        'year': ee.List(habitatExtent.map((f: ee.ComputedObject) => ee.Dictionary(f).get('year'))),
         'total_lenght': totalCoastline}
       });
   }
 
+  // Computes coastal coverage with a single reduceRegion. The maskedCoastline
+  // image is constant across years, so the reduction is done once and the
+  // value is replicated per year rather than firing N concurrent aggregations.
   _getCoastalExtent(coast: ee.FeatureCollection, geo: ee.Geometry): ee.List {
     const coastlineImage = ee.Image().toByte().paint(coast, 1, 1).rename('value');
 
-    // Build the distance mask once outside the per-year map()
     const extentSample = ee.Image(this.extentAsset.getEEAsset().first());
     const mask = extentSample.unmask()
       .distance(ee.Kernel.euclidean(200, 'meters'), true)
@@ -46,57 +48,73 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
     const maskedCoastline = coastlineImage.updateMask(mask)
       .multiply(ee.Image.pixelArea()).sqrt().divide(1000);
 
-    const regionReducer = {
+    // Single reduction — coastline geometry does not change by year
+    const coastlineLength: ee.Dictionary = maskedCoastline.reduceRegion({
       reducer: ee.Reducer.sum(),
       geometry: geo,
       scale: 30,
       bestEffort: true,
-      tileScale: 4, // subdivide tiles to reduce memory pressure on large geometries
-    };
+      tileScale: 4,
+    });
 
-    return this.extentAsset.getEEAsset().map((image: ee.Image) => {
-      const year = ee.Number.parse(ee.String(image.id()).split('_').get(-1));
+    // Replicate across years using the extent collection as the year source
+    const years = this.extentAsset.getEEAsset().sort('system:index').toList(10000)
+      .map((img: ee.ComputedObject) => {
+        // system:index format: "mangrove_extent-v3_YYYY" → year is last segment
+        return ee.String(ee.Image(img).get('system:index')).split('_').get(-1);
+      });
 
-      return ee.Feature(null, ee.Dictionary(
-        maskedCoastline.reduceRegion(regionReducer)).combine(
-          {
-          'year': year,
-          'indicator': 'linear_coverage'}
-          )
-        );
-    }).toList(10000).map((i: ee.Feature) => {
-        const feature = ee.Feature(i);
-        return feature.toDictionary();
-      }
-    );
+    return years.map((yr: ee.ComputedObject) => {
+      return ee.Dictionary({
+        'value':     coastlineLength.get('value'),
+        'year':      ee.Number.parse(ee.String(yr)),
+        'indicator': 'linear_coverage',
+      });
+    });
   }
 
+  // Stacks all extent images into a single multi-band image (one band per year)
+  // and performs a single reduceRegion instead of one per year.
   _getHabitatExtent(geo: ee.Geometry): ee.List {
+    const collection: ee.ImageCollection = this.extentAsset.getEEAsset();
+    const images = collection.sort('system:index').toList(10000);
 
-    const reducers = ee.Reducer.sum();
+    // system:index format: "mangrove_extent-v3_YYYY" → year is last segment
+    const first = ee.Image(images.get(0));
+    const firstYear = ee.String(first.get('system:index')).split('_').get(-1) as ee.String;
+    const init = first.rename(ee.String('extent_').cat(firstYear));
 
-    return this.extentAsset.getEEAsset().map(
-      (image: ee.Image) => ee.Feature(null, ee.Dictionary(image.rename('value'
-      ).multiply(ee.Image.pixelArea())
-      .divide(1000 * 1000) // convert from m2 to km2
-      .reduceRegion(
-        {
-        reducer: reducers,
-        geometry: geo,
-        scale: 30,
-        maxPixels: 1e12,
-        bestEffort: true,
-        tileScale: 4, // subdivide tiles to reduce memory pressure on large geometries
-      }
-      )).combine({
-        'year': ee.Number.parse(ee.String(image.id()).split('_').get(-1)),
-        'indicator': 'habitat_extent_area'}))
-        ).toList(10000).map(
-        (i: ee.Feature) => {
-          const feature = ee.Feature(i);
-          return feature.toDictionary();
-        }
-      );
+    const stacked = ee.Image(
+      images.slice(1).iterate(
+        (img: ee.ComputedObject, acc: ee.ComputedObject): ee.ComputedObject => {
+          const image = ee.Image(img);
+          const year = ee.String(image.get('system:index')).split('_').get(-1) as ee.String;
+          return ee.Image(acc).addBands(image.rename(ee.String('extent_').cat(year)));
+        },
+        init
+      )
+    ).multiply(ee.Image.pixelArea()).divide(1000 * 1000);
+
+    const reduced: ee.Dictionary = stacked.reduceRegion({
+      reducer: ee.Reducer.sum(),
+      geometry: geo,
+      scale: 30,
+      maxPixels: 1e12,
+      bestEffort: true,
+      tileScale: 4,
+    });
+
+    // Reconstruct per-year rows from flat dictionary.
+    // Band names are "extent_{year}" → slice(7) strips the "extent_" prefix.
+    return reduced.keys().sort().map((key: ee.ComputedObject) => {
+      const k = ee.String(key);
+      const year = k.slice(7);
+      return ee.Dictionary({
+        'value':     reduced.get(k),
+        'year':      ee.Number.parse(year),
+        'indicator': 'habitat_extent_area',
+      });
+    });
   }
 }
 

--- a/cloud-functions/analysis/src/calculations/HabitatExtent.ts
+++ b/cloud-functions/analysis/src/calculations/HabitatExtent.ts
@@ -73,27 +73,22 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
     });
   }
 
-  // Stacks all extent images into a single multi-band image (one band per year)
+  // Stacks all extent images into a single multi-band image using toBands() (faster than iterate())
   // and performs a single reduceRegion instead of one per year.
+  // Band names from toBands() are "{system:index}_extent_{year}"; year is the trailing 4 chars.
   _getHabitatExtent(geo: ee.Geometry): ee.List {
     const collection: ee.ImageCollection = this.extentAsset.getEEAsset();
-    const images = collection.sort('system:index').toList(10000);
 
     // system:index format: "mangrove_extent-v3_YYYY" → year is last segment
-    const first = ee.Image(images.get(0));
-    const firstYear = ee.String(first.get('system:index')).split('_').get(-1) as ee.String;
-    const init = first.rename(ee.String('extent_').cat(firstYear));
-
-    const stacked = ee.Image(
-      images.slice(1).iterate(
-        (img: ee.ComputedObject, acc: ee.ComputedObject): ee.ComputedObject => {
-          const image = ee.Image(img);
-          const year = ee.String(image.get('system:index')).split('_').get(-1) as ee.String;
-          return ee.Image(acc).addBands(image.rename(ee.String('extent_').cat(year)));
-        },
-        init
-      )
-    ).multiply(ee.Image.pixelArea()).divide(1000 * 1000);
+    const stacked = collection.sort('system:index')
+      .map((img: ee.ComputedObject) => {
+        const image = ee.Image(img);
+        const year = ee.String(image.get('system:index')).split('_').get(-1) as ee.String;
+        return image.rename(ee.String('extent_').cat(year));
+      })
+      .toBands()
+      .multiply(ee.Image.pixelArea())
+      .divide(1000 * 1000);
 
     const reduced: ee.Dictionary = stacked.reduceRegion({
       reducer: ee.Reducer.sum(),
@@ -104,14 +99,12 @@ class HabitatExtentCalculationsClass extends BaseCalculation {
       tileScale: 4,
     });
 
-    // Reconstruct per-year rows from flat dictionary.
-    // Band names are "extent_{year}" → slice(7) strips the "extent_" prefix.
+    // Band names are "{system:index}_extent_{year}" → year is the trailing 4 chars.
     return reduced.keys().sort().map((key: ee.ComputedObject) => {
       const k = ee.String(key);
-      const year = k.slice(7);
       return ee.Dictionary({
         'value':     reduced.get(k),
-        'year':      ee.Number.parse(year),
+        'year':      ee.Number.parse(k.slice(-4)),
         'indicator': 'habitat_extent_area',
       });
     });

--- a/cloud-functions/analysis/src/calculations/NetChange.ts
+++ b/cloud-functions/analysis/src/calculations/NetChange.ts
@@ -29,27 +29,21 @@ class NetChangeCalculationsClass extends BaseCalculation {
   }});
   }
 
-  // Returns a flat ee.Dictionary with keys "{name}_{year}" and values in km².
-  // A single reduceRegion covers all years to avoid concurrent aggregation limits.
+  // Stacks all images into a single multi-band image using toBands() (faster than iterate()).
+  // Band names from toBands() are "{system:index}_{name}_{year}"; year is always the last 4 chars.
   _getGainLoss(IC: IGainLossAsset, geom: ee.Geometry): ee.Dictionary {
     const collection: ee.ImageCollection = IC.getEEAsset();
-    const images = collection.sort('system:index').toList(100);
 
     // system:index format: "gl_{start}_{end}_{type}" → year at slice(8, 12)
-    const first = ee.Image(images.get(0));
-    const firstYear = ee.String(first.get('system:index')).slice(8, 12);
-    const init = first.rename(ee.String(IC.name).cat('_').cat(firstYear));
-
-    const stacked = ee.Image(
-      images.slice(1).iterate(
-        (img: ee.ComputedObject, acc: ee.ComputedObject): ee.ComputedObject => {
-          const image = ee.Image(img);
-          const year = ee.String(image.get('system:index')).slice(8, 12);
-          return ee.Image(acc).addBands(image.rename(ee.String(IC.name).cat('_').cat(year)));
-        },
-        init
-      )
-    ).multiply(ee.Image.pixelArea()).divide(1000 * 1000);
+    const stacked = collection.sort('system:index')
+      .map((img: ee.ComputedObject) => {
+        const image = ee.Image(img);
+        const year = ee.String(image.get('system:index')).slice(8, 12);
+        return image.rename(ee.String(IC.name).cat('_').cat(year));
+      })
+      .toBands()
+      .multiply(ee.Image.pixelArea())
+      .divide(1000 * 1000);
 
     return stacked.reduceRegion({
       reducer: ee.Reducer.sum(),
@@ -62,16 +56,18 @@ class NetChangeCalculationsClass extends BaseCalculation {
   }
 
   // Reconstructs per-year rows from the flat gain/loss dictionaries.
-  // Band names are "{name}_{year}" so slice(5) strips the "gain_"/"loss_" prefix.
+  // Keys from toBands() are "{system:index}_{name}_{year}"; year is the trailing 4 chars.
+  // Zip sorted gain/loss key lists — both collections share the same year sequence.
   _netChange(gainDict: ee.Dictionary, lossDict: ee.Dictionary): ee.List {
-    const years = gainDict.keys().sort().map(
-      (key: ee.ComputedObject) => ee.String(key).slice(5) // remove "gain_" prefix
-    );
+    const pairs = gainDict.keys().sort().zip(lossDict.keys().sort());
 
-    const rows = years.map((yr: ee.ComputedObject) => {
-      const year = ee.String(yr);
-      const gainVal = ee.Number(gainDict.get(ee.String('gain_').cat(year)));
-      const lossVal = ee.Number(lossDict.get(ee.String('loss_').cat(year)));
+    const rows = pairs.map((pair: ee.ComputedObject) => {
+      const p = ee.List(pair);
+      const gainKey = ee.String(p.get(0));
+      const lossKey = ee.String(p.get(1));
+      const year = gainKey.slice(-4);
+      const gainVal = ee.Number(gainDict.get(gainKey));
+      const lossVal = ee.Number(lossDict.get(lossKey));
       return ee.Dictionary({
         'year':       ee.Number.parse(year),
         'gain':       gainVal,

--- a/cloud-functions/analysis/src/calculations/NetChange.ts
+++ b/cloud-functions/analysis/src/calculations/NetChange.ts
@@ -10,12 +10,29 @@ class NetChangeCalculationsClass extends BaseCalculation {
   Loss = LossDataAsset;
 
   calculate(feature: ee.Feature): ee.Dictionary {
-
     const geometry = feature.geometry();
 
-    const gain = this._getGainLoss(this.Gain, geometry);
-    const loss = this._getGainLoss(this.Loss, geometry);
-    const netChange = this._netChange(gain, loss);
+    // Adaptive scale: 30 m for small areas, capped at 120 m for large areas.
+    // Reaches 60 m at ~1 000 km², 90 m at ~4 000 km², 120 m at ~9 000 km².
+    const scale = ee.Number(geometry.area(1000))
+      .divide(1e9).sqrt().multiply(30).add(30).max(30).min(120);
+
+    // Stack gain and loss into one image, then a single reduceRegion call.
+    const stacked = this._stackCollection(this.Gain)
+      .addBands(this._stackCollection(this.Loss))
+      .multiply(ee.Image.pixelArea())
+      .divide(1000 * 1000);
+
+    const reduced = stacked.reduceRegion({
+      reducer: ee.Reducer.sum(),
+      geometry,
+      scale,
+      maxPixels: 1e12,
+      bestEffort: true,
+      tileScale: 4,
+    });
+
+    const netChange = this._netChange(reduced);
 
     return ee.Dictionary({
       'data': netChange,
@@ -29,45 +46,35 @@ class NetChangeCalculationsClass extends BaseCalculation {
   }});
   }
 
-  // Stacks all images into a single multi-band image using toBands() (faster than iterate()).
-  // Band names from toBands() are "{system:index}_{name}_{year}"; year is always the last 4 chars.
-  _getGainLoss(IC: IGainLossAsset, geom: ee.Geometry): ee.Dictionary {
-    const collection: ee.ImageCollection = IC.getEEAsset();
-
+  // Returns a stacked image with one band per year, named "{system:index}_{name}_{year}".
+  // Pixel area is applied in calculate() after gain and loss are combined.
+  _stackCollection(IC: IGainLossAsset): ee.Image {
     // system:index format: "gl_{start}_{end}_{type}" → year at slice(8, 12)
-    const stacked = collection.sort('system:index')
+    return IC.getEEAsset().sort('system:index')
       .map((img: ee.ComputedObject) => {
         const image = ee.Image(img);
         const year = ee.String(image.get('system:index')).slice(8, 12);
         return image.rename(ee.String(IC.name).cat('_').cat(year));
       })
-      .toBands()
-      .multiply(ee.Image.pixelArea())
-      .divide(1000 * 1000);
-
-    return stacked.reduceRegion({
-      reducer: ee.Reducer.sum(),
-      geometry: geom,
-      scale: 30,
-      maxPixels: 1e12,
-      bestEffort: true,
-      tileScale: 4,
-    });
+      .toBands();
   }
 
-  // Reconstructs per-year rows from the flat gain/loss dictionaries.
-  // Keys from toBands() are "{system:index}_{name}_{year}"; year is the trailing 4 chars.
-  // Zip sorted gain/loss key lists — both collections share the same year sequence.
-  _netChange(gainDict: ee.Dictionary, lossDict: ee.Dictionary): ee.List {
-    const pairs = gainDict.keys().sort().zip(lossDict.keys().sort());
+  // Reconstructs per-year rows from the combined gain+loss reduced dictionary.
+  // Keys from toBands() are "{system:index}_{name}_{year}"; gain/loss separated by key content.
+  // Year is the trailing 4 chars of each key.
+  _netChange(reduced: ee.Dictionary): ee.List {
+    const gainKeys = reduced.keys()
+      .filter(ee.Filter.stringContains('item', '_gain_')).sort();
+    const lossKeys = reduced.keys()
+      .filter(ee.Filter.stringContains('item', '_loss_')).sort();
 
-    const rows = pairs.map((pair: ee.ComputedObject) => {
+    const rows = gainKeys.zip(lossKeys).map((pair: ee.ComputedObject) => {
       const p = ee.List(pair);
       const gainKey = ee.String(p.get(0));
       const lossKey = ee.String(p.get(1));
       const year = gainKey.slice(-4);
-      const gainVal = ee.Number(gainDict.get(gainKey));
-      const lossVal = ee.Number(lossDict.get(lossKey));
+      const gainVal = ee.Number(reduced.get(gainKey));
+      const lossVal = ee.Number(reduced.get(lossKey));
       return ee.Dictionary({
         'year':       ee.Number.parse(year),
         'gain':       gainVal,

--- a/cloud-functions/analysis/src/calculations/NetChange.ts
+++ b/cloud-functions/analysis/src/calculations/NetChange.ts
@@ -1,14 +1,15 @@
 import ee from '@google/earthengine';
-import { GainDataAsset } from '../geeAssets/GainDataAssets';
-import { LossDataAsset } from '../geeAssets/LossDataAssets';
+import { GainDataAsset, IGainDataAsset } from '../geeAssets/GainDataAssets';
+import { LossDataAsset, ILossDataAsset } from '../geeAssets/LossDataAssets';
 import {  BaseCalculation } from './BaseCalculation';
 
+type IGainLossAsset = IGainDataAsset | ILossDataAsset;
 
 class NetChangeCalculationsClass extends BaseCalculation {
   Gain = GainDataAsset;
   Loss = LossDataAsset;
 
-  calculate(feature: ee.Feature): ee.List {
+  calculate(feature: ee.Feature): ee.Dictionary {
 
     const geometry = feature.geometry();
 
@@ -24,42 +25,67 @@ class NetChangeCalculationsClass extends BaseCalculation {
           "net_change": "km2",
           "gain": "km2",
           "loss": "km2"},
-      'year': (netChange.map((f: ee.Dictionary) => ee.Dictionary(f).get('year')))
+      'year': (netChange.map((f: ee.ComputedObject) => ee.Dictionary(f).get('year')))
   }});
   }
 
-  _getGainLoss(IC: ee.ImageCollection, geom: ee.Geometry): ee.List {
-    const reducers = ee.Reducer.sum();
-    return IC.getEEAsset().map(
-      (image: ee.Image) => ee.Feature(null, image.rename(IC.name)
-                          .multiply(ee.Image.pixelArea()).divide(1000*1000)
-                          .reduceRegion({
-                            reducer: reducers,
-                            geometry: geom,
-                            scale: 30,
-                            maxPixels: 1e12,
-                            bestEffort: true,
-                            tileScale: 4, // subdivide tiles to reduce memory pressure on large geometries
-                          })))
-              .toList(10000)
-  }
-  _netChange(g: ee.List, l: ee.List): ee.Feature {
-    return g.zip(l).map((list: ee.List) => {
-          const item = ee.List(list);
-          const ga = ee.Feature(item.get(0));
-          const lo = ee.Feature(item.get(1));
-          const year = ee.Number.parse(ee.String(lo.id()).slice(8,12));
-          const net_change = ee.Number(ga.get('gain')).subtract(ee.Number(lo.get('loss')));
+  // Returns a flat ee.Dictionary with keys "{name}_{year}" and values in km².
+  // A single reduceRegion covers all years to avoid concurrent aggregation limits.
+  _getGainLoss(IC: IGainLossAsset, geom: ee.Geometry): ee.Dictionary {
+    const collection: ee.ImageCollection = IC.getEEAsset();
+    const images = collection.sort('system:index').toList(100);
 
-          return ga.toDictionary()
-          .combine(lo.toDictionary())
-          .combine(ee.Dictionary({'year':year, 'net_change': net_change}));
-        }).insert(0, ee.Dictionary({
-          "gain": 0,
-          "loss": 0,
-          "net_change": 0,
-          "year": 1996
-      }))
+    // system:index format: "gl_{start}_{end}_{type}" → year at slice(8, 12)
+    const first = ee.Image(images.get(0));
+    const firstYear = ee.String(first.get('system:index')).slice(8, 12);
+    const init = first.rename(ee.String(IC.name).cat('_').cat(firstYear));
+
+    const stacked = ee.Image(
+      images.slice(1).iterate(
+        (img: ee.ComputedObject, acc: ee.ComputedObject): ee.ComputedObject => {
+          const image = ee.Image(img);
+          const year = ee.String(image.get('system:index')).slice(8, 12);
+          return ee.Image(acc).addBands(image.rename(ee.String(IC.name).cat('_').cat(year)));
+        },
+        init
+      )
+    ).multiply(ee.Image.pixelArea()).divide(1000 * 1000);
+
+    return stacked.reduceRegion({
+      reducer: ee.Reducer.sum(),
+      geometry: geom,
+      scale: 30,
+      maxPixels: 1e12,
+      bestEffort: true,
+      tileScale: 4,
+    });
+  }
+
+  // Reconstructs per-year rows from the flat gain/loss dictionaries.
+  // Band names are "{name}_{year}" so slice(5) strips the "gain_"/"loss_" prefix.
+  _netChange(gainDict: ee.Dictionary, lossDict: ee.Dictionary): ee.List {
+    const years = gainDict.keys().sort().map(
+      (key: ee.ComputedObject) => ee.String(key).slice(5) // remove "gain_" prefix
+    );
+
+    const rows = years.map((yr: ee.ComputedObject) => {
+      const year = ee.String(yr);
+      const gainVal = ee.Number(gainDict.get(ee.String('gain_').cat(year)));
+      const lossVal = ee.Number(lossDict.get(ee.String('loss_').cat(year)));
+      return ee.Dictionary({
+        'year':       ee.Number.parse(year),
+        'gain':       gainVal,
+        'loss':       lossVal,
+        'net_change': gainVal.subtract(lossVal),
+      });
+    });
+
+    return ee.List(rows).insert(0, ee.Dictionary({
+      "gain": 0,
+      "loss": 0,
+      "net_change": 0,
+      "year": 1996
+    }));
   }
 }
 


### PR DESCRIPTION
## Summary

- **Problem:** `HabitatExtent` and `NetChange` used `ImageCollection.map(image => image.reduceRegion(...))`, which fires one concurrent GEE aggregation per year. With 10+ years × 2 collections this exceeded GEE's concurrent aggregation limit, producing a \"Too many concurrent aggregations\" error.
- **Fix:** Stack all yearly images into a single multi-band image (one band per year, named `{indicator}_{year}`) using `List.iterate()`, then call `reduceRegion` once per indicator. The flat result dictionary is parsed server-side to reconstruct the per-year rows.
- **Output shape:** Unchanged — `data`, `metadata`, `year`, `units`, and all indicator keys (`value`, `gain`, `loss`, `net_change`) are identical to the original.

## Changes

### `NetChange.ts`
- `_getGainLoss`: builds a multi-band image via `iterate()` with bands `gain_YYYY` / `loss_YYYY` (year from `system:index.slice(8,12)`), reduces once, returns `ee.Dictionary` instead of `ee.List`.
- `_netChange`: accepts the two flat dictionaries, extracts years from sorted keys (`slice(5)` strips the `gain_` prefix), reconstructs rows by direct key lookup. 1996 baseline row still prepended.

### `HabitatExtent.ts`
- `_getHabitatExtent`: same multi-band stacking with bands `extent_YYYY` (year from `system:index.split('_').get(-1)`), single `reduceRegion`, keys parsed with `slice(7)`.
- `_getCoastalExtent`: `maskedCoastline.reduceRegion` was already precomputed outside the loop but still called N times inside `.map()`. Now called **once**; the value is replicated across years by mapping over the sorted extent collection year labels.