### PR TITLE
feat: implement gain-loss-v4 tilesets for net change layer (GMW-1035)

### DIFF
--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -340,24 +340,36 @@ export function useMangroveNetChange(
   };
 }
 
-export function useSources(fluctuation): SourceProps[] {
+// Pure source-builder: one combined gain/loss v4 raster per year in the
+// (startYear, endYear] window. Exclusive lower bound — the start year is the
+// baseline, so change is only shown from the year after it onward.
+export function getNetChangeSources(
+  years: number[],
+  startYear: number,
+  endYear: number
+): SourceProps[] {
+  const filteredYears = years?.filter((year) => year <= endYear && year > startYear);
+
+  return filteredYears?.map((year) => ({
+    id: `net-change-${year}`,
+    type: 'raster',
+    tiles: [
+      `https://storage.googleapis.com/mangrove_atlas/staging/tilesets/gain-loss-v4/${year}/{z}/{x}/{y}.png`,
+    ],
+    minZoom: 0,
+    maxZoom: 12,
+  }));
+}
+
+export function useSources(): SourceProps[] {
   const startYear = useAtomValue(netChangeStartYear);
   const endYear = useAtomValue(netChangeEndYear);
   const { years, currentEndYear, currentStartYear } = useMangroveNetChange({
     startYear,
     endYear,
   });
-  const filteredYears = years?.filter((year) => year <= currentEndYear && year > currentStartYear);
 
-  return filteredYears?.map((year) => ({
-    id: `net-change-${year}-${fluctuation}`,
-    type: 'raster',
-    tiles: [
-      `https://mangrove_atlas.storage.googleapis.com/staging/tilesets/${fluctuation}/${year}/{z}/{x}/{y}.png`,
-    ],
-    minZoom: 0,
-    maxZoom: 12,
-  }));
+  return getNetChangeSources(years, currentStartYear, currentEndYear);
 }
 
 export function useLayer({

--- a/src/containers/datasets/net-change/layer.tsx
+++ b/src/containers/datasets/net-change/layer.tsx
@@ -10,21 +10,18 @@ const NetChangeLayer = ({ beforeId, id }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
 
-  const sourceLoss = useSources('loss') satisfies SourceProps[];
-  const sourceGain = useSources('gain') satisfies SourceProps[];
+  const sources = useSources() satisfies SourceProps[];
   const LAYER = useLayer({
     id,
     opacity: parseFloat(activeLayer.opacity),
     visibility: activeLayer.visibility,
   });
 
-  if (!LAYER || !sourceLoss || !sourceGain) return null;
-
-  const SOURCES = [...sourceGain, ...sourceLoss];
+  if (!LAYER || !sources) return null;
 
   return (
     <>
-      {SOURCES.map((SOURCE) => (
+      {sources.map((SOURCE) => (
         <Source key={SOURCE.id} {...SOURCE}>
           <Layer key={`${SOURCE.id}-layer`} {...LAYER} id={SOURCE.id} beforeId={beforeId} />
         </Source>

--- a/tests/unit/containers/datasets/net-change/hooks.test.ts
+++ b/tests/unit/containers/datasets/net-change/hooks.test.ts
@@ -1,5 +1,14 @@
-import { getFormat, getWidgetData, mockGainLoss } from '@/containers/datasets/net-change/hooks';
+import {
+  getFormat,
+  getNetChangeSources,
+  getWidgetData,
+  mockGainLoss,
+} from '@/containers/datasets/net-change/hooks';
 import type { Data } from '@/containers/datasets/net-change/types';
+
+// The raster member of react-map-gl's SourceProps union — the only variant
+// getNetChangeSources emits. Narrow to it so `tiles` is accessible in asserts.
+type RasterSource = { id: string; type: 'raster'; tiles: string[] };
 
 const rows = [
   { year: 2000, net_change: 0, gain: 0, loss: 0 },
@@ -53,6 +62,44 @@ describe('getWidgetData', () => {
     expect(result[0]['Net result']).toBe(0);
     expect(result[1]['Net result']).toBe(5);
     expect(result[2]['Net result']).toBe(3);
+  });
+});
+
+describe('getNetChangeSources', () => {
+  const years = [1986, 1996, 2007, 2015, 2020, 2025];
+
+  it('builds one combined raster source per year in the (start, end] window', () => {
+    const sources = getNetChangeSources(years, 1996, 2020);
+    // exclusive lower bound (1996 dropped), inclusive upper bound (2020 kept)
+    expect(sources.map((s) => s.id)).toEqual([
+      'net-change-2007',
+      'net-change-2015',
+      'net-change-2020',
+    ]);
+  });
+
+  it('points each source at the gain-loss-v4 combined tileset for its year', () => {
+    const [source] = getNetChangeSources(years, 1996, 2020) as RasterSource[];
+    expect(source).toMatchObject({
+      id: 'net-change-2007',
+      type: 'raster',
+      minZoom: 0,
+      maxZoom: 12,
+    });
+    expect(source.tiles).toEqual([
+      'https://storage.googleapis.com/mangrove_atlas/staging/tilesets/gain-loss-v4/2007/{z}/{x}/{y}.png',
+    ]);
+  });
+
+  it('emits a single source per year (no separate gain/loss)', () => {
+    const sources = getNetChangeSources(years, 2015, 2025) as RasterSource[];
+    expect(sources).toHaveLength(2); // 2020, 2025
+    expect(sources.every((s) => s.tiles?.length === 1)).toBe(true);
+    expect(sources.every((s) => !/\/(gain|loss)\//.test(s.tiles[0]))).toBe(true);
+  });
+
+  it('excludes the start year and returns empty when the window is degenerate', () => {
+    expect(getNetChangeSources(years, 2025, 2025)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Context

[GMW-1035](https://vizzuality.atlassian.net/browse/GMW-1035) — new Gain/Loss tilesets (1986–2025) are published in the GCS bucket:

```
https://storage.googleapis.com/mangrove_atlas/staging/tilesets/gain-loss-v4/{YEAR}/{z}/{x}/{y}.png
```

Unlike the old tilesets (two separate rasters per year: `/gain/{year}/` + `/loss/{year}/`), v4 is a **single combined** raster per year (gain + loss baked into one PNG). This PR points the net-change map layer at the new v4 URL and collapses the two-source setup into one.

Backend metadata (`data.metadata.year`) already returns the full 1986–2025 range, so the year list flows through automatically.

## Changes

- **`hooks.tsx`** — extract pure `getNetChangeSources(years, start, end)` from `useSources`; emit one combined raster source per year at the gain-loss-v4 URL (source id `net-change-${year}`, was `net-change-${year}-${fluctuation}`). Year filter, `minZoom`/`maxZoom` unchanged.
- **`layer.tsx`** — single `useSources()` call, drop the gain/loss merge.
- **`hooks.test.ts`** — 4 new unit tests covering the `(start, end]` window, the v4 URL, single-source-per-year (no gain/loss split), and the degenerate window.

Unchanged: chart, legend, colours, `applyMockGainLoss`, store atoms, widget registry.

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm test:unit` — 13/13 pass (9 existing + 4 new)
- [x] `pnpm lint` clean
- [ ] Manual: enable **Mangrove Net Change** layer, confirm Network requests hit `.../gain-loss-v4/{year}/...png` (single set per year, no `/gain/` or `/loss/`)
- [ ] Manual: year selector/brush exposes 1986–2025 and dragging loads matching v4 tiles
- [ ] Manual: map renders combined gain/loss raster over mangrove areas

[GMW-1035]: https://vizzuality.atlassian.net/browse/GMW-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ