### PR TITLE
fix: restore mobile layout and widgets scroll

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,8 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  width: 1024,
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/src/layouts/mobile/index.tsx
+++ b/src/layouts/mobile/index.tsx
@@ -46,7 +46,9 @@ const MobileLayout = () => {
       </Link>
       <NavigationBar />
       <WelcomeIntroMessage />
-      <main id="main-content">{!mapView && <WidgetsContainer />}</main>
+      <main id="main-content" className="h-full">
+        {!mapView && <WidgetsContainer />}
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes two regressions in the **mobile view** (introduced in the App Router migration):

1. **Whole mobile layout broken.** The root layout pinned the viewport meta to a fixed `width: 1024` (`src/app/layout.tsx`). On phones this rendered the page at 1024px logical width:
   - `body` `bg-brand-400` showed as a frame around the content
   - the map overflowed the device width
   - the **desktop** legend rendered (and was cut off the right edge)
   - the mobile bottom nav bar never appeared → no way to reach the widgets

   Fix: viewport → `width: 'device-width', initialScale: 1`.

2. **Widgets list couldn't scroll to the bottom.** The scroll container uses `h-full`, but its `<main id="main-content">` parent had no height, so the percentage height collapsed and the container expanded to fit all content (~6579px) inside `overflow-hidden` ancestors — the lower widgets were clipped with no internal scroll (`maxScroll: 0`).

   Fix: give `<main>` `h-full` so the container is viewport-bound and `overflow-y-auto` scrolls. On desktop the container is `xl:absolute`, so its `h-full` already resolved — this change only affects mobile.

## Test plan

Verified live in a real mobile-viewport browser (390×844) against the dev server:

- [x] viewport meta = `width=device-width, initial-scale=1`; `innerWidth` 390; `scrollWidth` 390 (no overflow)
- [x] mobile bottom nav bar renders; mobile full-width legend renders (desktop legend gone)
- [x] Map toggle switches map ↔ widgets; 9 widgets render
- [x] widgets view scrolls fully; last widget clears the nav bar (52px gap)
- [x] no console / page errors
- [x] desktop layout (≥1280px) unaffected — mobile layout component only renders below xl
- [x] `pnpm check-types` + `eslint` pass (pre-commit)

> Manual QA on a physical device still recommended (iOS Safari dynamic toolbar).