### PR TITLE
refactor: move analysis API path into hook request URLs

### DIFF
--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -18,6 +18,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
 import { Visibility } from '@/types/layers';
+import { env } from 'env.mjs';
 import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
@@ -59,7 +60,7 @@ export function useMangroveBiomass(
       if (isAnalysisEnabled) {
         return AnalysisAPI.request<AnalysisResponse<DataResponse> | AxiosError>({
           method: 'post',
-          url: '',
+          url: `/${env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
           data: {
             geometry: geojson,
           },

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -13,6 +13,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
 import { Visibility } from '@/types/layers';
+import { env } from 'env.mjs';
 import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
@@ -45,7 +46,7 @@ export function useMangroveBlueCarbon(
     if (isAnalysisEnabled) {
       return AnalysisAPI.request<AnalysisResponse<DataResponse> | AxiosError>({
         method: 'post',
-        url: '',
+        url: `/${env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
         data: {
           geometry: geojson,
         },

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -15,6 +15,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
 import { Visibility } from '@/types/layers';
+import { env } from 'env.mjs';
 import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
@@ -45,7 +46,7 @@ export function useMangroveHabitatExtent(
       if (isAnalysisEnabled) {
         return AnalysisAPI.request<AnalysisResponse<DataResponse> | AxiosError>({
           method: 'post',
-          url: '',
+          url: `/${env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
           data: {
             geometry: geojson,
           },

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -17,6 +17,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
 import { Visibility } from '@/types/layers';
+import { env } from 'env.mjs';
 import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
@@ -89,7 +90,7 @@ export function useMangroveHeight(
     if (isAnalysisEnabled) {
       return AnalysisAPI.request<AnalysisResponse<DataResponse> | AxiosError>({
         method: 'post',
-        url: '',
+        url: `/${env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
         data: {
           geometry: geojson,
         },

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -18,6 +18,7 @@ import { useLocation } from '@/containers/datasets/locations/hooks';
 
 import CustomTooltip from '@/components/chart/tooltip';
 import { Visibility } from '@/types/layers';
+import { env } from 'env.mjs';
 
 import API, { AnalysisAPI } from 'services/api';
 
@@ -153,7 +154,7 @@ export function useMangroveNetChange(
     if (isAnalysisEnabled) {
       return AnalysisAPI.request<AnalysisResponse<DataResponse | AxiosError>>({
         method: 'post',
-        url: '',
+        url: `/${env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
         data: {
           geometry: geojson,
         },

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -17,7 +17,7 @@ API.interceptors.request.use(async (config) => {
 });
 
 export const AnalysisAPI = axios.create({
-  baseURL: `${process.env.NEXT_PUBLIC_ANALYSIS_API_URL}/${process.env.NEXT_PUBLIC_ANALYSIS_API_PATH}`,
+  baseURL: process.env.NEXT_PUBLIC_ANALYSIS_API_URL,
   headers: { 'Content-Type': 'application/json' },
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,13 +5,36 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
-// Merge the .env files into an object passed to test.env so the Zod-validated
-// `env` from env.mjs (which runs createEnv at module load) resolves when hooks
-// import it. Hand-parsed to avoid depending on vite's loadEnv (transitive, no
-// types). Files are read in ascending priority — later overrides earlier — to
-// match Vite/Next precedence (mode and *.local files win over the base .env).
+// Dataset hooks import the Zod-validated `env` from env.mjs, which runs
+// createEnv at module load and requires EVERY var in the schema. CI only has
+// the committed .env.test (which is partial), so provide complete dummy
+// defaults here to keep validation green. Real .env values overlay these.
+const ENV_DEFAULTS: Record<string, string> = {
+  NEXT_PUBLIC_API_URL: 'https://example.com',
+  NEXT_PUBLIC_MRTT_SITE: 'https://example.com',
+  NEXT_PUBLIC_AUTH_URL: 'https://example.com',
+  NEXT_PUBLIC_ANALYSIS_API_URL: 'https://example.com',
+  NEXT_PUBLIC_ANALYSIS_API_PATH: 'analysis-staging',
+  NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: 'test',
+  NEXT_PUBLIC_PLANET_API_KEY: 'test',
+  NEXT_PUBLIC_TRANSIFEX_API_KEY: 'test',
+  NEXT_PUBLIC_SMTP_ADDRESS: 'test',
+  NEXT_PUBLIC_SMTP_PASSWORD: 'test',
+  NEXT_PUBLIC_SMTP_PORT: '587',
+  NEXT_PUBLIC_SMTP_USER_NAME: 'test',
+  NEXT_PUBLIC_GA_ID: 'test',
+  NEXT_PUBLIC_VERCEL_ENV: 'development',
+  NEXT_PUBLIC_ENVIRONMENT: 'development',
+  NEXTAUTH_URL: 'https://example.com',
+  NEXTAUTH_SECRET: 'test',
+  AUTH_API_URL: 'https://example.com',
+};
+
+// Overlay real .env files (ascending priority — later overrides earlier) onto
+// the defaults so local runs use real values while CI falls back to defaults.
+// Hand-parsed to avoid depending on vite's loadEnv (transitive, no types).
 function loadTestEnv(): Record<string, string> {
-  const env: Record<string, string> = {};
+  const env: Record<string, string> = { ...ENV_DEFAULTS };
   for (const name of ['.env', '.env.local', '.env.test', '.env.test.local']) {
     try {
       const file = readFileSync(resolve(process.cwd(), name), 'utf-8');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
+
+// Merge the .env files into an object passed to test.env so the Zod-validated
+// `env` from env.mjs (which runs createEnv at module load) resolves when hooks
+// import it. Hand-parsed to avoid depending on vite's loadEnv (transitive, no
+// types). Files are read in ascending priority — later overrides earlier — to
+// match Vite/Next precedence (mode and *.local files win over the base .env).
+function loadTestEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const name of ['.env', '.env.local', '.env.test', '.env.test.local']) {
+    try {
+      const file = readFileSync(resolve(process.cwd(), name), 'utf-8');
+      for (const line of file.split('\n')) {
+        const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*?)\s*$/);
+        if (match) env[match[1]] = match[2].replace(/^["']|["']$/g, '');
+      }
+    } catch {
+      // file absent — skip
+    }
+  }
+  return env;
+}
+
+const testEnv = loadTestEnv();
 
 export default defineConfig({
   // ignoreConfigErrors: skip the nested cloud-functions/* tsconfigs (out of scope).
@@ -8,6 +34,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    env: testEnv,
     setupFiles: ['./vitest.setup.ts'],
     // Vitest owns the unit/component/integration suites under tests/. Playwright
     // e2e + a11y specs (tests/*.spec.ts, tests/a11y) use *.spec.ts and are not


### PR DESCRIPTION
## Summary
- Keep `AnalysisAPI.baseURL` as the bare cloud function host (`NEXT_PUBLIC_ANALYSIS_API_URL`)
- Append the function-name path (`NEXT_PUBLIC_ANALYSIS_API_PATH`) at each analysis call site instead of baking it into `baseURL`
- Path sourced from the Zod-validated `env` export (absolute import `from 'env.mjs'`), so it stays typed/validated

Reverts the previous approach of `baseURL: \`\${URL}/\${PATH}\`` + blank `url: ''`. Service stays clean; the path lives with the request.

## Files
- `src/services/api.ts` — `AnalysisAPI.baseURL` back to bare URL
- `src/containers/datasets/{biomass,blue-carbon,habitat-extent,height,net-change}/hooks.tsx` — `url: \`/\${env.NEXT_PUBLIC_ANALYSIS_API_PATH}\``

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint` (changed files)
- [ ] Draw/upload a polygon → confirm analysis widgets hit `…cloudfunctions.net/analysis-staging` and return data