### PR TITLE
feat(data): add notebook to export GMW v4 gain/loss map tiles

### DIFF
--- a/data/notebooks/Lab/data_processing/GEE/create_tiles_gain_loss_v4.ipynb
+++ b/data/notebooks/Lab/data_processing/GEE/create_tiles_gain_loss_v4.ipynb
@@ -1,0 +1,483 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-0",
+   "metadata": {},
+   "source": [
+    "# Export map tiles for gain and loss — GMW v4\n",
+    "\n",
+    "Exports one combined gain/loss tileset per year from the unified GMW v4\n",
+    "ImageCollection (`mangrove_change_ic_v4`). Each image has a single\n",
+    "`classification` band where gain=1 and loss=2. Both classes are rendered\n",
+    "at all zoom levels (0–12)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ee\n",
+    "import geemap\n",
+    "%run utils.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ee.Authenticate(auth_mode=\"notebook\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "ee.Initialize(project='mangrove-atlas-246414')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-4",
+   "metadata": {},
+   "source": [
+    "### Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "cell-5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gcs_bucket = 'mangrove_atlas'\n",
+    "ic_asset   = 'projects/mangrove-atlas-246414/assets/land-cover/mangrove_change_ic_v4'\n",
+    "\n",
+    "# All 40 change years available in the v4 IC (1986–2025).\n",
+    "# Reduce this list to export a subset.\n",
+    "data_year_range = list(range(1986, 2026))\n",
+    "\n",
+    "region = ee.Geometry.BBox(-179, -40, 179, 40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-6",
+   "metadata": {},
+   "source": [
+    "### Load collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "cell-7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "IC size: 40 images\n",
+      "Change years: [1986, 1987, 1988, 1989, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025]\n"
+     ]
+    }
+   ],
+   "source": [
+    "ic = ee.ImageCollection(ic_asset).sort('system:time_start')\n",
+    "\n",
+    "print(f'IC size: {ic.size().getInfo()} images')\n",
+    "print(f'Change years: {ic.aggregate_array(\"change_year\").sort().getInfo()}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-8",
+   "metadata": {},
+   "source": [
+    "### Style"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "cell-9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "gain_loss_ramp = '''\n",
+    "    <RasterSymbolizer>\n",
+    "        <ColorMap type=\"values\" extended=\"false\">\n",
+    "            <ColorMapEntry color=\"#a6cb10\" quantity=\"1\" label=\"Gain\"/>\n",
+    "            <ColorMapEntry color=\"#eb6240\" quantity=\"2\" label=\"Loss\"/>\n",
+    "        </ColorMap>\n",
+    "    </RasterSymbolizer>\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "### Visualise prior to export"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "cell-11",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <style>\n",
+       "                .geemap-dark {\n",
+       "                    --jp-widgets-color: white;\n",
+       "                    --jp-widgets-label-color: white;\n",
+       "                    --jp-ui-font-color1: white;\n",
+       "                    --jp-layout-color2: #454545;\n",
+       "                    background-color: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-dark .jupyter-button {\n",
+       "                    --jp-layout-color3: #383838;\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab {\n",
+       "                    background-color: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "\n",
+       "                .geemap-colab .jupyter-button {\n",
+       "                    --jp-layout-color3: var(--colab-primary-surface-color, white);\n",
+       "                }\n",
+       "            </style>\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "be77199ae4e04aa7a551e3e052ca437a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Map(center=[-5, 39], controls=(WidgetControl(options=['position', 'transparent_bg'], position='topright', tran…"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Map = geemap.Map(center=(-5, 39), zoom=5, basemap='CartoDB.PositronNoLabels')\n",
+    "#render the last year of the IC (2025) for visualization\n",
+    "\n",
+    "last_img = ee.Image(ic.sort('system:time_start', False).first())\n",
+    "\n",
+    "Map.addLayer(\n",
+    "    last_img.clip(region).sldStyle(gain_loss_ramp),\n",
+    "    {}, 'Gain + Loss (last year)', True, 1\n",
+    ")\n",
+    "Map.addLayer(region, {}, 'Export region', True, 0.3)\n",
+    "\n",
+    "Map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "### Export map tiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-13",
+   "metadata": {},
+   "outputs": [],
+   "source": "export_tasks = exportMapTasks(\n    ic, 'gain-loss-v4', gcs_bucket, data_year_range,\n    region, gain_loss_ramp, 0, 12, env='staging', key='change_year'\n)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Total tasks to submit: {len(export_tasks)}')\n",
+    "batchExecute(export_tasks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-15",
+   "metadata": {},
+   "source": [
+    "### Monitor tasks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-16",
+   "metadata": {},
+   "outputs": [],
+   "source": "from collections import Counter\n\nall_ops  = ee.data.listOperations()\nrelevant = [\n    t for t in all_ops\n    if t.get('metadata', {}).get('description', '').startswith('gain-loss-v4_')\n]\n\nstatus_counts = Counter(\n    t.get('metadata', {}).get('state', 'UNKNOWN') for t in relevant\n)\nprint('Task status summary:', dict(status_counts))\n\nfailed = [\n    (t['metadata']['description'], t['metadata'].get('errorMessage', 'no message'))\n    for t in relevant\n    if t.get('metadata', {}).get('state') == 'FAILED'\n]\nif failed:\n    print('\\nFailed tasks:')\n    for name, msg in failed:\n        print(f'  {name}: {msg}')\nelse:\n    print('No failed tasks.')"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

- Adds `create_tiles_gain_loss_v4.ipynb` to export combined gain/loss map tiles from the GMW v4 unified ImageCollection (`mangrove_change_ic_v4`)
- Uses a single two-entry SLD (gain=1 green `#a6cb10`, loss=2 red `#eb6240`) applied to the `classification` band — one tileset per year at all zoom levels (0–12)
- Exports 40 tilesets (1986–2025) to `gs://mangrove_atlas/staging/tilesets/gain-loss-v4/{year}/` via `exportMapTasks` + `batchExecute` from `utils.ipynb`
- Tasks are named `gain-loss-v4_{year}` for easy monitoring

## Differences from v3 (`create_tiles_gain_loss.ipynb`)

| | v3 | v4 |
|---|---|---|
| Source | Two separate ICs (gain-v3, loss-v3) | Single IC (mangrove_change_ic_v4) |
| Tilesets per year | 2 (gain + loss separately) | 1 (combined gain+loss) |
| Years covered | Subset (2007–2020) | All 40 years (1986–2025) |
| Year property key | `end_year` | `change_year` |
| Output path | `staging/tilesets/gain/{year}` + `staging/tilesets/loss/{year}` | `staging/tilesets/gain-loss-v4/{year}` |

## Test plan

- [ ] Run the visualisation cell and confirm gain (green) and loss (red) pixels render correctly on the map
- [ ] Submit tasks for a single year and verify tiles appear at the expected GCS path
- [ ] Check monitor cell reports no FAILED tasks after submission