### PR TITLE
fix: remount habitat-extent prod layers on year change

### DIFF
--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -71,6 +71,7 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
     return (
       <Source id="habitat_extent" type="vector" url={LEGACY_EXTENT_SOURCE_URL}>
         <Layer
+          key={`${id}_${currentYear}_fill`}
           id={`${id}_${currentYear}_fill`}
           type="fill"
           source="habitat_extent"
@@ -83,6 +84,7 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
           beforeId={beforeId}
         />
         <Layer
+          key={`${id}_${currentYear}_line`}
           id={`${id}_${currentYear}_line`}
           type="line"
           source="habitat_extent"


### PR DESCRIPTION
The legacy (timeline_slider off) codepath rendered the fill/line layers with a year-dependent id but reused the same React instance across year changes. react-map-gl@7 memoizes the layer id at mount and never mutates the immutable source-layer on update, so the Mapbox layer stayed pinned to the first-rendered year.

Add a year-keyed key to each Layer so React remounts them on selection, removing the stale layer and recreating it with the correct source-layer.
