### PR TITLE
feat: add year dropdown to habitat extent timeline sentence

### DIFF
--- a/src/components/ui/timeline/index.tsx
+++ b/src/components/ui/timeline/index.tsx
@@ -90,10 +90,12 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
   );
 
   const draggingRef = useRef(false);
+  const [isDragging, setIsDragging] = useState(false);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       draggingRef.current = true;
+      setIsDragging(true);
       e.currentTarget.setPointerCapture(e.pointerId);
       goToIndex(indexFromClientX(e.clientX));
     },
@@ -110,6 +112,7 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
 
   const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     draggingRef.current = false;
+    setIsDragging(false);
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
       e.currentTarget.releasePointerCapture(e.pointerId);
     }
@@ -214,7 +217,11 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
             viewBox="0 0 12 12"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
-            className="pointer-events-none absolute -top-1.75 -translate-x-1/2 motion-safe:transition-[left] motion-safe:duration-150 motion-safe:ease-out"
+            className={cn(
+              'pointer-events-none absolute -top-1.75 -translate-x-1/2',
+              !isDragging &&
+                'motion-safe:transition-[left] motion-safe:duration-150 motion-safe:ease-out'
+            )}
             style={{ left: `calc(12px + (100% - 24px) * ${dotPct / 100})` }}
           >
             <path d="M0 0H12V6L6 12L0 6V0Z" fill="#00857F" />

--- a/src/components/ui/timeline/index.tsx
+++ b/src/components/ui/timeline/index.tsx
@@ -76,6 +76,45 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
     [years, currentYear, isPlaying, onTogglePlay, onYearChange]
   );
 
+  const indexFromClientX = useCallback(
+    (clientX: number) => {
+      const el = trackRef.current;
+      if (!el || years.length <= 1) return 0;
+      const rect = el.getBoundingClientRect();
+      const usable = rect.width - 24;
+      const x = clientX - rect.left - 12;
+      const t = usable > 0 ? x / usable : 0;
+      return Math.round(t * (years.length - 1));
+    },
+    [years.length]
+  );
+
+  const draggingRef = useRef(false);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      draggingRef.current = true;
+      e.currentTarget.setPointerCapture(e.pointerId);
+      goToIndex(indexFromClientX(e.clientX));
+    },
+    [goToIndex, indexFromClientX]
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      goToIndex(indexFromClientX(e.clientX));
+    },
+    [goToIndex, indexFromClientX]
+  );
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    draggingRef.current = false;
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+  }, []);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLButtonElement>, i: number) => {
       let nextIdx = i;
@@ -120,7 +159,13 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
       </button>
 
       <div ref={trackRef} className="relative flex-1">
-        <div className="relative mt-2 h-10">
+        <div
+          className="relative mt-2 h-10 cursor-pointer touch-none"
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+        >
           {years.map((y, i) => {
             const isCurrent = y === currentYear;
             const showLabel = labelIndices.has(i);

--- a/src/components/ui/timeline/index.tsx
+++ b/src/components/ui/timeline/index.tsx
@@ -21,7 +21,9 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
 
   const trackRef = useRef<HTMLDivElement>(null);
   const tickRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const draggingRef = useRef(false);
   const [trackWidth, setTrackWidth] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
 
   useEffect(() => {
     const el = trackRef.current;
@@ -88,9 +90,6 @@ const Timeline = ({ years, currentYear, isPlaying, onYearChange, onTogglePlay }:
     },
     [years.length]
   );
-
-  const draggingRef = useRef(false);
-  const [isDragging, setIsDragging] = useState(false);
 
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -302,7 +302,39 @@ const HabitatExtent = () => {
                   </PopoverContent>
                 </Popover>
               </span>{' '}
-              in <span className="font-bold">{currentYear}</span>.
+              in{' '}
+              <Popover>
+                <PopoverTrigger asChild>
+                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                    {currentYear}
+                    <ARROW_SVG
+                      className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
+                      role="img"
+                      title="Arrow"
+                    />
+                  </span>
+                </PopoverTrigger>
+                <PopoverContent className="shadow-border rounded-2xl px-2">
+                  <ul className="z-20 max-h-56 space-y-0.5">
+                    {sortedYears?.map((y) => (
+                      <li key={y} className="last-of-type:pb-4">
+                        <button
+                          aria-label="select year"
+                          className={cn({
+                            'hover:bg-brand-800/20 rounded-lg px-2 py-1': true,
+                            'text-brand-800 font-semibold': y === currentYear,
+                          })}
+                          type="button"
+                          onClick={() => handleYearChange(y)}
+                        >
+                          {y}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </PopoverContent>
+              </Popover>
+              .
             </p>
             <div className="py-4">
               {sortedYears.length > 1 && (

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -323,8 +323,10 @@ const HabitatExtent = () => {
                           className={cn({
                             'hover:bg-brand-800/20 rounded-lg px-2 py-1': true,
                             'text-brand-800 font-semibold': y === currentYear,
+                            'pointer-events-none opacity-50': isPlaying,
                           })}
                           type="button"
+                          disabled={isPlaying}
                           onClick={() => handleYearChange(y)}
                         >
                           {y}


### PR DESCRIPTION
## Summary

The habitat extent widget's timeline-slider variant showed the selected year as static text. This adds a year selector dropdown in the sentence, mirroring the existing unit dropdown.

The dropdown and the timeline slider both write through `handleYearChange` → `habitatExtentSettings` atom and read the same `currentYear`, so they stay in sync in both directions:
- Pick a year in the dropdown → timeline slider moves
- Scrub/play the timeline → dropdown label updates

Reuses existing dropdown markup (`WIDGET_SELECT_STYLES`, `ARROW_SVG`, `Popover`), `sortedYears` for the option list, and highlights the active year via `y === currentYear`.

## Test plan

- [ ] With `timeline_slider` feature flag on, open habitat extent widget
- [ ] Year in sentence is now a clickable dropdown
- [ ] Selecting a year updates both the sentence and the timeline slider
- [ ] Playing/scrubbing the timeline updates the year in the sentence
- [ ] Unit dropdown still works