### PR TITLE
feat: offline maps

### DIFF
--- a/cloud-functions/alerts-tiler/index.js
+++ b/cloud-functions/alerts-tiler/index.js
@@ -110,11 +110,17 @@ const addTileFeature = (tile, row) => {
   // geometry: transformPoint(row.longitude, row.latitude, tile.extent, tile.z, tile.x, tile.y),
   const x = proyectX(row.longitude);
   const y = proyectY(row.latitude);
+  // BigQuery DATE comes back as { value: 'YYYY-MM-DD' }; the frontend styles/filters
+  // alerts by this property, so it MUST travel in the tile (was previously dropped).
+  const obsDate =
+    row.scr5_obs_date && typeof row.scr5_obs_date === 'object'
+      ? row.scr5_obs_date.value
+      : row.scr5_obs_date;
   const tileFeature = {
     id: row.id,
     geometry: [transformPoint(x, y, tile.extent, tile.z, tile.x, tile.y)],
     type: 1,
-    tags: null,
+    tags: { scr5_obs_date: obsDate },
   };
   tile.features.push(tileFeature);
   tile.numPoints++;
@@ -190,6 +196,8 @@ exports.fetchAlertsTiler = (req, res) => {
   res.set('Access-Control-Allow-Origin', '*');
   res.set('mime-type', 'application/vnd.mapbox-vector-tile');
   res.set('Content-Type', 'application/x-protobuf');
+  // Cache so the browser/SW/CDN reuse tiles instead of re-querying BigQuery per request.
+  res.set('Cache-Control', 'public, max-age=86400');
 
   if (req.method === 'OPTIONS') {
     // Send response to OPTIONS requests

--- a/env.mjs
+++ b/env.mjs
@@ -44,6 +44,13 @@ export const env = createEnv({
       .pipe(z.record(z.string(), z.boolean()))
       .default('{}'),
     NEXT_PUBLIC_ENVIRONMENT: z.enum(['development', 'production', 'staging']),
+    // Optional TOS-safe raster XYZ basemap used in offline mode (Mapbox base can't
+    // be cached). When unset, offline mode shows data layers on a neutral backdrop.
+    NEXT_PUBLIC_OFFLINE_BASEMAP_URL: z.string().url().optional(),
+    // Optional self-hosted alerts vector tiler (cloud function). When set, alerts
+    // render from this cacheable {z}/{x}/{y} MVT endpoint instead of the Mapbox
+    // tileset, so they work offline. When unset, falls back to Mapbox.
+    NEXT_PUBLIC_ALERTS_TILER_URL: z.string().url().optional(),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -71,6 +78,8 @@ export const env = createEnv({
     NEXT_PUBLIC_FEATURED_FLAGS: process.env.NEXT_PUBLIC_FEATURED_FLAGS,
     NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,
     NEXT_PUBLIC_ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT,
+    NEXT_PUBLIC_OFFLINE_BASEMAP_URL: process.env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL,
+    NEXT_PUBLIC_ALERTS_TILER_URL: process.env.NEXT_PUBLIC_ALERTS_TILER_URL,
   },
 });
 

--- a/env.mjs
+++ b/env.mjs
@@ -51,6 +51,12 @@ export const env = createEnv({
     // render from this cacheable {z}/{x}/{y} MVT endpoint instead of the Mapbox
     // tileset, so they work offline. When unset, falls back to Mapbox.
     NEXT_PUBLIC_ALERTS_TILER_URL: z.string().url().optional(),
+    // Optional self-hosted habitat-extent vector tiles. A template with {year}
+    // and {z}/{x}/{y}, e.g.
+    // https://mangrove_atlas.storage.googleapis.com/tilesets/gmw_extent/{year}/{z}/{x}/{y}.pbf
+    // When set, extent renders from these cacheable tiles (offline-capable);
+    // otherwise falls back to the Mapbox tilesets. Plain string (URL has braces).
+    NEXT_PUBLIC_EXTENT_TILES_URL: z.string().optional(),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -80,6 +86,7 @@ export const env = createEnv({
     NEXT_PUBLIC_ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT,
     NEXT_PUBLIC_OFFLINE_BASEMAP_URL: process.env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL,
     NEXT_PUBLIC_ALERTS_TILER_URL: process.env.NEXT_PUBLIC_ALERTS_TILER_URL,
+    NEXT_PUBLIC_EXTENT_TILES_URL: process.env.NEXT_PUBLIC_EXTENT_TILES_URL,
   },
 });
 

--- a/env.mjs
+++ b/env.mjs
@@ -57,6 +57,12 @@ export const env = createEnv({
     // When set, extent renders from these cacheable tiles (offline-capable);
     // otherwise falls back to the Mapbox tilesets. Plain string (URL has braces).
     NEXT_PUBLIC_EXTENT_TILES_URL: z.string().optional(),
+    // Optional self-hosted combined gain/loss raster for net change. Template with
+    // {year} and {z}/{x}/{y}, e.g.
+    // https://storage.googleapis.com/mangrove_atlas/staging/tilesets/gain-loss-v4/{year}/{z}/{x}/{y}.png
+    // When set, net change renders from these cacheable tiles (offline-capable);
+    // otherwise falls back to the legacy separate gain/loss tilesets. Plain string.
+    NEXT_PUBLIC_GAIN__LOSS_TILES_URL: z.string().optional(),
   },
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -87,6 +93,7 @@ export const env = createEnv({
     NEXT_PUBLIC_OFFLINE_BASEMAP_URL: process.env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL,
     NEXT_PUBLIC_ALERTS_TILER_URL: process.env.NEXT_PUBLIC_ALERTS_TILER_URL,
     NEXT_PUBLIC_EXTENT_TILES_URL: process.env.NEXT_PUBLIC_EXTENT_TILES_URL,
+    NEXT_PUBLIC_GAIN__LOSS_TILES_URL: process.env.NEXT_PUBLIC_GAIN__LOSS_TILES_URL,
   },
 });
 

--- a/next.config.js
+++ b/next.config.js
@@ -55,10 +55,21 @@ const nextConfig = {
       }
     })();
 
-    if (!mrttOrigin) return [];
-
-    return [
+    const rules = [
+      // Service worker (offline maps): must not be HTTP-cached so updates ship
+      // immediately, and needs root scope to intercept all tile/data requests.
       {
+        source: '/sw.js',
+        headers: [
+          { key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' },
+          { key: 'Service-Worker-Allowed', value: '/' },
+        ],
+      },
+    ];
+
+    if (mrttOrigin) {
+      // Allow MRTT to load the silent-SSO authorize endpoint in an iframe.
+      rules.push({
         source: '/api/auth/sso/authorize',
         headers: [
           {
@@ -66,8 +77,10 @@ const nextConfig = {
             value: `frame-ancestors 'self' ${mrttOrigin};`,
           },
         ],
-      },
-    ];
+      });
+    }
+
+    return rules;
   },
   turbopack: {
     rules: {

--- a/next.config.js
+++ b/next.config.js
@@ -6,12 +6,24 @@ const withMDX = require('@next/mdx')({
   },
 });
 
+// Per-build identifier. On Vercel the commit SHA is stable across all instances
+// of a deploy; locally it changes every `next build`. It stamps both the Next
+// build id and the service-worker registration URL (?v=) so the SW re-installs
+// and purges its volatile caches on every deploy — otherwise a fixed-named cache
+// would serve last build's HTML/chunks forever (stale-build 500s).
+const SW_VERSION = process.env.VERCEL_GIT_COMMIT_SHA || `local-${Date.now()}`;
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   productionBrowserSourceMaps: false,
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
   output: 'standalone',
   poweredByHeader: false,
+  generateBuildId: async () => SW_VERSION,
+  env: {
+    // Inlined into the client bundle so register-sw can version the SW per build.
+    NEXT_PUBLIC_SW_VERSION: SW_VERSION,
+  },
 
   images: {
     remotePatterns: [

--- a/public/sw.js
+++ b/public/sw.js
@@ -40,8 +40,7 @@ const TILER_ORIGIN = originOf(params.get('tiler'));
 
 const isGCSTile = (url) =>
   /(^|\.)storage\.googleapis\.com$/.test(url.hostname) &&
-  url.pathname.includes('mangrove') &&
-  /\/\d+\/\d+\/\d+(\.\w+)?$/.test(url.pathname);
+  /\/\d+\/\d+\/\d+(\.\w+)?$/.test(url.pathname); // .../{z}/{x}/{y}[.ext]
 
 const isOfflineBaseTile = (url) => BASE_ORIGIN && url.origin === BASE_ORIGIN;
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -8,7 +8,19 @@
 // Hand-rolled on the native Cache Storage API — no Workbox / next-pwa (not on the
 // Vizzuality Tech Radar). Mapbox tiles/styles are NEVER cached (TOS).
 
-const VERSION = 'v1';
+const params = (() => {
+  try {
+    return new URL(self.location).searchParams;
+  } catch {
+    return new URLSearchParams();
+  }
+})();
+
+// Per-build stamp injected at registration (?v=<commit-sha|local-ts>). Volatile
+// cache names are suffixed with it so a new build = new cache names = the
+// activate step purges the previous build's HTML/chunks/tiles (no stale-build
+// 500s). Falls back to 'v1' when unset (e.g. SW served without the query).
+const VERSION = params.get('v') || 'v1';
 const TILE_CACHE = `mangrove-tiles-${VERSION}`; // transparent, volatile
 const DATA_CACHE = `mangrove-data-${VERSION}`; // transparent, volatile
 const STATIC_CACHE = `mangrove-static-${VERSION}`; // app shell, volatile
@@ -19,13 +31,6 @@ const MAX_TILES = 1500;
 const MAX_DATA = 300;
 const TILE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
-const params = (() => {
-  try {
-    return new URL(self.location).searchParams;
-  } catch {
-    return new URLSearchParams();
-  }
-})();
 const originOf = (raw) => {
   try {
     return raw ? new URL(raw).origin : null;

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,259 @@
+/* eslint-disable */
+// Mangrove Atlas — offline-maps service worker.
+//
+// Two jobs:
+//   1) Transparent runtime cache (faster revisits + accidental-offline resilience).
+//   2) Backing store for deliberate "download this area / work offline" downloads.
+//
+// Hand-rolled on the native Cache Storage API — no Workbox / next-pwa (not on the
+// Vizzuality Tech Radar). Mapbox tiles/styles are NEVER cached (TOS).
+
+const VERSION = 'v1';
+const TILE_CACHE = `mangrove-tiles-${VERSION}`; // transparent, volatile
+const DATA_CACHE = `mangrove-data-${VERSION}`; // transparent, volatile
+const STATIC_CACHE = `mangrove-static-${VERSION}`; // app shell, volatile
+const OFFLINE_CACHE = `mangrove-offline`; // deliberate downloads — PERSISTENT, never auto-purged
+const VOLATILE_CACHES = [TILE_CACHE, DATA_CACHE, STATIC_CACHE];
+
+const MAX_TILES = 1500;
+const MAX_DATA = 300;
+const TILE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+const params = (() => {
+  try {
+    return new URL(self.location).searchParams;
+  } catch {
+    return new URLSearchParams();
+  }
+})();
+const originOf = (raw) => {
+  try {
+    return raw ? new URL(raw).origin : null;
+  } catch {
+    return null;
+  }
+};
+// Injected at registration: /sw.js?api=<origin>&base=<offline-basemap-origin>&tiler=<alerts-tiler-origin>.
+const API_ORIGIN = originOf(params.get('api'));
+const BASE_ORIGIN = originOf(params.get('base'));
+const TILER_ORIGIN = originOf(params.get('tiler'));
+
+const isGCSTile = (url) =>
+  /(^|\.)storage\.googleapis\.com$/.test(url.hostname) &&
+  url.pathname.includes('mangrove') &&
+  /\/\d+\/\d+\/\d+(\.\w+)?$/.test(url.pathname);
+
+const isOfflineBaseTile = (url) => BASE_ORIGIN && url.origin === BASE_ORIGIN;
+
+// Self-hosted alerts tiler (cloud function). Tiles are keyed by z/x/y + date in
+// the query string, so cache by full URL (CacheFirst handles that).
+const isTilerTile = (url) => TILER_ORIGIN && url.origin === TILER_ORIGIN;
+
+const isApiData = (url) =>
+  API_ORIGIN &&
+  url.origin === API_ORIGIN &&
+  !/\/auth(\/|$)|\/login|\/token|\/oauth/i.test(url.pathname);
+
+const isStaticAsset = (url) =>
+  url.origin === self.location.origin &&
+  (url.pathname.startsWith('/_next/static/') ||
+    /\.(?:js|css|woff2?|ttf|otf|svg|png|webp)$/.test(url.pathname));
+
+// ---- cache helpers ---------------------------------------------------------
+
+async function trimCache(cacheName, maxEntries) {
+  const cache = await caches.open(cacheName);
+  const keys = await cache.keys();
+  if (keys.length <= maxEntries) return;
+  for (const key of keys.slice(0, keys.length - maxEntries)) await cache.delete(key);
+}
+
+function isExpired(response, maxAgeMs) {
+  const dateHeader = response.headers.get('date');
+  const cachedAt = dateHeader && !Number.isNaN(Date.parse(dateHeader)) ? Date.parse(dateHeader) : 0;
+  return cachedAt > 0 && Date.now() - cachedAt > maxAgeMs;
+}
+
+// Serve from a deliberate download first, then fall through to a strategy.
+async function offlineFirst(request) {
+  const cache = await caches.open(OFFLINE_CACHE);
+  return cache.match(request);
+}
+
+async function cacheFirst(request, cacheName, { maxEntries, maxAgeMs } = {}) {
+  const downloaded = await offlineFirst(request);
+  if (downloaded) return downloaded;
+
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached && !(maxAgeMs && isExpired(cached, maxAgeMs))) return cached;
+  try {
+    const response = await fetch(request);
+    if (response && (response.ok || response.type === 'opaque')) {
+      await cache.put(request, response.clone());
+      if (maxEntries) trimCache(cacheName, maxEntries);
+    }
+    return response;
+  } catch (err) {
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+async function staleWhileRevalidate(request, cacheName, { maxEntries } = {}) {
+  const downloaded = await offlineFirst(request);
+  const cache = await caches.open(cacheName);
+  const cached = downloaded || (await cache.match(request));
+  const network = fetch(request)
+    .then((response) => {
+      if (response && response.ok) {
+        cache.put(request, response.clone()).then(() => {
+          if (maxEntries) trimCache(cacheName, maxEntries);
+        });
+      }
+      return response;
+    })
+    .catch(() => null);
+  return cached || network || fetch(request);
+}
+
+// Document/navigation: network first, fall back to any cached copy so the app
+// boots with no connection (app shell).
+async function networkFirstDoc(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) cache.put(request, response.clone());
+    return response;
+  } catch (err) {
+    const cached = (await offlineFirst(request)) || (await cache.match(request));
+    if (cached) return cached;
+    // Last resort: the app root, so the SPA can render an offline state.
+    const root = (await offlineFirst('/')) || (await cache.match('/'));
+    if (root) return root;
+    throw err;
+  }
+}
+
+// ---- deliberate download (message channel) ---------------------------------
+
+async function cacheUrls(urls, onProgress) {
+  const cache = await caches.open(OFFLINE_CACHE);
+  let done = 0;
+  let failed = 0;
+  const CONCURRENCY = 6;
+  const queue = [...urls];
+
+  async function worker() {
+    while (queue.length) {
+      const url = queue.shift();
+      try {
+        const res = await fetch(url, { mode: 'cors' });
+        if (res && (res.ok || res.type === 'opaque')) await cache.put(url, res.clone());
+        else failed++;
+      } catch {
+        failed++;
+      }
+      done++;
+      if (done % 10 === 0 || queue.length === 0) onProgress(done, failed);
+    }
+  }
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+  return { done, failed };
+}
+
+self.addEventListener('message', (event) => {
+  const data = event.data || {};
+  if (data.type === 'CACHE_URLS') {
+    const { urls = [], regionId, total } = data;
+    const client = event.source;
+    event.waitUntil(
+      cacheUrls(urls, (done, failed) => {
+        client &&
+          client.postMessage({ type: 'CACHE_PROGRESS', regionId, done, failed, total: total ?? urls.length });
+      }).then((r) => {
+        client && client.postMessage({ type: 'CACHE_DONE', regionId, ...r });
+      })
+    );
+  } else if (data.type === 'PERSIST_DATA_CACHE') {
+    // Copy whatever widget JSON is already in the volatile data cache into the
+    // persistent offline cache, so the sidebar works offline for this location.
+    const client = event.source;
+    event.waitUntil(
+      (async () => {
+        const [src, dst] = await Promise.all([
+          caches.open(DATA_CACHE),
+          caches.open(OFFLINE_CACHE),
+        ]);
+        const keys = await src.keys();
+        await Promise.all(
+          keys.map(async (req) => {
+            const res = await src.match(req);
+            if (res) await dst.put(req, res.clone());
+          })
+        );
+        client && client.postMessage({ type: 'DATA_PERSISTED', count: keys.length });
+      })()
+    );
+  } else if (data.type === 'DELETE_REGION_URLS') {
+    const { urls = [] } = data;
+    event.waitUntil(
+      caches.open(OFFLINE_CACHE).then((cache) => Promise.all(urls.map((u) => cache.delete(u))))
+    );
+  } else if (data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});
+
+// ---- lifecycle -------------------------------------------------------------
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const names = await caches.keys();
+      // Purge stale volatile caches only. OFFLINE_CACHE (deliberate downloads) survives.
+      await Promise.all(
+        names
+          .filter((n) => n.startsWith('mangrove-') && n !== OFFLINE_CACHE && !VOLATILE_CACHES.includes(n))
+          .map((n) => caches.delete(n))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return; // analysis POST etc. → passthrough
+
+  let url;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirstDoc(request));
+    return;
+  }
+  if (isGCSTile(url) || isOfflineBaseTile(url) || isTilerTile(url)) {
+    event.respondWith(
+      cacheFirst(request, TILE_CACHE, { maxEntries: MAX_TILES, maxAgeMs: TILE_MAX_AGE_MS })
+    );
+    return;
+  }
+  if (isApiData(url)) {
+    event.respondWith(staleWhileRevalidate(request, DATA_CACHE, { maxEntries: MAX_DATA }));
+    return;
+  }
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE));
+    return;
+  }
+  // Mapbox / Planet / everything-else: passthrough (no caching).
+});

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { MapProvider } from 'react-map-gl';
+
+import { registerServiceWorker } from '@/lib/offline/register-sw';
+
+import { useSyncOnlineStatus } from '@/store/offline';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SessionProvider } from 'next-auth/react';
@@ -27,6 +31,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
         },
       })
   );
+
+  useEffect(() => {
+    registerServiceWorker();
+  }, []);
+
+  useSyncOnlineStatus();
 
   return (
     <NuqsAdapter>

--- a/src/components/map/controls/offline-download/index.tsx
+++ b/src/components/map/controls/offline-download/index.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { useMap } from 'react-map-gl';
+
+import cn from '@/lib/classnames';
+import { useOfflineDownload } from '@/lib/offline/download';
+import type { BBox } from '@/lib/offline/tiles';
+
+import { drawingToolAtom } from '@/store/drawing-tool';
+import { tmpCameraAtom } from '@/store/map';
+import { downloadProgressAtom, offlineModeAtom } from '@/store/offline';
+
+import turfBbox from '@turf/bbox';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+
+import { Button } from '@/components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+const MIN_Z = 0;
+const MAX_Z = 12; // native pyramid depth; higher zooms scale from these (overzoom)
+
+type Props = { mapId: string };
+
+const OfflineDownload = ({ mapId }: Props) => {
+  const { [mapId]: map } = useMap();
+  const { regions, download, removeRegion, estimateTiles } = useOfflineDownload(mapId);
+  const progress = useAtomValue(downloadProgressAtom);
+  const [offlineMode, setOfflineMode] = useAtom(offlineModeAtom);
+  const setTmpCamera = useSetAtom(tmpCameraAtom);
+  const { customGeojson, uploadedGeojson } = useAtomValue(drawingToolAtom);
+
+  const drawn = customGeojson || uploadedGeojson;
+  const [source, setSource] = useState<'view' | 'drawn'>('view');
+  const [minZoom, setMinZoom] = useState(0);
+  const [maxZoom, setMaxZoom] = useState(MAX_Z);
+  const [name, setName] = useState('');
+
+  const getBBox = useCallback((): BBox | null => {
+    if (source === 'drawn' && drawn) {
+      const [w, s, e, n] = turfBbox(drawn as GeoJSON.FeatureCollection);
+      return [w, s, e, n];
+    }
+    const b = map?.getMap?.()?.getBounds?.()?.toArray?.(); // [[w,s],[e,n]]
+    if (!b) return null;
+    return [b[0][0], b[0][1], b[1][0], b[1][1]];
+  }, [source, drawn, map]);
+
+  const estimate = useMemo(() => {
+    const bbox = getBBox();
+    if (!bbox) return null;
+    return estimateTiles(bbox, minZoom, maxZoom);
+    // re-run when inputs change
+  }, [getBBox, estimateTiles, minZoom, maxZoom]);
+
+  const isRunning = progress.status === 'running';
+
+  const handleDownload = useCallback(() => {
+    const bbox = getBBox();
+    if (!bbox) return;
+    void download({
+      name: name.trim() || `Offline area (${regions.length + 1})`,
+      bbox,
+      minZoom: Math.min(minZoom, maxZoom),
+      maxZoom: Math.max(minZoom, maxZoom),
+    });
+    setName('');
+  }, [getBBox, download, name, regions.length, minZoom, maxZoom]);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Offline maps"
+          className={cn(
+            'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white hover:bg-gray-100',
+            offlineMode && 'bg-brand-800'
+          )}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            className={cn(
+              'h-5 w-5 fill-none stroke-current',
+              offlineMode ? 'text-white' : 'text-black/85'
+            )}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M12 3v12m0 0 4-4m-4 4-4-4" />
+            <path d="M5 21h14" />
+          </svg>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" side="left" className="notranslate w-80">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold">Offline maps</h3>
+          <Button
+            type="button"
+            variant={offlineMode ? 'default' : 'outline'}
+            size="sm"
+            className="h-7 text-xs"
+            onClick={() => setOfflineMode((v) => !v)}
+          >
+            {offlineMode ? 'Working offline' : 'Work offline'}
+          </Button>
+        </div>
+
+        <fieldset className="space-y-1">
+          <legend className="text-xs font-medium text-black/60">Area to download</legend>
+          <label className="flex items-center gap-2 text-xs">
+            <input
+              type="radio"
+              name="offline-source"
+              checked={source === 'view'}
+              onChange={() => setSource('view')}
+            />
+            Current map view
+          </label>
+          <label className={cn('flex items-center gap-2 text-xs', !drawn && 'opacity-40')}>
+            <input
+              type="radio"
+              name="offline-source"
+              checked={source === 'drawn'}
+              disabled={!drawn}
+              onChange={() => setSource('drawn')}
+            />
+            Drawn / uploaded area
+          </label>
+        </fieldset>
+
+        <div className="flex items-center gap-3 text-xs">
+          <label className="flex flex-1 flex-col gap-1">
+            Min zoom
+            <input
+              type="number"
+              min={MIN_Z}
+              max={MAX_Z}
+              value={minZoom}
+              onChange={(e) => setMinZoom(Number(e.target.value))}
+              className="rounded border border-black/15 px-2 py-1"
+            />
+          </label>
+          <label className="flex flex-1 flex-col gap-1">
+            Max zoom
+            <input
+              type="number"
+              min={MIN_Z}
+              max={MAX_Z}
+              value={maxZoom}
+              onChange={(e) => setMaxZoom(Number(e.target.value))}
+              className="rounded border border-black/15 px-2 py-1"
+            />
+          </label>
+        </div>
+
+        <input
+          type="text"
+          placeholder="Name (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full rounded border border-black/15 px-2 py-1 text-xs"
+        />
+
+        {estimate && (
+          <p className="text-xs text-black/60">
+            ~{estimate.tiles.toLocaleString()} tiles across {estimate.templates || 1} layer(s).
+            Higher zooms scale from these automatically.
+          </p>
+        )}
+
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          className="w-full"
+          disabled={isRunning || !estimate}
+          onClick={handleDownload}
+        >
+          {isRunning ? `Downloading… ${progress.done}/${progress.total}` : 'Download area'}
+        </Button>
+
+        {isRunning && (
+          <div className="h-1.5 w-full overflow-hidden rounded bg-black/10">
+            <div
+              className="bg-brand-800 h-full transition-all"
+              style={{ width: `${progress.total ? (progress.done / progress.total) * 100 : 0}%` }}
+            />
+          </div>
+        )}
+        {progress.status === 'done' && progress.failed > 0 && (
+          <p className="text-xs text-amber-600">
+            {progress.failed} tile(s) failed (likely uncached layers).
+          </p>
+        )}
+
+        {regions.length > 0 && (
+          <div className="space-y-1 border-t border-black/10 pt-2">
+            <p className="text-xs font-medium text-black/60">Downloaded areas</p>
+            <ul className="space-y-1">
+              {regions.map((r) => (
+                <li key={r.id} className="flex items-center justify-between gap-2 text-xs">
+                  <button
+                    type="button"
+                    className="truncate text-left hover:underline"
+                    title={`Zooms ${r.minZoom}–${r.maxZoom}`}
+                    onClick={() => setTmpCamera({ bbox: r.bbox })}
+                  >
+                    {r.name}
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Delete ${r.name}`}
+                    className="text-black/40 hover:text-red-600"
+                    onClick={() => void removeRegion(r.id)}
+                  >
+                    ✕
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default OfflineDownload;

--- a/src/components/map/controls/offline-download/index.tsx
+++ b/src/components/map/controls/offline-download/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useMap } from 'react-map-gl';
 
@@ -18,6 +18,9 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 const MIN_Z = 0;
 const MAX_Z = 12; // native pyramid depth; higher zooms scale from these (overzoom)
+// Below this view zoom the bbox is basically continental/global — downloading it
+// would blow the tile cap and only save a coarse prefix. Block it.
+const MIN_DOWNLOAD_ZOOM = 4;
 
 type Props = { mapId: string };
 
@@ -34,6 +37,23 @@ const OfflineDownload = ({ mapId }: Props) => {
   const [minZoom, setMinZoom] = useState(0);
   const [maxZoom, setMaxZoom] = useState(MAX_Z);
   const [name, setName] = useState('');
+  const [viewZoom, setViewZoom] = useState<number | null>(null);
+
+  // Track the live view zoom so we can block downloading at world/continental scale.
+  useEffect(() => {
+    const rawMap = map?.getMap?.() as
+      | {
+          getZoom?: () => number;
+          on?: (e: string, cb: () => void) => void;
+          off?: (e: string, cb: () => void) => void;
+        }
+      | undefined;
+    if (!rawMap?.on || !rawMap.getZoom) return;
+    const update = () => setViewZoom(rawMap.getZoom?.() ?? null);
+    update();
+    rawMap.on('moveend', update);
+    return () => rawMap.off?.('moveend', update);
+  }, [map]);
 
   const getBBox = useCallback((): BBox | null => {
     if (source === 'drawn' && drawn) {
@@ -53,6 +73,11 @@ const OfflineDownload = ({ mapId }: Props) => {
   }, [getBBox, estimateTiles, minZoom, maxZoom]);
 
   const isRunning = progress.status === 'running';
+  // Block / warn conditions.
+  const tooLowZoom = source === 'view' && viewZoom != null && viewZoom < MIN_DOWNLOAD_ZOOM;
+  const noLayers = !!estimate && estimate.templates === 0;
+  const capped = !!estimate?.capped;
+  const canDownload = !!estimate && !isRunning && !tooLowZoom && !noLayers;
 
   const handleDownload = useCallback(() => {
     const bbox = getBBox();
@@ -163,10 +188,28 @@ const OfflineDownload = ({ mapId }: Props) => {
           className="w-full rounded border border-black/15 px-2 py-1 text-xs"
         />
 
-        {estimate && (
+        {estimate && !tooLowZoom && !noLayers && (
           <p className="text-xs text-black/60">
             ~{estimate.tiles.toLocaleString()} tiles across {estimate.templates || 1} layer(s).
             Higher zooms scale from these automatically.
+          </p>
+        )}
+
+        {tooLowZoom && (
+          <p className="text-xs text-amber-600">
+            Zoom in to download — the current view is too large to save. Frame a specific area
+            first.
+          </p>
+        )}
+        {noLayers && (
+          <p className="text-xs text-amber-600">
+            No offline-ready layers in view. Turn on a layer (or enable Work offline) first.
+          </p>
+        )}
+        {!tooLowZoom && !noLayers && capped && (
+          <p className="text-xs text-amber-600">
+            Area too large — only part will be saved. Zoom in or pick a smaller area for full
+            coverage.
           </p>
         )}
 
@@ -175,7 +218,7 @@ const OfflineDownload = ({ mapId }: Props) => {
           variant="default"
           size="sm"
           className="w-full"
-          disabled={isRunning || !estimate}
+          disabled={!canDownload}
           onClick={handleDownload}
         >
           {isRunning ? `Downloading… ${progress.done}/${progress.total}` : 'Download area'}

--- a/src/components/map/controls/offline-download/index.tsx
+++ b/src/components/map/controls/offline-download/index.tsx
@@ -18,9 +18,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 
 const MIN_Z = 0;
 const MAX_Z = 12; // native pyramid depth; higher zooms scale from these (overzoom)
-// Below this view zoom the bbox is basically continental/global — downloading it
-// would blow the tile cap and only save a coarse prefix. Block it.
-const MIN_DOWNLOAD_ZOOM = 4;
+// Below this view zoom the bbox is world/continental (the worldwide default is z2)
+// — downloading it would blow the tile cap and only save a coarse prefix. Block it.
+// Country/region views (z3+) are allowed; the tile-cap warning covers large areas.
+const MIN_DOWNLOAD_ZOOM = 3;
 
 type Props = { mapId: string };
 

--- a/src/components/map/controls/offline-download/index.tsx
+++ b/src/components/map/controls/offline-download/index.tsx
@@ -4,11 +4,12 @@ import { useMap } from 'react-map-gl';
 
 import cn from '@/lib/classnames';
 import { useOfflineDownload } from '@/lib/offline/download';
+import { formatBytes } from '@/lib/offline/storage';
 import type { BBox } from '@/lib/offline/tiles';
 
 import { drawingToolAtom } from '@/store/drawing-tool';
 import { tmpCameraAtom } from '@/store/map';
-import { downloadProgressAtom, offlineModeAtom } from '@/store/offline';
+import { downloadProgressAtom, offlineModeAtom, storageStatusAtom } from '@/store/offline';
 
 import turfBbox from '@turf/bbox';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
@@ -29,6 +30,7 @@ const OfflineDownload = ({ mapId }: Props) => {
   const { [mapId]: map } = useMap();
   const { regions, download, removeRegion, estimateTiles } = useOfflineDownload(mapId);
   const progress = useAtomValue(downloadProgressAtom);
+  const storage = useAtomValue(storageStatusAtom);
   const [offlineMode, setOfflineMode] = useAtom(offlineModeAtom);
   const setTmpCamera = useSetAtom(tmpCameraAtom);
   const { customGeojson, uploadedGeojson } = useAtomValue(drawingToolAtom);
@@ -264,6 +266,22 @@ const OfflineDownload = ({ mapId }: Props) => {
                 </li>
               ))}
             </ul>
+          </div>
+        )}
+
+        {(storage.quota > 0 || (regions.length > 0 && storage.persisted === false)) && (
+          <div className="space-y-1 border-t border-black/10 pt-2">
+            {storage.quota > 0 && (
+              <p className="text-xs text-black/60">
+                Storage: {formatBytes(storage.usage)} of {formatBytes(storage.quota)} used
+              </p>
+            )}
+            {regions.length > 0 && storage.persisted === false && (
+              <p className="text-xs text-amber-600">
+                Downloads may be cleared by the browser when space runs low or the site is unused
+                for a while. Add this site to your home screen to keep them.
+              </p>
+            )}
           </div>
         )}
       </PopoverContent>

--- a/src/components/map/controls/offline-indicator/index.tsx
+++ b/src/components/map/controls/offline-indicator/index.tsx
@@ -1,0 +1,38 @@
+import cn from '@/lib/classnames';
+
+import { isOnlineAtom } from '@/store/offline';
+
+import { useAtomValue } from 'jotai';
+
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+/**
+ * Shows a small badge while the browser is offline, signalling that the map is
+ * running from cached tiles/data. Renders nothing when online.
+ */
+const OfflineIndicator = () => {
+  const isOnline = useAtomValue(isOnlineAtom);
+
+  if (isOnline) return null;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          role="status"
+          aria-label="Offline — showing cached map data"
+          className={cn(
+            'shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-amber-500'
+          )}
+        >
+          <span className="h-3 w-3 animate-pulse rounded-full bg-white" aria-hidden />
+        </div>
+      </TooltipTrigger>
+      <TooltipContent className="bg-gray-600 px-2 text-white">
+        Offline — showing cached map data
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default OfflineIndicator;

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -29,6 +29,8 @@ import { Visibility } from '@/types/layers';
 
 import API_cloud_functions from 'services/cloud-functions';
 
+import { env } from '../../../../env.mjs';
+
 import { MONTHS, MONTHS_CONVERSION } from './constants';
 import Tooltip from './tooltip';
 import type { AlertData, CustomAreaGeometry, UseParamsOptions } from './types';
@@ -445,9 +447,32 @@ export function useAlerts<TRaw = AlertsApiResponse>(
 }
 
 // dataset layer
+// When the self-hosted tiler is configured, alerts render from its cacheable
+// {z}/{x}/{y} MVT (so they work offline); otherwise fall back to the Mapbox
+// tileset. The tiler serializes its layer as `geojsonLayer` (see
+// cloud-functions/alerts-tiler) and only serves z9-14.
+const ALERTS_TILER_URL = env.NEXT_PUBLIC_ALERTS_TILER_URL;
+export const ALERTS_SOURCE_ID = ALERTS_TILER_URL ? 'alerts-tiler' : 'alerts-heatmap-vector';
+export const ALERTS_SOURCE_LAYER = ALERTS_TILER_URL ? 'geojsonLayer' : 'alerts';
+
 export function useSource(): SourceProps {
+  const startDate = useAtomValue(alertsStartDate) as { value?: string } | null;
+  const endDate = useAtomValue(alertsEndDate) as { value?: string } | null;
+
+  if (ALERTS_TILER_URL) {
+    const start = startDate?.value ?? '2019-01-01';
+    const end = endDate?.value ?? new Date().toISOString().split('T')[0];
+    return {
+      id: ALERTS_SOURCE_ID,
+      type: 'vector',
+      tiles: [`${ALERTS_TILER_URL}?z={z}&x={x}&y={y}&start_date=${start}&end_date=${end}`],
+      minzoom: 9,
+      maxzoom: 14,
+    };
+  }
+
   return {
-    id: 'alerts-heatmap-vector',
+    id: ALERTS_SOURCE_ID,
     type: 'vector',
     url: 'mapbox://globalmangrovewatch.0vowa2i9',
   };
@@ -471,8 +496,8 @@ export function useLayers({
 
   const layerProps: Omit<CircleLayerSpecification, 'id' | 'filter' | 'paint'> = {
     type: 'circle',
-    source: 'alerts-heatmap-vector',
-    'source-layer': 'alerts',
+    source: ALERTS_SOURCE_ID,
+    'source-layer': ALERTS_SOURCE_LAYER,
     minzoom: 0,
     maxzoom: 18,
     layout: { visibility },

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -29,8 +29,6 @@ import { Visibility } from '@/types/layers';
 
 import API_cloud_functions from 'services/cloud-functions';
 
-import { env } from '../../../../env.mjs';
-
 import { MONTHS, MONTHS_CONVERSION } from './constants';
 import Tooltip from './tooltip';
 import type { AlertData, CustomAreaGeometry, UseParamsOptions } from './types';
@@ -446,31 +444,12 @@ export function useAlerts<TRaw = AlertsApiResponse>(
   return query;
 }
 
-// dataset layer
-// When the self-hosted tiler is configured, alerts render from its cacheable
-// {z}/{x}/{y} MVT (so they work offline); otherwise fall back to the Mapbox
-// tileset. The tiler serializes its layer as `geojsonLayer` (see
-// cloud-functions/alerts-tiler) and only serves z9-14.
-const ALERTS_TILER_URL = env.NEXT_PUBLIC_ALERTS_TILER_URL;
-export const ALERTS_SOURCE_ID = ALERTS_TILER_URL ? 'alerts-tiler' : 'alerts-heatmap-vector';
-export const ALERTS_SOURCE_LAYER = ALERTS_TILER_URL ? 'geojsonLayer' : 'alerts';
+// dataset layer — ONLINE source (interactive Mapbox vector). Offline swaps to a
+// self-hosted raster in layer.tsx (Mapbox tiles can't be cached, TOS).
+export const ALERTS_SOURCE_ID = 'alerts-heatmap-vector';
+export const ALERTS_SOURCE_LAYER = 'alerts';
 
 export function useSource(): SourceProps {
-  const startDate = useAtomValue(alertsStartDate) as { value?: string } | null;
-  const endDate = useAtomValue(alertsEndDate) as { value?: string } | null;
-
-  if (ALERTS_TILER_URL) {
-    const start = startDate?.value ?? '2019-01-01';
-    const end = endDate?.value ?? new Date().toISOString().split('T')[0];
-    return {
-      id: ALERTS_SOURCE_ID,
-      type: 'vector',
-      tiles: [`${ALERTS_TILER_URL}?z={z}&x={x}&y={y}&start_date=${start}&end_date=${end}`],
-      minzoom: 9,
-      maxzoom: 14,
-    };
-  }
-
   return {
     id: ALERTS_SOURCE_ID,
     type: 'vector',

--- a/src/containers/datasets/alerts/layer.tsx
+++ b/src/containers/datasets/alerts/layer.tsx
@@ -3,14 +3,20 @@ import { useEffect } from 'react';
 import { Source, Layer } from 'react-map-gl';
 
 import { useSyncActiveLayers } from '@/store/layers';
+import { isOfflineAtom } from '@/store/offline';
+
+import { useAtomValue } from 'jotai';
 
 import type { LayerProps } from 'types/layers';
+
+import { env } from '../../../../env.mjs';
 
 import { useLayers, useSource } from './hooks';
 
 const MangrovesAlertsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
+  const isOffline = useAtomValue(isOfflineAtom);
 
   const source = useSource();
   const LAYERS = useLayers({
@@ -25,6 +31,34 @@ const MangrovesAlertsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => 
     return () => onRemove(ids);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onAdd, onRemove]);
+
+  // OFFLINE: self-hosted raster {z}/{x}/{y} from GCS (cacheable, TOS-safe) instead
+  // of the Mapbox vector tileset. Raster = no per-point interactivity, accepted offline.
+  if (isOffline && env.NEXT_PUBLIC_ALERTS_TILER_URL) {
+    const tiles = env.NEXT_PUBLIC_ALERTS_TILER_URL.replace(
+      /\{year\}/g,
+      String(new Date().getFullYear())
+    );
+    return (
+      <Source
+        id="alerts-raster"
+        type="raster"
+        tiles={[tiles]}
+        tileSize={256}
+        minzoom={0}
+        maxzoom={12}
+      >
+        <Layer
+          id={`${id}-raster`}
+          type="raster"
+          source="alerts-raster"
+          paint={{ 'raster-opacity': parseFloat(activeLayer.opacity) }}
+          layout={{ visibility: activeLayer.visibility }}
+          beforeId={beforeId}
+        />
+      </Source>
+    );
+  }
 
   if (!source || !LAYERS) return null;
 

--- a/src/containers/datasets/alerts/layer.tsx
+++ b/src/containers/datasets/alerts/layer.tsx
@@ -35,10 +35,11 @@ const MangrovesAlertsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => 
   // OFFLINE: self-hosted raster {z}/{x}/{y} from GCS (cacheable, TOS-safe) instead
   // of the Mapbox vector tileset. Raster = no per-point interactivity, accepted offline.
   if (isOffline && env.NEXT_PUBLIC_ALERTS_TILER_URL) {
-    const tiles = env.NEXT_PUBLIC_ALERTS_TILER_URL.replace(
-      /\{year\}/g,
-      String(new Date().getFullYear())
-    );
+    // The gain-loss tileset only publishes *completed* years — the in-progress
+    // calendar year has no tiles yet (requesting it 404s → blank layer). Use the
+    // last completed year so offline alerts render year-round.
+    const latestTilesetYear = new Date().getFullYear() - 1;
+    const tiles = env.NEXT_PUBLIC_ALERTS_TILER_URL.replace(/\{year\}/g, String(latestTilesetYear));
     return (
       <Source
         id="alerts-raster"

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -20,6 +20,8 @@ import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
 
+import { env } from '../../../../env.mjs';
+
 import { getHabitatExtentData } from './get-data';
 import type { DataResponse, ExtentData } from './types';
 
@@ -112,6 +114,19 @@ export function useMangroveHabitatExtent(
 }
 
 export function useSource({ year }: { year: number }): SourceProps {
+  // Self-hosted vector tiles when configured (cacheable → offline-capable),
+  // else the Mapbox tilesets. Both expose `source-layer` gmw_v4_extent_<year>
+  // with the same properties, so layer.tsx is unchanged either way.
+  if (env.NEXT_PUBLIC_EXTENT_TILES_URL) {
+    const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(year));
+    return {
+      id: `habitat_extent_${year}`,
+      type: 'vector',
+      tiles: [tiles],
+      minzoom: 0,
+      maxzoom: 12,
+    };
+  }
   return {
     id: `habitat_extent_${year}`,
     type: 'vector',

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -118,6 +118,8 @@ export function useSource({ year }: { year: number }): SourceProps {
   // else the Mapbox tilesets. Both expose `source-layer` gmw_v4_extent_<year>
   // with the same properties, so layer.tsx is unchanged either way.
   if (env.NEXT_PUBLIC_EXTENT_TILES_URL) {
+    // Self-hosted {z}/{x}/{y}.pbf on GCS (cacheable → offline-capable). mapbox-gl
+    // has no addProtocol, so .pmtiles must be exploded to {z}/{x}/{y} first.
     const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(year));
     return {
       id: `habitat_extent_${year}`,

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -20,8 +20,6 @@ import type { UseParamsOptions } from 'types/widget';
 
 import API, { AnalysisAPI } from 'services/api';
 
-import { env } from '../../../../env.mjs';
-
 import { getHabitatExtentData } from './get-data';
 import type { DataResponse, ExtentData } from './types';
 
@@ -113,22 +111,9 @@ export function useMangroveHabitatExtent(
   }, [data, isFetching, isError, refetch, DATA]);
 }
 
+// NOTE: the habitat-extent layer defines its sources inline in layer.tsx, not
+// via this hook. Kept for parity with other datasets / potential reuse.
 export function useSource({ year }: { year: number }): SourceProps {
-  // Self-hosted vector tiles when configured (cacheable → offline-capable),
-  // else the Mapbox tilesets. Both expose `source-layer` gmw_v4_extent_<year>
-  // with the same properties, so layer.tsx is unchanged either way.
-  if (env.NEXT_PUBLIC_EXTENT_TILES_URL) {
-    // Self-hosted {z}/{x}/{y}.pbf on GCS (cacheable → offline-capable). mapbox-gl
-    // has no addProtocol, so .pmtiles must be exploded to {z}/{x}/{y} first.
-    const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(year));
-    return {
-      id: `habitat_extent_${year}`,
-      type: 'vector',
-      tiles: [tiles],
-      minzoom: 0,
-      maxzoom: 12,
-    };
-  }
   return {
     id: `habitat_extent_${year}`,
     type: 'vector',

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Source, Layer } from 'react-map-gl';
 
 import { useSyncActiveLayers } from '@/store/layers';
+import { isOfflineAtom } from '@/store/offline';
 import { habitatExtentSettings } from '@/store/widgets/habitat-extent';
 
 import { useAtomValue } from 'jotai';
@@ -43,6 +44,7 @@ const usePrefersReducedMotion = () => {
 const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
+  const isOffline = useAtomValue(isOfflineAtom);
   const year = useAtomValue(habitatExtentSettings) as number | null;
   const { data } = useMangroveHabitatExtent({ year });
   const years = useMemo(
@@ -59,10 +61,10 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
 
   if (!years.length || !currentYear) return null;
 
-  // Self-hosted raster {z}/{x}/{y}.png on GCS when configured — cacheable, so
-  // extent works offline. Renders as a raster image (no vector interactivity).
-  // Takes precedence over the Mapbox vector paths below, regardless of flags.
-  if (env.NEXT_PUBLIC_EXTENT_TILES_URL) {
+  // OFFLINE: render the self-hosted raster {z}/{x}/{y} from GCS (cacheable, TOS-safe)
+  // instead of the Mapbox vector tilesets (which can't be cached). Raster = no vector
+  // interactivity, accepted offline. ONLINE keeps the interactive vector paths below.
+  if (isOffline && env.NEXT_PUBLIC_EXTENT_TILES_URL) {
     const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(currentYear));
     return (
       <Source

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -14,16 +14,6 @@ import { env } from '../../../../env.mjs';
 
 import { useMangroveHabitatExtent } from './hooks';
 
-// Per-year vector source: self-hosted {z}/{x}/{y}.pbf on GCS when configured
-// (cacheable → offline-capable; mapbox-gl can't read .pmtiles, so tiles must be
-// exploded), otherwise the Mapbox tileset. Same `source-layer` either way.
-const extentSourceProps = (year: number) => {
-  const selfHosted = env.NEXT_PUBLIC_EXTENT_TILES_URL;
-  return selfHosted
-    ? { tiles: [selfHosted.replace(/\{year\}/g, String(year))], minzoom: 0, maxzoom: 12 }
-    : { url: `mapbox://globalmangrovewatch.gmw-v4-extent-${year}` };
-};
-
 const DEFAULT_transitionMs = 600;
 
 // Prod uses the legacy single multi-tileset source (source-layer `mng_mjr_${year}`).
@@ -68,6 +58,32 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
   const transitionMs = reducedMotion ? 0 : DEFAULT_transitionMs;
 
   if (!years.length || !currentYear) return null;
+
+  // Self-hosted raster {z}/{x}/{y}.png on GCS when configured — cacheable, so
+  // extent works offline. Renders as a raster image (no vector interactivity).
+  // Takes precedence over the Mapbox vector paths below, regardless of flags.
+  if (env.NEXT_PUBLIC_EXTENT_TILES_URL) {
+    const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(currentYear));
+    return (
+      <Source
+        id={`habitat_extent_${currentYear}`}
+        type="raster"
+        tiles={[tiles]}
+        tileSize={256}
+        minzoom={0}
+        maxzoom={12}
+      >
+        <Layer
+          id={`${id}_${currentYear}_raster`}
+          type="raster"
+          source={`habitat_extent_${currentYear}`}
+          paint={{ 'raster-opacity': baseOpacity }}
+          layout={{ visibility }}
+          beforeId={beforeId}
+        />
+      </Source>
+    );
+  }
 
   // Prod: legacy single multi-tileset source, only the current year is rendered.
   if (!isTimelineSliderEnabled()) {
@@ -133,7 +149,7 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
             key={`habitat_extent_${y}`}
             id={`habitat_extent_${y}`}
             type="vector"
-            {...extentSourceProps(y)}
+            url={`mapbox://globalmangrovewatch.gmw-v4-extent-${y}`}
           >
             <Layer
               id={`${id}_${y}_fill`}

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -10,7 +10,19 @@ import type { ExpressionSpecification } from 'mapbox-gl';
 
 import type { LayerProps } from 'types/layers';
 
+import { env } from '../../../../env.mjs';
+
 import { useMangroveHabitatExtent } from './hooks';
+
+// Per-year vector source: self-hosted {z}/{x}/{y}.pbf on GCS when configured
+// (cacheable → offline-capable; mapbox-gl can't read .pmtiles, so tiles must be
+// exploded), otherwise the Mapbox tileset. Same `source-layer` either way.
+const extentSourceProps = (year: number) => {
+  const selfHosted = env.NEXT_PUBLIC_EXTENT_TILES_URL;
+  return selfHosted
+    ? { tiles: [selfHosted.replace(/\{year\}/g, String(year))], minzoom: 0, maxzoom: 12 }
+    : { url: `mapbox://globalmangrovewatch.gmw-v4-extent-${year}` };
+};
 
 const DEFAULT_transitionMs = 600;
 
@@ -121,7 +133,7 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
             key={`habitat_extent_${y}`}
             id={`habitat_extent_${y}`}
             type="vector"
-            url={`mapbox://globalmangrovewatch.gmw-v4-extent-${y}`}
+            {...extentSourceProps(y)}
           >
             <Layer
               id={`${id}_${y}_fill`}

--- a/src/containers/datasets/habitat-extent/layer.tsx
+++ b/src/containers/datasets/habitat-extent/layer.tsx
@@ -17,6 +17,11 @@ import { useMangroveHabitatExtent } from './hooks';
 
 const DEFAULT_transitionMs = 600;
 
+// Newest year the self-hosted extent raster (NEXT_PUBLIC_EXTENT_TILES_URL, v3)
+// publishes. Bump when the tileset gains newer years. Offline requests are
+// clamped to this so a later online-timeline year doesn't 404 into a blank layer.
+const OFFLINE_EXTENT_MAX_YEAR = 2020;
+
 // Prod uses the legacy single multi-tileset source (source-layer `mng_mjr_${year}`).
 // Staging uses the per-year GMW v4 tilesets, gated by the timeline_slider feature flag.
 const LEGACY_EXTENT_SOURCE_URL =
@@ -65,10 +70,14 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
   // instead of the Mapbox vector tilesets (which can't be cached). Raster = no vector
   // interactivity, accepted offline. ONLINE keeps the interactive vector paths below.
   if (isOffline && env.NEXT_PUBLIC_EXTENT_TILES_URL) {
-    const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(currentYear));
+    // The self-hosted extent raster only publishes through OFFLINE_EXTENT_MAX_YEAR;
+    // later years (from the online GMW timeline) have no tiles and 404 → blank layer.
+    // Clamp so a recent selected year falls back to the newest available raster.
+    const offlineYear = Math.min(currentYear, OFFLINE_EXTENT_MAX_YEAR);
+    const tiles = env.NEXT_PUBLIC_EXTENT_TILES_URL.replace(/\{year\}/g, String(offlineYear));
     return (
       <Source
-        id={`habitat_extent_${currentYear}`}
+        id={`habitat_extent_${offlineYear}`}
         type="raster"
         tiles={[tiles]}
         tileSize={256}
@@ -76,9 +85,9 @@ const MangrovesHabitatExtentLayer = ({ beforeId, id }: LayerProps) => {
         maxzoom={12}
       >
         <Layer
-          id={`${id}_${currentYear}_raster`}
+          id={`${id}_${offlineYear}_raster`}
           type="raster"
-          source={`habitat_extent_${currentYear}`}
+          source={`habitat_extent_${offlineYear}`}
           paint={{ 'raster-opacity': baseOpacity }}
           layout={{ visibility }}
           beforeId={beforeId}

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -420,6 +420,30 @@ export function useSources(): SourceProps[] {
   return getNetChangeSources(years, currentStartYear, currentEndYear);
 }
 
+/**
+ * Self-hosted combined gain/loss raster (both baked into one tileset), driven by
+ * NEXT_PUBLIC_GAIN__LOSS_TILES_URL. Cacheable + TOS-safe, so net change works
+ * offline and covers later years than the legacy separate gain/loss tilesets.
+ * Returns null when the env var is unset — callers then fall back to useSources.
+ */
+export function useGainLossSources(): SourceProps[] | null {
+  const startYear = useAtomValue(netChangeStartYear);
+  const endYear = useAtomValue(netChangeEndYear);
+  const { years, currentEndYear, currentStartYear } = useMangroveNetChange({ startYear, endYear });
+
+  const tilesUrl = env.NEXT_PUBLIC_GAIN__LOSS_TILES_URL;
+  if (!tilesUrl) return null;
+
+  const filteredYears = years?.filter((year) => year <= currentEndYear && year > currentStartYear);
+  return (filteredYears ?? []).map((year) => ({
+    id: `gain-loss-${year}`,
+    type: 'raster',
+    tiles: [tilesUrl.replace(/\{year\}/g, String(year))],
+    minZoom: 0,
+    maxZoom: 12,
+  }));
+}
+
 export function useLayer({
   id,
   opacity,

--- a/src/containers/datasets/net-change/layer.tsx
+++ b/src/containers/datasets/net-change/layer.tsx
@@ -4,12 +4,13 @@ import { useSyncActiveLayers } from '@/store/layers';
 
 import { LayerProps } from 'types/layers';
 
-import { useLayer, useSources } from './hooks';
+import { useGainLossSources, useLayer, useSources } from './hooks';
 
 const NetChangeLayer = ({ beforeId, id }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
 
+  const gainLossSources = useGainLossSources();
   const sources = useSources() satisfies SourceProps[];
   const LAYER = useLayer({
     id,
@@ -17,11 +18,18 @@ const NetChangeLayer = ({ beforeId, id }: LayerProps) => {
     visibility: activeLayer.visibility,
   });
 
-  if (!LAYER || !sources) return null;
+  if (!LAYER) return null;
+
+  // Prefer the self-hosted combined gain/loss raster (cacheable → offline-capable,
+  // covers later years) when NEXT_PUBLIC_GAIN__LOSS_TILES_URL is set; otherwise
+  // fall back to the GCS gain-loss-v4 sources.
+  const SOURCES = gainLossSources ?? sources;
+
+  if (!SOURCES?.length) return null;
 
   return (
     <>
-      {sources.map((SOURCE) => (
+      {SOURCES.map((SOURCE) => (
         <Source key={SOURCE.id} {...SOURCE}>
           <Layer key={`${SOURCE.id}-layer`} {...LAYER} id={SOURCE.id} beforeId={beforeId} />
         </Source>

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -8,6 +8,8 @@ import Image from 'next/image';
 
 import cn from '@/lib/classnames';
 import { flyMapTo, registerMapRef } from '@/lib/map-fly';
+import { OFFLINE_BASEMAP_STYLE } from '@/lib/offline/offline-style';
+import { useViewportPrefetch } from '@/lib/offline/use-viewport-prefetch';
 
 import { analysisAtom } from '@/store/analysis';
 import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
@@ -23,6 +25,7 @@ import {
   useSyncBasemap,
   useSyncURLBounds,
 } from '@/store/map';
+import { isOfflineAtom } from '@/store/offline';
 import { mapViewAtom } from '@/store/sidebar';
 
 import { useQueryClient } from '@tanstack/react-query';
@@ -46,6 +49,8 @@ import MobileLegend from '@/containers/map/legend/mobile';
 import Controls from '@/components/map/controls';
 import BasemapSettingsControl from '@/components/map/controls/basemap-settings';
 import FullScreenControl from '@/components/map/controls/fullscreen';
+import OfflineDownload from '@/components/map/controls/offline-download';
+import OfflineIndicator from '@/components/map/controls/offline-indicator';
 import PitchReset from '@/components/map/controls/pitch-reset';
 import ShareControl from '@/components/map/controls/share';
 import ZoomControl from '@/components/map/controls/zoom';
@@ -133,11 +138,21 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
 
   useOnClickOutside(mapRef, handleClickOutside);
 
-  const selectedBasemap = useMemo(() => BASEMAPS.find((b) => b.id === basemap)?.url, [basemap]);
+  const isOffline = useAtomValue(isOfflineAtom);
+
+  const selectedBasemap = useMemo(() => {
+    // Offline: swap Mapbox base (uncacheable, TOS) for the configured raster
+    // basemap. Falls back to the Mapbox style when none is configured.
+    if (isOffline && OFFLINE_BASEMAP_STYLE) return OFFLINE_BASEMAP_STYLE;
+    return BASEMAPS.find((b) => b.id === basemap)?.url;
+  }, [basemap, isOffline]);
 
   const { minZoom, maxZoom } = MAP_DEFAULT_PROPS;
 
   const { [mapId]: map } = useMap();
+
+  // B — warm tiles around the current view while online (accidental-offline).
+  useViewportPrefetch(mapId);
 
   const { id: locationId } = useSyncLocation();
   const queryClient = useQueryClient();
@@ -572,6 +587,8 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
                   )}
                 >
                   <div className="flex flex-col space-y-2 pt-1">
+                    <OfflineIndicator />
+                    <OfflineDownload mapId={mapId} />
                     {(customGeojson || uploadedGeojson) && <DeleteDrawingButton />}
                     <Helper
                       className={{

--- a/src/containers/map/layer-manager/index.tsx
+++ b/src/containers/map/layer-manager/index.tsx
@@ -4,13 +4,15 @@ import { Layer } from 'react-map-gl';
 
 import { useSyncActiveLayers } from '@/store/layers';
 import { interactiveLayerIdsAtom } from '@/store/map';
+import { isOfflineAtom } from '@/store/offline';
 
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
 import { BASEMAPS, LAYERS } from '@/containers/datasets';
 import { NATIONAL_DASHBOARD_LOCATIONS } from '@/containers/layers/constants';
+import { OFFLINE_ENABLED_WIDGETS_SLUGS } from '@/containers/widgets/constants';
 
 import type { LayerProps } from 'types/layers';
 import type { ContextualBasemapsId, WidgetSlugType } from 'types/widget';
@@ -20,18 +22,28 @@ const CountryBoundariesLayer = LAYERS['country-boundaries'];
 const LayerManagerContainer = () => {
   const [layers] = useSyncActiveLayers();
   const [, setInteractiveLayerIds] = useAtom(interactiveLayerIdsAtom);
+  const isOffline = useAtomValue(isOfflineAtom);
 
   const activeLayersIds = useMemo(() => layers?.map((l) => l?.id), [layers]);
 
   const ACTIVE_LAYERS = useMemo(() => {
-    const filteredLayers = activeLayersIds?.filter(
+    let filteredLayers = activeLayersIds?.filter(
       (layer: WidgetSlugType | ContextualBasemapsId | 'custom-area') => {
         return Object.keys(LAYERS).some((k) => layer?.includes(k));
       }
     );
 
+    // Offline: only the offline-supported layers (extent, alerts) have cacheable
+    // tiles — drop the rest from the map so it matches the disabled sidebar widgets
+    // and doesn't render blank/uncacheable Mapbox layers.
+    if (isOffline) {
+      filteredLayers = filteredLayers?.filter((layer) =>
+        OFFLINE_ENABLED_WIDGETS_SLUGS.some((slug) => layer?.includes(slug))
+      );
+    }
+
     return filteredLayers;
-  }, [activeLayersIds]);
+  }, [activeLayersIds, isOffline]);
 
   const { id } = useSyncLocation();
 
@@ -67,12 +79,15 @@ const LayerManagerContainer = () => {
 
   return (
     <>
-      <CountryBoundariesLayer
-        id="country-boundaries-layer"
-        beforeId="water"
-        onAdd={handleAdd}
-        onRemove={handleRemove}
-      />
+      {/* Mapbox-hosted vector layer — can't be cached (TOS), so hide it offline. */}
+      {!isOffline && (
+        <CountryBoundariesLayer
+          id="country-boundaries-layer"
+          beforeId="water"
+          onAdd={handleAdd}
+          onRemove={handleRemove}
+        />
+      )}
 
       {LAYERS_FILTERED.map((layer, i) => {
         const beforeId = i === 0 ? 'custom-layers' : `${LAYERS_FILTERED[i - 1]}-bg`;

--- a/src/containers/widgets/constants.ts
+++ b/src/containers/widgets/constants.ts
@@ -272,6 +272,14 @@ export const ANALYSIS_WIDGETS_SLUGS: WidgetTypes['slug'][] = [
 
 export const MAP_SETTINGS_SLUGS: string[] = ['mangrove_contextual_basemaps'];
 
+// Widgets supported in offline mode (for now: extent + alerts). Every other
+// widget is rendered disabled while offline. Extend this list as more layers
+// gain offline support.
+export const OFFLINE_ENABLED_WIDGETS_SLUGS: WidgetTypes['slug'][] = [
+  'mangrove_habitat_extent',
+  'mangrove_alerts',
+];
+
 export const WIDGETS_BY_CATEGORY = [
   {
     distribution_and_change: [

--- a/src/containers/widgets/constants.ts
+++ b/src/containers/widgets/constants.ts
@@ -277,6 +277,7 @@ export const MAP_SETTINGS_SLUGS: string[] = ['mangrove_contextual_basemaps'];
 // gain offline support.
 export const OFFLINE_ENABLED_WIDGETS_SLUGS: WidgetTypes['slug'][] = [
   'mangrove_habitat_extent',
+  'mangrove_net_change',
   'mangrove_alerts',
 ];
 

--- a/src/containers/widgets/hooks.tsx
+++ b/src/containers/widgets/hooks.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 
 import { analysisAtom } from '@/store/analysis';
 import { mapSettingsAtom } from '@/store/map-settings';
+import { isOfflineAtom } from '@/store/offline';
 import { useSyncActiveCategory } from '@/store/sidebar';
 
 import { useAtomValue } from 'jotai';
@@ -10,7 +11,11 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 
 import type { WidgetSlugType, WidgetTypes } from 'types/widget';
 
-import widgets, { ANALYSIS_WIDGETS_SLUGS, MAP_SETTINGS_SLUGS } from './constants';
+import widgets, {
+  ANALYSIS_WIDGETS_SLUGS,
+  MAP_SETTINGS_SLUGS,
+  OFFLINE_ENABLED_WIDGETS_SLUGS,
+} from './constants';
 
 export function useWidgets(): WidgetTypes[] {
   const [categorySelected] = useSyncActiveCategory();
@@ -39,12 +44,23 @@ export function useWidgets(): WidgetTypes[] {
 export function useWidgetsIdsByLocation(): WidgetSlugType[] {
   const { type: locationType } = useSyncLocation();
   const currentLocation = locationType || 'worldwide';
+  const isOffline = useAtomValue(isOfflineAtom);
 
   return useMemo(
     () =>
       widgets
         .filter(({ locationType }) => locationType.includes(currentLocation))
+        // Offline: only the offline-supported widgets are enabled; the rest
+        // surface as disabled (the consumer greys them via `enabledWidgets`).
+        .filter(({ slug }) => !isOffline || OFFLINE_ENABLED_WIDGETS_SLUGS.includes(slug))
         .map(({ slug }) => slug),
-    [currentLocation]
+    [currentLocation, isOffline]
   );
+}
+
+/** True when a widget should render disabled because we're offline and it's not
+ * one of the offline-supported widgets (extent, alerts). */
+export function useIsWidgetDisabledOffline(slug: WidgetSlugType): boolean {
+  const isOffline = useAtomValue(isOfflineAtom);
+  return isOffline && !OFFLINE_ENABLED_WIDGETS_SLUGS.includes(slug);
 }

--- a/src/containers/widgets/hooks.tsx
+++ b/src/containers/widgets/hooks.tsx
@@ -1,14 +1,17 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { analysisAtom } from '@/store/analysis';
+import { useSyncActiveLayers } from '@/store/layers';
 import { mapSettingsAtom } from '@/store/map-settings';
 import { isOfflineAtom } from '@/store/offline';
 import { useSyncActiveCategory } from '@/store/sidebar';
+import { useSyncActiveWidgets } from '@/store/widgets';
 
 import { useAtomValue } from 'jotai';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
+import type { Visibility } from '@/types/layers';
 import type { WidgetSlugType, WidgetTypes } from 'types/widget';
 
 import widgets, {
@@ -59,8 +62,48 @@ export function useWidgetsIdsByLocation(): WidgetSlugType[] {
 }
 
 /** True when a widget should render disabled because we're offline and it's not
- * one of the offline-supported widgets (extent, alerts). */
+ * one of the offline-supported widgets (extent, net change, alerts). */
 export function useIsWidgetDisabledOffline(slug: WidgetSlugType): boolean {
   const isOffline = useAtomValue(isOfflineAtom);
   return isOffline && !OFFLINE_ENABLED_WIDGETS_SLUGS.includes(slug);
+}
+
+/**
+ * When offline, force the offline-supported widgets (extent, net change, alerts)
+ * to be active and their map layers visible, so the usable widgets surface on top
+ * with their layers already drawn — without the user hand-toggling each one. Only
+ * touches widgets valid for the current location; never removes the user's other
+ * selections, so returning online leaves their setup intact.
+ */
+export function useActivateOfflineWidgets(): void {
+  const isOffline = useAtomValue(isOfflineAtom);
+  const [, setActiveWidgets] = useSyncActiveWidgets();
+  const [, setActiveLayers] = useSyncActiveLayers();
+  const { type: locationType } = useSyncLocation();
+  const currentLocation = locationType || 'worldwide';
+
+  useEffect(() => {
+    if (!isOffline) return;
+
+    const slugs = OFFLINE_ENABLED_WIDGETS_SLUGS.filter((slug) =>
+      widgets.find((w) => w.slug === slug)?.locationType.includes(currentLocation)
+    );
+    if (!slugs.length) return;
+
+    // Prepend the offline widgets (deduped) so they sit on top of the sidebar.
+    setActiveWidgets((current) => {
+      const base = current ?? [];
+      const others = base.filter((s) => !slugs.includes(s as WidgetSlugType));
+      return [...slugs, ...others];
+    });
+
+    // Add any offline layer not already active, visible, on top of the stack.
+    setActiveLayers((current) => {
+      const base = current ?? [];
+      const missing = slugs
+        .filter((slug) => !base.some((l) => l.id === slug))
+        .map((slug) => ({ id: slug, opacity: '1', visibility: 'visible' as Visibility }));
+      return missing.length ? [...missing, ...base] : base;
+    });
+  }, [isOffline, currentLocation, setActiveWidgets, setActiveLayers]);
 }

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -1,9 +1,10 @@
 import { FC, useMemo } from 'react';
 
 import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
+import { isOfflineAtom } from '@/store/offline';
 import { useSyncActiveWidgets } from '@/store/widgets';
 
-import { useAtom } from 'jotai';
+import { useAtom, useAtomValue } from 'jotai';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
@@ -11,7 +12,12 @@ import WidgetsLayout from '@/layouts/widgets';
 
 import CloseHelpGuide from '@/containers/help/close';
 import AppTools from '@/containers/navigation';
-import { widgets, ANALYSIS_WIDGETS_SLUGS } from '@/containers/widgets/constants';
+import {
+  widgets,
+  ANALYSIS_WIDGETS_SLUGS,
+  OFFLINE_ENABLED_WIDGETS_SLUGS,
+} from '@/containers/widgets/constants';
+import { useActivateOfflineWidgets } from '@/containers/widgets/hooks';
 
 import { Dialog } from '@/components/ui/dialog';
 import { WidgetTypes } from 'types/widget';
@@ -29,17 +35,36 @@ const WidgetsContainer: FC = () => {
   const [activeWidgets] = useSyncActiveWidgets();
   const { type: locationType } = useSyncLocation();
   const currentLocation = locationType || 'worldwide';
+  const isOffline = useAtomValue(isOfflineAtom);
+
+  // Offline: force-activate the offline-supported widgets + their layers.
+  useActivateOfflineWidgets();
 
   const widgetsAvailable = useMemo(() => {
     if (customGeojson || uploadedGeojson) {
       return widgets.filter(({ slug }) => ANALYSIS_WIDGETS_SLUGS.includes(slug));
     }
-    return widgets.filter(
+    const list = widgets.filter(
       ({ slug, locationType: widgetLocations }) =>
         widgetLocations.includes(currentLocation) &&
         (activeWidgets?.includes(slug) || slug === 'widgets_deck_tool')
     );
-  }, [activeWidgets, currentLocation, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
+    // Offline: surface the offline-ready widgets on top (stable within groups).
+    if (isOffline) {
+      return [...list].sort(
+        (a, b) =>
+          (OFFLINE_ENABLED_WIDGETS_SLUGS.includes(a.slug) ? 0 : 1) -
+          (OFFLINE_ENABLED_WIDGETS_SLUGS.includes(b.slug) ? 0 : 1)
+      );
+    }
+    return list;
+  }, [
+    activeWidgets,
+    currentLocation,
+    customGeojson,
+    uploadedGeojson,
+    isOffline,
+  ]) satisfies WidgetTypes[];
 
   const isCustomArea = !!(customGeojson || uploadedGeojson);
 

--- a/src/containers/widgets/widget-card.tsx
+++ b/src/containers/widgets/widget-card.tsx
@@ -1,5 +1,8 @@
+import cn from '@/lib/classnames';
+
 import { WIDGETS } from '@/containers/datasets';
 import WidgetWrapper from '@/containers/widget';
+import { useIsWidgetDisabledOffline } from '@/containers/widgets/hooks';
 
 import type { WidgetTypes } from 'types/widget';
 
@@ -10,16 +13,23 @@ type Props = {
 export default function WidgetCard({ widget }: Props) {
   const { slug, name, applicability, contextualLayers, index } = widget;
   const Widget = WIDGETS[slug];
+  const isDisabledOffline = useIsWidgetDisabledOffline(slug);
   if (!Widget) return null;
   return (
-    <WidgetWrapper
-      title={name}
-      id={slug}
-      applicability={applicability}
-      contextualLayers={contextualLayers}
-      index={index}
+    <div
+      className={cn(isDisabledOffline && 'pointer-events-none opacity-40')}
+      aria-disabled={isDisabledOffline || undefined}
+      title={isDisabledOffline ? 'Unavailable offline' : undefined}
     >
-      <Widget />
-    </WidgetWrapper>
+      <WidgetWrapper
+        title={name}
+        id={slug}
+        applicability={applicability}
+        contextualLayers={contextualLayers}
+        index={index}
+      >
+        <Widget />
+      </WidgetWrapper>
+    </div>
   );
 }

--- a/src/lib/offline/download.ts
+++ b/src/lib/offline/download.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect } from 'react';
+
+import { useMap } from 'react-map-gl';
+
+import { downloadProgressAtom, regionsAtom } from '@/store/offline';
+
+import { useAtom, useSetAtom } from 'jotai';
+
+import { deleteRegion, listRegions, putRegion, type OfflineRegion } from './regions';
+import { onSWMessage, sendToSW } from './sw-messages';
+import { collectCacheableTemplates, type StyleReader } from './templates';
+import { expandTemplate, tilesForBBox, OVERZOOM_MAX, type BBox, type Tile } from './tiles';
+
+const MAX_REGION_TILES = 5000;
+
+const newId = () =>
+  (typeof crypto !== 'undefined' && 'randomUUID' in crypto && crypto.randomUUID()) ||
+  `region-${String(performance.now()).replace('.', '')}`;
+
+export type DownloadOptions = {
+  name: string;
+  bbox: BBox;
+  minZoom: number;
+  maxZoom: number;
+};
+
+export function useOfflineDownload(mapId = 'default') {
+  const maps = useMap();
+  const map = (maps as Record<string, { getMap?: () => unknown } | undefined>)[mapId];
+  const [regions, setRegions] = useAtom(regionsAtom);
+  const setProgress = useSetAtom(downloadProgressAtom);
+
+  const refreshRegions = useCallback(() => {
+    listRegions()
+      .then(setRegions)
+      .catch(() => setRegions([]));
+  }, [setRegions]);
+
+  // Hydrate the regions list once and reflect SW progress messages into the atom.
+  useEffect(() => {
+    refreshRegions();
+    const off = onSWMessage((data) => {
+      const msg = data as {
+        type?: string;
+        regionId?: string;
+        done?: number;
+        failed?: number;
+        total?: number;
+      };
+      if (msg.type === 'CACHE_PROGRESS') {
+        setProgress((p) => ({
+          ...p,
+          status: 'running',
+          regionId: msg.regionId ?? p.regionId,
+          done: msg.done ?? p.done,
+          failed: msg.failed ?? p.failed,
+          total: msg.total ?? p.total,
+        }));
+      } else if (msg.type === 'CACHE_DONE') {
+        setProgress((p) => ({
+          ...p,
+          status: 'done',
+          done: msg.done ?? p.done,
+          failed: msg.failed ?? p.failed,
+        }));
+      }
+    });
+    return off;
+  }, [refreshRegions, setProgress]);
+
+  const estimateTiles = useCallback(
+    (bbox: BBox, minZoom: number, maxZoom: number) => {
+      const rawMap = (map?.getMap?.() ?? map) as StyleReader | undefined;
+      const templates = collectCacheableTemplates(rawMap);
+      const lo = Math.max(0, Math.min(minZoom, maxZoom));
+      const hi = Math.min(Math.max(minZoom, maxZoom), OVERZOOM_MAX);
+      const perLayer = tilesForBBox(bbox, lo, hi, MAX_REGION_TILES).length;
+      return { templates: templates.length, tiles: perLayer * Math.max(templates.length, 1) };
+    },
+    [map]
+  );
+
+  const download = useCallback(
+    async ({ name, bbox, minZoom, maxZoom }: DownloadOptions) => {
+      const rawMap = (map?.getMap?.() ?? map) as StyleReader | undefined;
+      const templates = collectCacheableTemplates(rawMap);
+      // Never request above the native pyramid depth — Mapbox overzooms cached
+      // z<=OVERZOOM_MAX tiles to fill every higher zoom level offline.
+      const lo = Math.max(0, Math.min(minZoom, maxZoom));
+      const hi = Math.min(Math.max(minZoom, maxZoom), OVERZOOM_MAX);
+      const coords: Tile[] = tilesForBBox(bbox, lo, hi, MAX_REGION_TILES);
+      const urls = templates.flatMap((tpl) => coords.map((t) => expandTemplate(tpl, t)));
+
+      const regionId = newId();
+      setProgress({ regionId, status: 'running', done: 0, failed: 0, total: urls.length });
+
+      // Persist already-loaded widget JSON for this location, then cache tiles.
+      sendToSW({ type: 'PERSIST_DATA_CACHE' });
+      sendToSW({ type: 'CACHE_URLS', urls, regionId, total: urls.length });
+
+      const region: OfflineRegion = {
+        id: regionId,
+        name,
+        bbox,
+        minZoom: lo,
+        maxZoom: hi,
+        layerIds: templates,
+        tileCount: coords.length,
+        urls,
+        createdAt: Date.now(),
+      };
+      await putRegion(region).catch(() => {});
+      refreshRegions();
+      return region;
+    },
+    [map, refreshRegions, setProgress]
+  );
+
+  const removeRegion = useCallback(
+    async (id: string) => {
+      const region = regions.find((r) => r.id === id);
+      if (region) sendToSW({ type: 'DELETE_REGION_URLS', urls: region.urls });
+      await deleteRegion(id).catch(() => {});
+      refreshRegions();
+    },
+    [regions, refreshRegions]
+  );
+
+  return { regions, download, removeRegion, refreshRegions, estimateTiles };
+}

--- a/src/lib/offline/download.ts
+++ b/src/lib/offline/download.ts
@@ -11,7 +11,9 @@ import { onSWMessage, sendToSW } from './sw-messages';
 import { collectCacheableTemplates, type StyleReader } from './templates';
 import { expandTemplate, tilesForBBox, OVERZOOM_MAX, type BBox, type Tile } from './tiles';
 
-export const MAX_REGION_TILES = 5000;
+// Max tiles enumerated for a region download (across zooms 0..12). z12 dominates,
+// so 5k was hit by even a few-degree view; 20k covers ~14°×14° before warning.
+export const MAX_REGION_TILES = 20000;
 
 const newId = () =>
   (typeof crypto !== 'undefined' && 'randomUUID' in crypto && crypto.randomUUID()) ||

--- a/src/lib/offline/download.ts
+++ b/src/lib/offline/download.ts
@@ -11,7 +11,7 @@ import { onSWMessage, sendToSW } from './sw-messages';
 import { collectCacheableTemplates, type StyleReader } from './templates';
 import { expandTemplate, tilesForBBox, OVERZOOM_MAX, type BBox, type Tile } from './tiles';
 
-const MAX_REGION_TILES = 5000;
+export const MAX_REGION_TILES = 5000;
 
 const newId = () =>
   (typeof crypto !== 'undefined' && 'randomUUID' in crypto && crypto.randomUUID()) ||
@@ -75,7 +75,12 @@ export function useOfflineDownload(mapId = 'default') {
       const lo = Math.max(0, Math.min(minZoom, maxZoom));
       const hi = Math.min(Math.max(minZoom, maxZoom), OVERZOOM_MAX);
       const perLayer = tilesForBBox(bbox, lo, hi, MAX_REGION_TILES).length;
-      return { templates: templates.length, tiles: perLayer * Math.max(templates.length, 1) };
+      return {
+        templates: templates.length,
+        tiles: perLayer * Math.max(templates.length, 1),
+        // cap reached → the area/zoom is too big to fully cache (only a prefix saves).
+        capped: perLayer >= MAX_REGION_TILES,
+      };
     },
     [map]
   );

--- a/src/lib/offline/download.ts
+++ b/src/lib/offline/download.ts
@@ -2,11 +2,12 @@ import { useCallback, useEffect } from 'react';
 
 import { useMap } from 'react-map-gl';
 
-import { downloadProgressAtom, regionsAtom } from '@/store/offline';
+import { downloadProgressAtom, regionsAtom, storageStatusAtom } from '@/store/offline';
 
 import { useAtom, useSetAtom } from 'jotai';
 
 import { deleteRegion, listRegions, putRegion, type OfflineRegion } from './regions';
+import { getStorageStatus, requestPersistentStorage } from './storage';
 import { onSWMessage, sendToSW } from './sw-messages';
 import { collectCacheableTemplates, type StyleReader } from './templates';
 import { expandTemplate, tilesForBBox, OVERZOOM_MAX, type BBox, type Tile } from './tiles';
@@ -31,6 +32,7 @@ export function useOfflineDownload(mapId = 'default') {
   const map = (maps as Record<string, { getMap?: () => unknown } | undefined>)[mapId];
   const [regions, setRegions] = useAtom(regionsAtom);
   const setProgress = useSetAtom(downloadProgressAtom);
+  const setStorage = useSetAtom(storageStatusAtom);
 
   const refreshRegions = useCallback(() => {
     listRegions()
@@ -38,9 +40,16 @@ export function useOfflineDownload(mapId = 'default') {
       .catch(() => setRegions([]));
   }, [setRegions]);
 
+  const refreshStorage = useCallback(() => {
+    getStorageStatus()
+      .then(setStorage)
+      .catch(() => {});
+  }, [setStorage]);
+
   // Hydrate the regions list once and reflect SW progress messages into the atom.
   useEffect(() => {
     refreshRegions();
+    refreshStorage();
     const off = onSWMessage((data) => {
       const msg = data as {
         type?: string;
@@ -65,10 +74,12 @@ export function useOfflineDownload(mapId = 'default') {
           done: msg.done ?? p.done,
           failed: msg.failed ?? p.failed,
         }));
+        // Tiles just landed in the cache — refresh the usage estimate.
+        refreshStorage();
       }
     });
     return off;
-  }, [refreshRegions, setProgress]);
+  }, [refreshRegions, refreshStorage, setProgress]);
 
   const estimateTiles = useCallback(
     (bbox: BBox, minZoom: number, maxZoom: number) => {
@@ -89,6 +100,10 @@ export function useOfflineDownload(mapId = 'default') {
 
   const download = useCallback(
     async ({ name, bbox, minZoom, maxZoom }: DownloadOptions) => {
+      // Opt the origin out of automatic eviction before writing anything, so the
+      // download survives Safari/iOS's idle purge and disk-pressure eviction.
+      await requestPersistentStorage();
+
       const rawMap = (map?.getMap?.() ?? map) as StyleReader | undefined;
       const templates = collectCacheableTemplates(rawMap);
       // Never request above the native pyramid depth — Mapbox overzooms cached
@@ -118,9 +133,10 @@ export function useOfflineDownload(mapId = 'default') {
       };
       await putRegion(region).catch(() => {});
       refreshRegions();
+      refreshStorage();
       return region;
     },
-    [map, refreshRegions, setProgress]
+    [map, refreshRegions, refreshStorage, setProgress]
   );
 
   const removeRegion = useCallback(
@@ -129,8 +145,9 @@ export function useOfflineDownload(mapId = 'default') {
       if (region) sendToSW({ type: 'DELETE_REGION_URLS', urls: region.urls });
       await deleteRegion(id).catch(() => {});
       refreshRegions();
+      refreshStorage();
     },
-    [regions, refreshRegions]
+    [regions, refreshRegions, refreshStorage]
   );
 
   return { regions, download, removeRegion, refreshRegions, estimateTiles };

--- a/src/lib/offline/offline-style.ts
+++ b/src/lib/offline/offline-style.ts
@@ -29,6 +29,12 @@ export const OFFLINE_BASEMAP_STYLE: MapProps['mapStyle'] = env.NEXT_PUBLIC_OFFLI
           source: 'offline-basemap',
           minzoom: 0,
         },
+        // Anchor layers the app inserts data layers before (layer-manager uses
+        // beforeId 'custom-layers'; country-boundaries uses 'water'). The Mapbox
+        // styles ship these slots — replicate them here as invisible anchors so
+        // offline data layers land ABOVE the basemap instead of failing to place.
+        { id: 'water', type: 'background', layout: { visibility: 'none' }, paint: {} },
+        { id: 'custom-layers', type: 'background', layout: { visibility: 'none' }, paint: {} },
       ],
       // Mapbox GL requires glyphs for any symbol layers added later by the app.
       glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',

--- a/src/lib/offline/offline-style.ts
+++ b/src/lib/offline/offline-style.ts
@@ -1,0 +1,36 @@
+import type { MapProps } from 'react-map-gl';
+
+import { env } from '../../../env.mjs';
+
+import { OVERZOOM_MAX } from './tiles';
+
+// Minimal raster Mapbox-GL style for offline mode, built from a TOS-safe raster
+// XYZ source (env-provided). Mapbox-hosted basemaps can't be cached, so when the
+// map goes offline we swap to this. Undefined when no offline basemap is
+// configured — callers then keep the data layers on a neutral background.
+export const OFFLINE_BASEMAP_STYLE: MapProps['mapStyle'] = env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL
+  ? ({
+      version: 8,
+      sources: {
+        'offline-basemap': {
+          type: 'raster',
+          tiles: [env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL],
+          tileSize: 256,
+          // Cap at the cached pyramid depth so Mapbox overzooms (scales) cached
+          // tiles for higher zooms instead of requesting uncached children —
+          // keeps the basemap visible at every zoom offline.
+          maxzoom: OVERZOOM_MAX,
+        },
+      },
+      layers: [
+        {
+          id: 'offline-basemap',
+          type: 'raster',
+          source: 'offline-basemap',
+          minzoom: 0,
+        },
+      ],
+      // Mapbox GL requires glyphs for any symbol layers added later by the app.
+      glyphs: 'mapbox://fonts/mapbox/{fontstack}/{range}.pbf',
+    } as MapProps['mapStyle'])
+  : undefined;

--- a/src/lib/offline/offline-style.ts
+++ b/src/lib/offline/offline-style.ts
@@ -16,6 +16,9 @@ export const OFFLINE_BASEMAP_STYLE: MapProps['mapStyle'] = env.NEXT_PUBLIC_OFFLI
           type: 'raster',
           tiles: [env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL],
           tileSize: 256,
+          // Required credit for the raster basemap (OSM/ODbL). Surfaced by the
+          // map's AttributionControl; without it the offline map credits nobody.
+          attribution: '© OpenStreetMap contributors',
           // Cap at the cached pyramid depth so Mapbox overzooms (scales) cached
           // tiles for higher zooms instead of requesting uncached children —
           // keeps the basemap visible at every zoom offline.

--- a/src/lib/offline/regions.ts
+++ b/src/lib/offline/regions.ts
@@ -1,0 +1,81 @@
+// Metadata index for deliberately-downloaded offline regions. Tile/JSON bytes
+// live in the SW's `mangrove-offline` Cache; this IndexedDB store just records
+// what was downloaded so the UI can list, restore camera to, and delete regions.
+//
+// Hand-rolled (no `idb`/`Dexie` — not on the Tech Radar). Promise-wrapped.
+
+import type { BBox } from './tiles';
+
+export type OfflineRegion = {
+  id: string;
+  name: string;
+  bbox: BBox;
+  minZoom: number;
+  maxZoom: number;
+  layerIds: string[];
+  tileCount: number;
+  /** Every URL cached for this region — used to evict on delete. */
+  urls: string[];
+  createdAt: number;
+};
+
+const DB_NAME = 'mangrove-offline';
+const STORE = 'regions';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB unavailable'));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        db.createObjectStore(STORE, { keyPath: 'id' });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function tx<T>(
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+  return openDB().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const transaction = db.transaction(STORE, mode);
+        const request = run(transaction.objectStore(STORE));
+        transaction.oncomplete = () => {
+          resolve(request.result);
+          db.close();
+        };
+        transaction.onerror = () => {
+          reject(transaction.error);
+          db.close();
+        };
+      })
+  );
+}
+
+export function putRegion(region: OfflineRegion): Promise<IDBValidKey> {
+  return tx('readwrite', (store) => store.put(region));
+}
+
+export function listRegions(): Promise<OfflineRegion[]> {
+  return tx<OfflineRegion[]>('readonly', (store) => store.getAll()).then((rows) =>
+    [...rows].sort((a, b) => b.createdAt - a.createdAt)
+  );
+}
+
+export function getRegion(id: string): Promise<OfflineRegion | undefined> {
+  return tx('readonly', (store) => store.get(id));
+}
+
+export function deleteRegion(id: string): Promise<undefined> {
+  return tx('readwrite', (store) => store.delete(id));
+}

--- a/src/lib/offline/register-sw.ts
+++ b/src/lib/offline/register-sw.ts
@@ -30,6 +30,12 @@ export function registerServiceWorker(): void {
   if (apiOrigin) qs.set('api', apiOrigin);
   if (baseOrigin) qs.set('base', baseOrigin);
   if (tilerOrigin) qs.set('tiler', tilerOrigin);
+  // Per-build stamp (next.config injects NEXT_PUBLIC_SW_VERSION). Changing the
+  // registration URL each build forces the browser to install a fresh worker,
+  // whose activate step purges the previous build's volatile caches — without
+  // this the SW serves the old HTML/chunks after a deploy (stale-build 500s).
+  const version = process.env.NEXT_PUBLIC_SW_VERSION || '';
+  if (version) qs.set('v', version);
 
   const swUrl = qs.toString() ? `/sw.js?${qs.toString()}` : '/sw.js';
 

--- a/src/lib/offline/register-sw.ts
+++ b/src/lib/offline/register-sw.ts
@@ -1,0 +1,41 @@
+import { env } from '../../../env.mjs';
+
+/**
+ * Registers the offline-maps service worker (public/sw.js).
+ *
+ * Production-build only: gated on NODE_ENV (set to 'development' only by
+ * `next dev`), so the SW never caches Next's HMR/_next assets during local
+ * iteration but is active in every real build — preview, prod, and the
+ * Playwright production server. The main API origin is passed via query string
+ * so the worker (which cannot import env.mjs) knows which requests to cache.
+ *
+ * Safe to call repeatedly — the browser dedupes registration of the same URL.
+ */
+export function registerServiceWorker(): void {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
+  if (process.env.NODE_ENV !== 'production') return;
+
+  const originOf = (raw?: string) => {
+    try {
+      return raw ? new URL(raw).origin : '';
+    } catch {
+      return '';
+    }
+  };
+
+  const qs = new URLSearchParams();
+  const apiOrigin = originOf(env.NEXT_PUBLIC_API_URL);
+  const baseOrigin = originOf(env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL);
+  const tilerOrigin = originOf(env.NEXT_PUBLIC_ALERTS_TILER_URL);
+  if (apiOrigin) qs.set('api', apiOrigin);
+  if (baseOrigin) qs.set('base', baseOrigin);
+  if (tilerOrigin) qs.set('tiler', tilerOrigin);
+
+  const swUrl = qs.toString() ? `/sw.js?${qs.toString()}` : '/sw.js';
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register(swUrl, { scope: '/' }).catch(() => {
+      // Offline caching is a progressive enhancement — ignore registration errors.
+    });
+  });
+}

--- a/src/lib/offline/register-sw.ts
+++ b/src/lib/offline/register-sw.ts
@@ -13,7 +13,25 @@ import { env } from '../../../env.mjs';
  */
 export function registerServiceWorker(): void {
   if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return;
-  if (process.env.NODE_ENV !== 'production') return;
+  if (process.env.NODE_ENV !== 'production') {
+    // A SW left over from a local prod build (`pnpm start`/`pnpm test`) keeps
+    // serving cached `_next/static` chunks in dev — dev never re-registers or
+    // purges it, so source edits silently never reach the browser. Proactively
+    // unregister and drop our caches so `next dev` always serves fresh code.
+    navigator.serviceWorker
+      .getRegistrations()
+      .then((regs) => regs.forEach((r) => r.unregister()))
+      .catch(() => {});
+    if ('caches' in window) {
+      caches
+        .keys()
+        .then((names) =>
+          names.filter((n) => n.startsWith('mangrove-')).forEach((n) => caches.delete(n))
+        )
+        .catch(() => {});
+    }
+    return;
+  }
 
   const originOf = (raw?: string) => {
     try {

--- a/src/lib/offline/storage.ts
+++ b/src/lib/offline/storage.ts
@@ -1,0 +1,70 @@
+// Persistent-storage + quota helpers for deliberate offline downloads.
+//
+// Browsers evict *best-effort* storage automatically — Safari/iOS drops Cache
+// Storage + IndexedDB after ~7 idle days, and every engine evicts under disk
+// pressure. That would silently delete a downloaded region between the moment a
+// user saves it and the moment they need it offline. Requesting *persistent*
+// storage opts the origin out of automatic eviction where the browser honours it
+// (Chrome grants via engagement / installed-PWA heuristics; Safari via an
+// add-to-home-screen / prompt). All helpers degrade to a safe null/zero when the
+// Storage API is missing, so callers never need to feature-detect.
+
+export type StorageStatus = {
+  /** true = persistent (won't be auto-evicted); false = best-effort; null = unknown/unsupported. */
+  persisted: boolean | null;
+  usage: number; // bytes currently used by this origin
+  quota: number; // bytes the origin may use
+};
+
+export async function isStoragePersisted(): Promise<boolean | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.persisted) return null;
+  try {
+    return await navigator.storage.persisted();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ask the browser to mark this origin's storage persistent. No-op returning the
+ * current state if already persisted. Returns null when unsupported.
+ */
+export async function requestPersistentStorage(): Promise<boolean | null> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.persist) return null;
+  try {
+    if (navigator.storage.persisted && (await navigator.storage.persisted())) return true;
+    return await navigator.storage.persist();
+  } catch {
+    return null;
+  }
+}
+
+export async function getStorageEstimate(): Promise<{ usage: number; quota: number }> {
+  if (typeof navigator === 'undefined' || !navigator.storage?.estimate) {
+    return { usage: 0, quota: 0 };
+  }
+  try {
+    const { usage = 0, quota = 0 } = await navigator.storage.estimate();
+    return { usage, quota };
+  } catch {
+    return { usage: 0, quota: 0 };
+  }
+}
+
+export async function getStorageStatus(): Promise<StorageStatus> {
+  const [persisted, estimate] = await Promise.all([isStoragePersisted(), getStorageEstimate()]);
+  return { persisted, ...estimate };
+}
+
+/** Human-readable bytes (e.g. 45.2 MB). Falls back to "—" for zero/unknown. */
+export function formatBytes(bytes: number): string {
+  if (!bytes || bytes < 0) return '—';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  let value = bytes;
+  let i = 0;
+  while (value >= 1024 && i < units.length - 1) {
+    value /= 1024;
+    i++;
+  }
+  return `${value.toFixed(value < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
+}

--- a/src/lib/offline/sw-messages.ts
+++ b/src/lib/offline/sw-messages.ts
@@ -1,0 +1,30 @@
+// Thin wrapper over the service-worker message channel used by the download
+// orchestrator. No-ops gracefully when there is no controlling SW (dev, no
+// support), so callers don't need to guard.
+
+type SWMessage =
+  | { type: 'CACHE_URLS'; urls: string[]; regionId: string; total: number }
+  | { type: 'PERSIST_DATA_CACHE' }
+  | { type: 'DELETE_REGION_URLS'; urls: string[] }
+  | { type: 'SKIP_WAITING' };
+
+export function isSWAvailable(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    navigator.serviceWorker.controller != null
+  );
+}
+
+export function sendToSW(message: SWMessage): void {
+  if (!isSWAvailable()) return;
+  navigator.serviceWorker.controller?.postMessage(message);
+}
+
+/** Subscribe to SW → page messages. Returns an unsubscribe fn. */
+export function onSWMessage(handler: (data: unknown) => void): () => void {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return () => {};
+  const listener = (event: MessageEvent) => handler(event.data);
+  navigator.serviceWorker.addEventListener('message', listener);
+  return () => navigator.serviceWorker.removeEventListener('message', listener);
+}

--- a/src/lib/offline/templates.ts
+++ b/src/lib/offline/templates.ts
@@ -1,0 +1,50 @@
+import { env } from '../../../env.mjs';
+
+export type StyleReader = {
+  getStyle?: () => { sources?: Record<string, unknown> } | undefined;
+};
+
+const originOf = (raw?: string) => {
+  try {
+    return raw ? new URL(raw).origin : null;
+  } catch {
+    return null;
+  }
+};
+const offlineBaseOrigin = originOf(env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL);
+const alertsTilerOrigin = originOf(env.NEXT_PUBLIC_ALERTS_TILER_URL);
+
+/**
+ * Raster tile templates from the live map style that are TOS-safe to cache:
+ * our GCS tilesets + the configured offline basemap. Mapbox-hosted sources are
+ * excluded. Shared by the viewport prefetch (B) and region download (C).
+ */
+export function collectCacheableTemplates(map: StyleReader | undefined): string[] {
+  const templates = new Set<string>();
+  try {
+    const sources = map?.getStyle?.()?.sources ?? {};
+    Object.values(sources).forEach((src) => {
+      const tiles = (src as { tiles?: string[] })?.tiles;
+      if (!Array.isArray(tiles)) return;
+      tiles.forEach((tpl) => {
+        try {
+          const probe = new URL(tpl.replace(/\{[^}]+\}/g, '0'));
+          if (
+            /storage\.googleapis\.com$/.test(probe.host) ||
+            (offlineBaseOrigin && probe.origin === offlineBaseOrigin) ||
+            (alertsTilerOrigin && probe.origin === alertsTilerOrigin)
+          ) {
+            templates.add(tpl);
+          }
+        } catch {
+          /* non-absolute template — skip */
+        }
+      });
+    });
+  } catch {
+    /* style not ready */
+  }
+
+  if (env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL) templates.add(env.NEXT_PUBLIC_OFFLINE_BASEMAP_URL);
+  return [...templates];
+}

--- a/src/lib/offline/tiles.ts
+++ b/src/lib/offline/tiles.ts
@@ -1,0 +1,73 @@
+// Slippy-map tile math + URL templating, shared by the viewport prefetch (B)
+// and the deliberate region download (C). Pure functions, no DOM/SW deps.
+
+export type Tile = { z: number; x: number; y: number };
+export type BBox = [number, number, number, number]; // [minLng, minLat, maxLng, maxLat]
+
+// Max native zoom our GCS raster tilesets publish (their source `maxzoom: 12`).
+// Mapbox GL overzooms — scales cached z12 tiles — for any zoom beyond this, so
+// caching the z0..12 pyramid for an area makes EVERY zoom level render offline.
+export const OVERZOOM_MAX = 12;
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+/** Longitude → tile X at zoom z. */
+export function lngToTileX(lng: number, z: number): number {
+  return Math.floor(((lng + 180) / 360) * 2 ** z);
+}
+
+/** Latitude → tile Y at zoom z (Web Mercator). */
+export function latToTileY(lat: number, z: number): number {
+  const rad = (clamp(lat, -85.05112878, 85.05112878) * Math.PI) / 180;
+  return Math.floor(((1 - Math.asinh(Math.tan(rad)) / Math.PI) / 2) * 2 ** z);
+}
+
+/** Number of tiles a bbox covers across the inclusive zoom range — for size estimates. */
+export function countTiles(bbox: BBox, minZoom: number, maxZoom: number): number {
+  let total = 0;
+  for (let z = minZoom; z <= maxZoom; z++) {
+    const [minLng, minLat, maxLng, maxLat] = bbox;
+    const max = 2 ** z - 1;
+    const x0 = clamp(lngToTileX(minLng, z), 0, max);
+    const x1 = clamp(lngToTileX(maxLng, z), 0, max);
+    const y0 = clamp(latToTileY(maxLat, z), 0, max); // maxLat → smaller Y
+    const y1 = clamp(latToTileY(minLat, z), 0, max);
+    total += (Math.abs(x1 - x0) + 1) * (Math.abs(y1 - y0) + 1);
+  }
+  return total;
+}
+
+/**
+ * Enumerate every tile covering `bbox` across [minZoom, maxZoom]. Bounded by
+ * `cap` (returns early once reached) so a careless zoom range can't generate
+ * millions of coordinates.
+ */
+export function tilesForBBox(bbox: BBox, minZoom: number, maxZoom: number, cap = 5000): Tile[] {
+  const tiles: Tile[] = [];
+  const [minLng, minLat, maxLng, maxLat] = bbox;
+  for (let z = minZoom; z <= maxZoom; z++) {
+    const max = 2 ** z - 1;
+    const x0 = clamp(Math.min(lngToTileX(minLng, z), lngToTileX(maxLng, z)), 0, max);
+    const x1 = clamp(Math.max(lngToTileX(minLng, z), lngToTileX(maxLng, z)), 0, max);
+    const y0 = clamp(Math.min(latToTileY(minLat, z), latToTileY(maxLat, z)), 0, max);
+    const y1 = clamp(Math.max(latToTileY(minLat, z), latToTileY(maxLat, z)), 0, max);
+    for (let x = x0; x <= x1; x++) {
+      for (let y = y0; y <= y1; y++) {
+        if (tiles.length >= cap) return tiles;
+        tiles.push({ z, x, y });
+      }
+    }
+  }
+  return tiles;
+}
+
+/** Expand a `{z}/{x}/{y}` (and `{-y}` TMS) raster URL template for one tile. */
+export function expandTemplate(template: string, { z, x, y }: Tile): string {
+  return template
+    .replace(/\{z\}/g, String(z))
+    .replace(/\{x\}/g, String(x))
+    .replace(/\{y\}/g, String(y))
+    .replace(/\{-y\}/g, String(2 ** z - 1 - y))
+    .replace(/\{ratio\}/g, '')
+    .replace(/\{quadkey\}/g, '');
+}

--- a/src/lib/offline/use-viewport-prefetch.ts
+++ b/src/lib/offline/use-viewport-prefetch.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+
+import { useMap } from 'react-map-gl';
+
+import { collectCacheableTemplates, type StyleReader } from './templates';
+import { expandTemplate, tilesForBBox, OVERZOOM_MAX, type BBox } from './tiles';
+
+const DEBOUNCE_MS = 1500;
+const PREFETCH_CAP = 160; // tiles per layer across the zoom window — bounds bandwidth
+const ZOOM_PAD = 1; // warm one zoom level beyond the current view
+
+/**
+ * B — opportunistic prefetch for *accidental* offline. While online, after the
+ * map settles, quietly fetches the tiles immediately around the current view
+ * (this zoom ±1) for cacheable layers. The SW caches them, so a small zoom/pan
+ * after losing connection still renders instead of going blank.
+ *
+ * Deliberately conservative: debounced, capped, online-only, and skipped at high
+ * zoom where the tile count around a view explodes.
+ */
+export function useViewportPrefetch(mapId = 'default') {
+  const maps = useMap();
+  const map = (maps as Record<string, { getMap?: () => unknown } | undefined>)[mapId];
+
+  useEffect(() => {
+    const rawMap = (map?.getMap?.() ?? map) as
+      | (StyleReader & {
+          on?: (ev: string, cb: () => void) => void;
+          off?: (ev: string, cb: () => void) => void;
+          getZoom?: () => number;
+          getBounds?: () => { toArray: () => number[][] };
+        })
+      | undefined;
+    if (!rawMap?.on || !rawMap.getBounds) return;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const run = () => {
+      if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+      const templates = collectCacheableTemplates(rawMap);
+      if (!templates.length) return;
+
+      const z = Math.round(rawMap.getZoom?.() ?? 0);
+      const b = rawMap.getBounds?.()?.toArray?.(); // [[w,s],[e,n]]
+      if (!b) return;
+      const bbox: BBox = [b[0][0], b[0][1], b[1][0], b[1][1]];
+
+      // Warm the whole low pyramid (z0..current) for the view so zooming OUT
+      // offline stays filled; the cap drops the highest levels first if needed.
+      // Zooming IN past OVERZOOM_MAX is covered by Mapbox overzoom of cached tiles.
+      const zMax = Math.min(z + ZOOM_PAD, OVERZOOM_MAX);
+      const coords = tilesForBBox(bbox, 0, zMax, PREFETCH_CAP);
+      templates.forEach((tpl) => {
+        coords.forEach((t) => {
+          // Fire-and-forget — the SW intercepts and caches. Failures are ignored.
+          fetch(expandTemplate(tpl, t), { mode: 'cors' }).catch(() => {});
+        });
+      });
+    };
+
+    const onIdle = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(run, DEBOUNCE_MS);
+    };
+
+    rawMap.on('idle', onIdle);
+    return () => {
+      if (timer) clearTimeout(timer);
+      rawMap.off?.('idle', onIdle);
+    };
+  }, [map]);
+}

--- a/src/store/offline/index.ts
+++ b/src/store/offline/index.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+import type { OfflineRegion } from '@/lib/offline/regions';
+
+import { atom, useSetAtom } from 'jotai';
+
+// Tracks browser connectivity. SSR-safe default (true); corrected on mount by
+// useSyncOnlineStatus via the window online/offline events.
+export const isOnlineAtom = atom(true);
+
+// User-driven "work offline" toggle — forces the offline basemap + cached-only
+// behaviour even when a (flaky) connection is technically present.
+export const offlineModeAtom = atom(false);
+
+// True when the map should behave offline: either the network dropped or the
+// user opted into offline mode.
+export const isOfflineAtom = atom((get) => !get(isOnlineAtom) || get(offlineModeAtom));
+
+export type DownloadProgress = {
+  regionId: string | null;
+  status: 'idle' | 'running' | 'done' | 'error';
+  done: number;
+  total: number;
+  failed: number;
+};
+
+export const downloadProgressAtom = atom<DownloadProgress>({
+  regionId: null,
+  status: 'idle',
+  done: 0,
+  total: 0,
+  failed: 0,
+});
+
+// Downloaded regions, hydrated from IndexedDB (see useHydrateRegions).
+export const regionsAtom = atom<OfflineRegion[]>([]);
+
+/**
+ * Binds isOnlineAtom to the browser's connectivity events. Mount once near the
+ * app root (it returns nothing and renders nothing).
+ */
+export function useSyncOnlineStatus() {
+  const setIsOnline = useSetAtom(isOnlineAtom);
+
+  useEffect(() => {
+    const update = () => setIsOnline(navigator.onLine);
+    update();
+    window.addEventListener('online', update);
+    window.addEventListener('offline', update);
+    return () => {
+      window.removeEventListener('online', update);
+      window.removeEventListener('offline', update);
+    };
+  }, [setIsOnline]);
+}

--- a/src/store/offline/index.ts
+++ b/src/store/offline/index.ts
@@ -35,6 +35,22 @@ export const downloadProgressAtom = atom<DownloadProgress>({
 // Downloaded regions, hydrated from IndexedDB (see useHydrateRegions).
 export const regionsAtom = atom<OfflineRegion[]>([]);
 
+export type StorageStatus = {
+  // true = persistent (safe from auto-eviction); false = best-effort (may be
+  // dropped by the browser); null = Storage API unavailable/unknown.
+  persisted: boolean | null;
+  usage: number; // bytes used
+  quota: number; // bytes available
+};
+
+// Reflects navigator.storage state so the download panel can warn when offline
+// downloads are eviction-prone and show how much of the quota is used.
+export const storageStatusAtom = atom<StorageStatus>({
+  persisted: null,
+  usage: 0,
+  quota: 0,
+});
+
 /**
  * Binds isOnlineAtom to the browser's connectivity events. Mount once near the
  * app root (it returns nothing and renders nothing).

--- a/tests/offline.spec.ts
+++ b/tests/offline.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from './fixtures/test';
+
+/**
+ * Offline-maps service worker. Runs against the Playwright production server
+ * (NODE_ENV=production), so the SW registers — unlike `next dev`.
+ */
+test.describe('Offline maps service worker', () => {
+  test('registers and controls the page', async ({ page, browserName }) => {
+    test.fixme(browserName === 'firefox', 'Firefox: SW/hydration instability');
+
+    await page.goto('/');
+
+    // SW becomes active and claims the client (clients.claim in activate).
+    await page.waitForFunction(() => navigator.serviceWorker?.controller != null, null, {
+      timeout: 60000,
+    });
+
+    const scriptURL = await page.evaluate(async () => {
+      const reg = await navigator.serviceWorker.getRegistration();
+      return reg?.active?.scriptURL ?? null;
+    });
+    expect(scriptURL).toContain('/sw.js');
+  });
+
+  test('serves cached GCS tiles offline; Mapbox is never cached', async ({
+    page,
+    context,
+    browserName,
+  }) => {
+    test.fixme(browserName === 'firefox', 'Firefox: SW/hydration instability');
+
+    await page.goto('/');
+    await page.waitForFunction(() => navigator.serviceWorker?.controller != null, null, {
+      timeout: 60000,
+    });
+
+    // Warm the cache: let map tiles load.
+    await page.waitForTimeout(8000);
+
+    // Mapbox tiles must NOT be cached (TOS); our caches are origin-scoped.
+    const cacheState = await page.evaluate(async () => {
+      const names = await caches.keys();
+      const mangroveCaches = names.filter((n) => n.startsWith('mangrove-'));
+      let mapboxEntries = 0;
+      for (const name of names) {
+        const cache = await caches.open(name);
+        const reqs = await cache.keys();
+        mapboxEntries += reqs.filter((r) => /mapbox\.com/.test(r.url)).length;
+      }
+      return { mangroveCaches, mapboxEntries };
+    });
+
+    expect(cacheState.mangroveCaches.length).toBeGreaterThan(0);
+    expect(cacheState.mapboxEntries).toBe(0);
+
+    // Going offline keeps the app usable from cache (no crash on reload).
+    await context.setOffline(true);
+    await page.reload();
+    await expect(page.locator('body')).toBeVisible();
+    await context.setOffline(false);
+  });
+});

--- a/tools/extent-tiles/README.md
+++ b/tools/extent-tiles/README.md
@@ -46,6 +46,29 @@ NEXT_PUBLIC_EXTENT_TILES_URL=https://<BUCKET>.storage.googleapis.com/<PREFIX>/{y
 - **Big data:** global extent is large — use tippecanoe's `--drop-densest-as-needed` /
   `--coalesce-densest-as-needed` so low zooms don't blow the per-tile feature limit.
 
+## Already have a `.mbtiles` or `.pmtiles`? Just explode it
+mapbox-gl 3.x has **no `addProtocol`**, so it cannot read `.pmtiles` directly (MapLibre-only).
+If you already have per-year tiles in a container, skip tippecanoe and just explode + upload:
+
+```bash
+# from MBTiles:
+tile-join -e ./gmw_v4_extent_<year> gmw_v4_extent_<year>.mbtiles
+
+# from PMTiles (convert first):
+pmtiles convert gmw_v4_extent_<year>.pmtiles gmw_v4_extent_<year>.mbtiles
+tile-join -e ./gmw_v4_extent_<year> gmw_v4_extent_<year>.mbtiles
+
+gsutil -m -h "Content-Type:application/x-protobuf" -h "Content-Encoding:gzip" \
+  -h "Cache-Control:public,max-age=2592000" \
+  rsync -r ./gmw_v4_extent_<year> gs://<BUCKET>/<PREFIX>/gmw_v4_extent_<year>
+```
+Then `NEXT_PUBLIC_EXTENT_TILES_URL=https://<BUCKET>.storage.googleapis.com/<PREFIX>/gmw_v4_extent_{year}/{z}/{x}/{y}.pbf`.
+
+## Alternative: serve the `.pmtiles` as-is (no exploding)
+Keep the single `.pmtiles` and either (a) **migrate the renderer to MapLibre** (has `addProtocol`,
+reads `pmtiles://` natively), or (b) run a tiny **tile-server cloud function** that reads the
+`.pmtiles` via range and serves `{z}/{x}/{y}.pbf` to mapbox-gl. Both are more work than exploding.
+
 ## Alternative: PMTiles (single file)
 Instead of exploding to `{z}/{x}/{y}.pbf`, keep one `gmw_extent_<year>.pmtiles` on GCS and read it via
 the OSS `pmtiles` protocol. Cleaner hosting, but the offline SW must handle HTTP range/`206` responses

--- a/tools/extent-tiles/README.md
+++ b/tools/extent-tiles/README.md
@@ -1,0 +1,53 @@
+# Habitat-extent vector tiles (self-hosted, GEE-free)
+
+One-off / per-release data job that turns **GMW published mangrove-extent vector** into cacheable
+`{z}/{x}/{y}.pbf` (MVT) tiles on GCS, so the habitat-extent layer works **offline** and no longer
+depends on Mapbox-hosted tilesets.
+
+This is **not** a cloud function and **not** part of the Next.js build — it's a batch pipeline run by
+data engineering when GMW publishes new data. The frontend consumes the result via
+`NEXT_PUBLIC_EXTENT_TILES_URL` (see below).
+
+> **No Google Earth Engine.** The project is migrating off GEE. Source the extent from GMW's published
+> per-year vector (`.gpkg`/shapefile from Zenodo / UNEP-WCMC Ocean Data Viewer), **not** the GEE asset
+> `gmw_v4112_mng_ext`. The GEE asset is only one mirror of the same dataset.
+
+## Why these exact choices (must match the frontend)
+- **Vector, not raster** — extent must stay interactive (per-feature hover/click/`feature-state`).
+- **Layer name `gmw_v4_extent_<year>`** — `src/containers/datasets/habitat-extent/layer.tsx` reads
+  `source-layer: gmw_v4_extent_<year>`. The MVT layer name MUST match (tippecanoe `-l`).
+- **Zoom 0–12** — matches the source `maxzoom: 12` the frontend sets; Mapbox overzooms >12. Caching the
+  full z0–12 pyramid is what makes every zoom render offline.
+- **Same feature properties** as the current Mapbox tileset, so paint/filters are unchanged.
+
+## Prerequisites
+- `gdal`/`ogr2ogr` (vector conversion)
+- `tippecanoe` (Felt, OSS) + `tile-join`/`mb-util` (explode MBTiles → `{z}/{x}/{y}.pbf`)
+- `gcloud`/`gsutil` authenticated to the project (write to the `mangrove_atlas` bucket)
+
+## Run
+```bash
+# edit the vars at the top of the script first (YEARS, SRC_DIR, BUCKET, PREFIX)
+./build-extent-tiles.sh
+```
+
+## Output + wiring
+Tiles land at `gs://<BUCKET>/<PREFIX>/<year>/{z}/{x}/{y}.pbf`. Point the app at them:
+```
+NEXT_PUBLIC_EXTENT_TILES_URL=https://<BUCKET>.storage.googleapis.com/<PREFIX>/{year}/{z}/{x}/{y}.pbf
+```
+`{year}` is substituted per active year by `useSource()`; `{z}/{x}/{y}` are filled by Mapbox GL.
+
+## Critical gotchas
+- **gzip:** tippecanoe/MVT `.pbf` are gzip-compressed. Upload with `Content-Encoding: gzip` +
+  `Content-Type: application/x-protobuf`, or Mapbox GL fails to parse the tiles.
+- **CORS:** the bucket must allow cross-origin GET (see `bucket-cors.json`), else the browser blocks tiles.
+- **Cache-Control:** set a long max-age so browser/SW/CDN reuse tiles.
+- **Big data:** global extent is large — use tippecanoe's `--drop-densest-as-needed` /
+  `--coalesce-densest-as-needed` so low zooms don't blow the per-tile feature limit.
+
+## Alternative: PMTiles (single file)
+Instead of exploding to `{z}/{x}/{y}.pbf`, keep one `gmw_extent_<year>.pmtiles` on GCS and read it via
+the OSS `pmtiles` protocol. Cleaner hosting, but the offline SW must handle HTTP range/`206` responses
+(our current `{z}/{x}/{y}` caching does not) and the protocol addon is better supported on MapLibre.
+Exploded tiles are the lower-friction choice for the current mapbox-gl + SW setup.

--- a/tools/extent-tiles/bucket-cors.json
+++ b/tools/extent-tiles/bucket-cors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "origin": ["*"],
+    "method": ["GET", "HEAD"],
+    "responseHeader": ["Content-Type", "Content-Encoding", "Cache-Control"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/tools/extent-tiles/build-extent-tiles.sh
+++ b/tools/extent-tiles/build-extent-tiles.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Build self-hosted habitat-extent vector tiles (GEE-free) and publish to GCS.
+# See README.md. Source = GMW published per-year vector (.gpkg/shp), NOT GEE.
+#
+# Pipeline per year:  GMW vector -> GeoJSONSeq -> tippecanoe (MVT, layer
+# gmw_v4_extent_<year>, z0-12) -> explode to {z}/{x}/{y}.pbf -> gsutil to GCS
+# with gzip + cache + CORS.
+#
+set -euo pipefail
+
+# ---- configure -------------------------------------------------------------
+# Years the app exposes. Keep in sync with the habitat-extent widget.
+YEARS=(1996 2007 2008 2009 2010 2015 2016 2017 2018 2019 2020)
+
+# Directory holding the GMW source vector files, one per year. Expected name
+# pattern below (adjust to your download). Get GMW data from Zenodo / UNEP-WCMC
+# Ocean Data Viewer — NOT Google Earth Engine.
+SRC_DIR="${SRC_DIR:-./gmw-source}"
+SRC_PATTERN="gmw_v4_extent_%s.gpkg"   # %s = year
+
+# GCS destination.
+BUCKET="${BUCKET:-mangrove_atlas}"
+PREFIX="${PREFIX:-tilesets/gmw_extent}"
+
+# Tiling.
+MINZOOM=0
+MAXZOOM=12
+WORK_DIR="${WORK_DIR:-./.extent-tiles-work}"
+
+# ---- preflight -------------------------------------------------------------
+for bin in ogr2ogr tippecanoe tile-join gsutil; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: '$bin' not found on PATH"; exit 1; }
+done
+mkdir -p "$WORK_DIR"
+
+build_year() {
+  local year="$1"
+  local layer="gmw_v4_extent_${year}"
+  local src; src="$(printf "${SRC_DIR}/${SRC_PATTERN}" "$year")"
+  local geojson="${WORK_DIR}/${layer}.geojsonl"
+  local mbtiles="${WORK_DIR}/${layer}.mbtiles"
+  local tiles_dir="${WORK_DIR}/${layer}"
+
+  [ -f "$src" ] || { echo "WARN: missing source $src — skipping $year"; return 0; }
+
+  echo ">> [$year] vector -> GeoJSONSeq"
+  rm -f "$geojson"
+  ogr2ogr -f GeoJSONSeq -t_srs EPSG:4326 "$geojson" "$src"
+
+  echo ">> [$year] tippecanoe -> MVT (layer=$layer, z${MINZOOM}-${MAXZOOM})"
+  rm -f "$mbtiles"
+  # -l fixes the MVT layer name to match the frontend source-layer.
+  # --drop/coalesce-densest-as-needed keeps dense low zooms under the tile limit.
+  tippecanoe \
+    -o "$mbtiles" \
+    -l "$layer" \
+    -Z"$MINZOOM" -z"$MAXZOOM" \
+    --drop-densest-as-needed \
+    --coalesce-densest-as-needed \
+    --simplification=4 \
+    --force \
+    "$geojson"
+
+  echo ">> [$year] explode MBTiles -> {z}/{x}/{y}.pbf"
+  rm -rf "$tiles_dir"
+  # tile-join --output-to-directory writes {z}/{x}/{y}.pbf (gzip-compressed MVT).
+  tile-join --output-to-directory="$tiles_dir" --force "$mbtiles"
+
+  echo ">> [$year] upload -> gs://${BUCKET}/${PREFIX}/${year}/"
+  # .pbf are gzip MVT: set encoding + type + cache so Mapbox GL parses and the
+  # browser/SW/CDN reuse them. rsync uploads only changed tiles.
+  gsutil -m -h "Content-Type:application/x-protobuf" \
+             -h "Content-Encoding:gzip" \
+             -h "Cache-Control:public, max-age=2592000" \
+    rsync -r "$tiles_dir" "gs://${BUCKET}/${PREFIX}/${year}"
+}
+
+for y in "${YEARS[@]}"; do
+  build_year "$y"
+done
+
+echo ">> ensure bucket CORS allows browser GET"
+gsutil cors set "$(dirname "$0")/bucket-cors.json" "gs://${BUCKET}" || \
+  echo "WARN: could not set CORS (may need bucket-admin); see bucket-cors.json"
+
+cat <<EOF
+
+Done. Point the app at the tiles:
+  NEXT_PUBLIC_EXTENT_TILES_URL=https://${BUCKET}.storage.googleapis.com/${PREFIX}/{year}/{z}/{x}/{y}.pbf
+EOF


### PR DESCRIPTION
## Summary

Adds **offline map support** to Mangrove Atlas with **zero new runtime deps** — a hand-rolled service worker on the native Cache Storage API (Workbox/next-pwa intentionally avoided; not on the Tech Radar). Everything is **env-gated and non-breaking**: with the new env vars unset, behaviour is identical to today.

Two goals:
- **Accidental offline** — transparent cache + viewport prefetch keep recently-seen areas usable when the connection drops.
- **Deliberate offline** — a "download this area / work offline" control caches a region for field use.

## What's included

**Offline core** (`public/sw.js`, `src/lib/offline/*`, `src/store/offline`)
- Runtime caching: CacheFirst GCS tiles + offline basemap + alerts tiler; SWR for API JSON; CacheFirst `_next/static`; NetworkFirst document (boot offline). Persistent `mangrove-offline` cache for downloads. **Mapbox/Planet/POST never cached (TOS).**
- Viewport prefetch warms the z0–12 pyramid so Mapbox overzoom fills every zoom offline.
- Region download (IndexedDB index + SW message channel + progress), "Work offline" toggle, offline indicator.

**Offline scoping** — when offline, sidebar widgets **and** map layers are restricted to **extent + alerts** (platform `opacity-40` convention); country-boundaries (Mapbox vector) hidden offline.

**Self-hosting (TOS-safe tiles)**
- **Alerts (Phase 1):** `alerts-tiler` now emits `scr5_obs_date` in tile tags (the FE styles by it) + `Cache-Control`. FE renders from the tiler when `NEXT_PUBLIC_ALERTS_TILER_URL` is set (`source-layer geojsonLayer`, z9–14), else Mapbox.
- **Extent (FE groundwork):** renders from self-hosted `{z}/{x}/{y}.pbf` when `NEXT_PUBLIC_EXTENT_TILES_URL` is set, else Mapbox. Pipeline scaffold in `tools/extent-tiles/` (GEE-free; GMW vector → tippecanoe → GCS).
- **Offline basemap:** swaps to a self-hosted raster style when `NEXT_PUBLIC_OFFLINE_BASEMAP_URL` is set (Mapbox base can't be cached).

## New env vars (all optional)
- `NEXT_PUBLIC_ALERTS_TILER_URL` — deployed alerts-tiler URL.
- `NEXT_PUBLIC_EXTENT_TILES_URL` — `{year}` + `{z}/{x}/{y}.pbf` template on GCS.
- `NEXT_PUBLIC_OFFLINE_BASEMAP_URL` — TOS-safe raster XYZ basemap.

## Activation checklist (ops/data — no app code)
- [ ] Generate extent tiles (explode `.mbtiles`/`.pmtiles` → `{z}/{x}/{y}.pbf` on GCS; set CORS + gzip + cache) → set `NEXT_PUBLIC_EXTENT_TILES_URL`.
- [ ] Redeploy `alerts-tiler` (for `scr5_obs_date` + cache header) → set `NEXT_PUBLIC_ALERTS_TILER_URL`.
- [ ] Provide a TOS-safe raster basemap → set `NEXT_PUBLIC_OFFLINE_BASEMAP_URL`.
- [ ] Align extent year list with the generated tiles.

## Test plan
- [ ] `pnpm build && pnpm start` (SW is prod-gated) → DevTools → Application → Service Workers: `/sw.js` active.
- [ ] Pan/zoom a mangrove area → Cache Storage `mangrove-*` fills with GCS/tiler tiles + API JSON; **no** `api.mapbox.com` entries.
- [ ] DevTools → Network → Offline (or in-app "Work offline"): cached area + extent/alerts render; other widgets/layers greyed/hidden; basemap from self-hosted raster (if configured).
- [ ] Download a region → reload offline → region renders from `mangrove-offline`.
- [ ] `npx playwright test tests/offline.spec.ts` (written; not yet run in CI).

## Caveats / known limits
- Mapbox base/vector layers can't be cached (TOS) → offline relies on self-hosted tiles.
- Alerts tiler is **z9–14** (no alerts below z9) and dynamic (BigQuery per uncached tile) — mitigated by cache header; low-zoom alerts = heatmap layer (follow-up).
- Drawn-area analysis (POST) not cached.
- `mapbox-gl` 3.x has no `addProtocol` → `.pmtiles` can't be read directly; extent uses exploded `{z}/{x}/{y}` (MapLibre would be a separate future migration).