### PR TITLE
feat: implement new net change design + shared chart tick/brush (GMW-845)

### DIFF
--- a/src/components/chart/brush/component.tsx
+++ b/src/components/chart/brush/component.tsx
@@ -4,6 +4,8 @@ import { memo, useCallback, useRef, useState } from 'react';
 
 import { SVGBrushProps, Point, Box, SVGBrushEvent } from '@/components/chart/types';
 
+import DRAGGER_SVG from '@/svgs/ui/dragger';
+
 const defaultGetEventMouse = (event: React.PointerEvent<SVGElement>): Point => [
   event.clientX,
   event.clientY,
@@ -37,13 +39,14 @@ function SVGBrushComponent({
   brushType = '2d',
   scale,
   shadowFilterId,
+  stripePatternId,
 }: SVGBrushProps) {
   const [internalSelection, setInternalSelection] = useState<Box | null>(
     controlledSelection ?? null
   );
   const moveRef = useRef<Point | null>(null);
-  const handleERef = useRef<SVGRectElement | null>(null);
-  const handleWRef = useRef<SVGRectElement | null>(null);
+  const handleERef = useRef<SVGCircleElement | null>(null);
+  const handleWRef = useRef<SVGCircleElement | null>(null);
 
   const selection = controlledSelection === undefined ? internalSelection : controlledSelection;
 
@@ -120,9 +123,6 @@ function SVGBrushComponent({
   const w = Math.max(0, Number.isFinite(x1 - x0) ? x1 - x0 : 0);
   const h = Number.isFinite(y1 - y0) ? y1 - y0 : 0;
 
-  const hW = 1;
-  const hH = Math.max(0, h - 10);
-
   return (
     <g className="brush">
       <rect
@@ -136,8 +136,7 @@ function SVGBrushComponent({
       />
 
       <rect
-        fill="url(#diagonal-stripe-1)"
-        fillOpacity="0.75"
+        fill={`url(#${stripePatternId})`}
         shapeRendering="crispEdges"
         x={ex0}
         y={ey0}
@@ -147,14 +146,28 @@ function SVGBrushComponent({
       />
 
       <rect
-        fill="url(#diagonal-stripe-1)"
-        fillOpacity="0.75"
+        fill={`url(#${stripePatternId})`}
         shapeRendering="crispEdges"
         x={x1}
         y={ey0}
         width={Math.max(0, Number.isFinite(ex1 - x1) ? ex1 - x1 : 0)}
         height={Math.max(0, h - 2)}
         pointerEvents="all"
+      />
+
+      {/* Visible rounded border around the selected range. Non-interactive so
+          drags fall through to the hit rect below. */}
+      <rect
+        pointerEvents="none"
+        fill="none"
+        stroke="rgba(0, 0, 0, 0.85)"
+        strokeWidth={2}
+        x={x - 1}
+        y={y - 4}
+        width={w + 2}
+        // Bottom border lands on the middle of the x-axis tick marks (not their base).
+        height={Math.max(0, h + 5)}
+        rx={8}
       />
 
       <rect
@@ -209,17 +222,14 @@ function SVGBrushComponent({
         onPointerUp={handleBrushEnd}
       />
 
-      <g transform={`translate(${x + w - hW / 2}, ${y + 5})`}>
-        <rect
+      <g transform={`translate(${x + w}, ${y + h / 2})`}>
+        <circle
           ref={handleERef}
           className="handle handle--e"
           cursor="ew-resize"
-          width={hW}
-          height={hH}
-          fill="rgba(0, 0, 0, 0.85)"
-          stroke="rgba(0, 0, 0, 0.85)"
-          filter={`url(#${shadowFilterId})`}
-          pointerEvents="visible"
+          r={9}
+          fill="transparent"
+          pointerEvents="all"
           onPointerDown={handleBrushStart}
           onPointerMove={(event) => {
             const move = moveRef.current;
@@ -272,27 +282,24 @@ function SVGBrushComponent({
           }}
           onPointerUp={handleBrushEnd}
         />
-        <polygon
-          points="0.5,-5 0.5,5 6,-5"
-          style={{
-            fill: 'rgba(0,0,0,0.85)',
-            stroke: 'rgba(0,0,0,0.85)',
-            strokeWidth: 1,
-          }}
+        <DRAGGER_SVG
+          x={-8}
+          y={-8}
+          width={16}
+          height={16}
+          filter={`url(#${shadowFilterId})`}
+          pointerEvents="none"
         />
       </g>
 
-      <g transform={`translate(${x - hW / 2}, ${y + 5})`}>
-        <rect
+      <g transform={`translate(${x}, ${y + h / 2})`}>
+        <circle
           ref={handleWRef}
           className="handle handle--w"
           cursor="ew-resize"
-          width={hW}
-          height={hH}
-          fill="rgba(0, 0, 0, 0.85)"
-          stroke="rgba(0, 0, 0, 0.85)"
-          filter={`url(#${shadowFilterId})`}
-          pointerEvents="visible"
+          r={9}
+          fill="transparent"
+          pointerEvents="all"
           onPointerDown={handleBrushStart}
           onPointerMove={(event) => {
             const move = moveRef.current;
@@ -345,13 +352,13 @@ function SVGBrushComponent({
           }}
           onPointerUp={handleBrushEnd}
         />
-        <polygon
-          points="-5,-5 0.5,5 0.5,-5"
-          style={{
-            fill: 'rgba(0,0,0,0.85)',
-            stroke: 'rgba(0,0,0,0.85)',
-            strokeWidth: 1,
-          }}
+        <DRAGGER_SVG
+          x={-8}
+          y={-8}
+          width={16}
+          height={16}
+          filter={`url(#${shadowFilterId})`}
+          pointerEvents="none"
         />
       </g>
     </g>

--- a/src/components/chart/brush/index.tsx
+++ b/src/components/chart/brush/index.tsx
@@ -81,6 +81,7 @@ function BrushComponent<T>({
   const [brushSelection, setBrushSelection] = useState<Box | null>(null);
 
   const shadowFilterId = useId().replace(/:/g, '');
+  const stripePatternId = `brush-stripe-${useId().replace(/:/g, '')}`;
 
   const ready = useMemo(() => {
     return !!(svgWidth && svgHeight && data.length > 1);
@@ -123,6 +124,19 @@ function BrushComponent<T>({
     <div className="c-brush">
       <svg ref={svgRef} className="brush--svg" width={width} height={height}>
         <defs>
+          {/* Dedicated brush hatch: thin diagonal lines on a transparent tile so the
+              underlying data (solid bars / lines) stays visible in the unselected
+              region. Kept separate from any widget's `diagonal-stripe-1` (e.g. the
+              alerts main-chart area fill) so all brushes render the same light hatch. */}
+          <pattern
+            id={stripePatternId}
+            patternUnits="userSpaceOnUse"
+            patternTransform="rotate(-45)"
+            width={6}
+            height={6}
+          >
+            <rect x={0} y={0} width={1} height={6} fill="rgba(0,0,0,0.85)" />
+          </pattern>
           <filter id={shadowFilterId} x="-20%" y="-20%" width="140%" height="140%">
             <feDropShadow
               stdDeviation="2"
@@ -153,6 +167,7 @@ function BrushComponent<T>({
             brushType="x"
             selection={brushSelection}
             shadowFilterId={shadowFilterId}
+            stripePatternId={stripePatternId}
             onBrush={({ selection }) => {
               setBrushSelection(selection);
             }}

--- a/src/components/chart/chart-tick.tsx
+++ b/src/components/chart/chart-tick.tsx
@@ -1,0 +1,70 @@
+import type { FC } from 'react';
+
+// Max year/date labels drawn on an axis before we thin them so they never crowd.
+export const MAX_TICK_LABELS = 8;
+
+// Whether a tick at `index` should render its label: evenly spaced positions plus
+// the last tick, so a dense axis shows a readable, non-overlapping subset.
+export function shouldShowTickLabel(
+  index: number,
+  visibleTicksCount: number,
+  maxLabels: number = MAX_TICK_LABELS
+): boolean {
+  const step = Math.max(1, Math.ceil(visibleTicksCount / maxLabels));
+  return index % step === 0 || index === visibleTicksCount - 1;
+}
+
+export type ChartTickProps = {
+  // Injected by recharts.
+  x?: number;
+  y?: number;
+  payload?: { value: string | number };
+  index?: number;
+  visibleTicksCount?: number;
+  // Per-widget customization (defaults match the design spec).
+  offsetY?: number; // vertical gap between the tick mark and its label
+  fontSize?: number;
+  textAnchor?: 'start' | 'middle' | 'end';
+  maxLabels?: number;
+  angle?: number; // rotate the label (e.g. -90 for vertical month labels)
+};
+
+// Shared axis tick used across widget charts/brushes so tick↔label padding and
+// typography stay consistent. Widgets tweak only fontSize / textAnchor / maxLabels.
+const ChartTick: FC<ChartTickProps> = ({
+  x = 0,
+  y = 0,
+  payload,
+  index = 0,
+  visibleTicksCount = 1,
+  offsetY = 16,
+  fontSize = 12,
+  textAnchor = 'middle',
+  maxLabels = MAX_TICK_LABELS,
+  angle,
+}) => {
+  if (!shouldShowTickLabel(index, visibleTicksCount, maxLabels)) {
+    return <g transform={`translate(${x},${y})`} />;
+  }
+  const rotated = typeof angle === 'number';
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        x={0}
+        y={offsetY}
+        // Rotate around the tick point so vertical labels hang straight below it.
+        transform={rotated ? `rotate(${angle}, 0, ${offsetY})` : undefined}
+        textAnchor={rotated ? 'end' : textAnchor}
+        dominantBaseline={rotated ? 'central' : undefined}
+        fill="rgba(0,0,0,0.56)"
+        fontFamily="Open Sans"
+        fontWeight={400}
+        fontSize={`${fontSize}px`}
+      >
+        {payload?.value}
+      </text>
+    </g>
+  );
+};
+
+export default ChartTick;

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -77,7 +77,9 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
   return (
     <div
       className={cn({
-        'relative h-full w-full': true,
+        // `chart-overflow-visible` lets axis labels that overflow the plot stay
+        // visible (edge tick labels would otherwise be clipped by the svg surface).
+        'chart-overflow-visible relative h-full w-full': true,
         className,
       })}
     >

--- a/src/components/chart/types.d.ts
+++ b/src/components/chart/types.d.ts
@@ -70,6 +70,7 @@ export type SVGBrushProps = {
   brushType?: BrushType;
   scale: ScaleLinear<number, number>;
   shadowFilterId: string;
+  stripePatternId: string;
 };
 
 export type Margin = {

--- a/src/components/contextual-layers/index.tsx
+++ b/src/components/contextual-layers/index.tsx
@@ -34,7 +34,7 @@ const ContextualLayersComponent = ({
   if (isPrintReport && !isActive) return null;
 
   return (
-    <div className="bg-brand-800/10 relative flex flex-col space-y-5 rounded-3xl p-3">
+    <div className="bg-brand-800/10 relative flex flex-col space-y-5 rounded-2xl p-4">
       <div className="flex items-center justify-between space-x-8">
         <div className="flex items-center">
           <div className="flex items-center space-x-4">

--- a/src/containers/datasets/alerts-staging/hooks.tsx
+++ b/src/containers/datasets/alerts-staging/hooks.tsx
@@ -17,6 +17,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
+import ChartTick from '@/components/chart/chart-tick';
 import { Visibility } from '@/types/layers';
 import type { DateOption } from 'types/widget';
 
@@ -75,28 +76,6 @@ const getData = (data) =>
     }),
     ['month']
   );
-
-const TickSmall = ({ x, y, payload }) => {
-  const { value } = payload;
-  return (
-    <g transform={`translate(${x},${y})`}>
-      <text x={0} y={5} textAnchor="end" fill="#3A3F59" opacity={0.7} fontSize="10px">
-        {value}
-      </text>
-    </g>
-  );
-};
-
-const DefaultTick = ({ x, y, payload }) => {
-  const { value } = payload;
-  return (
-    <g transform={`translate(${x},${y})`}>
-      <text x={0} y={5} fill="#3A3F59" opacity={0.5} fontSize="12px">
-        {value}
-      </text>
-    </g>
-  );
-};
 
 const getTotal = (data: { count: number }[]) =>
   data?.reduce((previous: number, current: { count: number }) => current.count + previous, 0);
@@ -192,7 +171,7 @@ export function useAlerts<DataResponse>(
           vertical: false,
           horizontal: false,
         },
-        margin: { top: 50, right: 10, left: 10, bottom: 35 },
+        margin: { top: 50, right: 10, left: 10, bottom: 55 },
         label: 'alerts',
         xKey: 'name',
         chartBase: {
@@ -205,7 +184,12 @@ export function useAlerts<DataResponse>(
           },
         },
         xAxis: {
-          tick: TickSmall,
+          tick: <ChartTick fontSize={10} angle={-90} />,
+          // A tick mark at every month; ChartTick thins the labels so they don't crowd.
+          interval: 0,
+          axisLine: false,
+          tickLine: { stroke: 'rgba(0,0,0,0.3)' },
+          tickSize: 6,
           type: 'category',
         },
         yAxis: {
@@ -332,10 +316,13 @@ export function useAlerts<DataResponse>(
           },
         },
         xAxis: {
-          tick: DefaultTick,
+          tick: <ChartTick />,
           ticks: Array.from(new Set(fixedXAxis)),
           interval: 0,
           type: 'category',
+          axisLine: false,
+          tickLine: { stroke: 'rgba(0,0,0,0.3)' },
+          tickSize: 6,
         },
 
         tooltip: false,

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -24,6 +24,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
+import ChartTick from '@/components/chart/chart-tick';
 import { Visibility } from '@/types/layers';
 
 import API_cloud_functions from 'services/cloud-functions';
@@ -173,36 +174,6 @@ const getData = (data) =>
     ['month']
   );
 
-const TickSmall = ({ x, y, payload }) => {
-  const { value } = payload;
-  return (
-    <g transform={`translate(${x},${y})`}>
-      <text x={0} y={5} textAnchor="end" fill="#3A3F59" opacity={0.7} fontSize="10px">
-        {value}
-      </text>
-    </g>
-  );
-};
-
-// recharts draws the tick line for every tick; this only decides whether to
-// render the label, thinning labels when they would crowd (a tick stays at
-// every date, but not every date gets a label).
-const MAX_TICK_LABELS = 8;
-const DefaultTick = ({ x, y, payload, index = 0, visibleTicksCount = 1 }) => {
-  const { value } = payload;
-  const step = Math.max(1, Math.ceil(visibleTicksCount / MAX_TICK_LABELS));
-  const showLabel = index % step === 0 || index === visibleTicksCount - 1;
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {showLabel && (
-        <text x={0} y={16} textAnchor="middle" fill="#3A3F59" opacity={0.5} fontSize="12px">
-          {value}
-        </text>
-      )}
-    </g>
-  );
-};
-
 const getTotal = (data: { count: number }[]) =>
   data?.reduce((previous: number, current: { count: number }) => current.count + previous, 0);
 
@@ -304,7 +275,7 @@ export function useAlerts<TRaw = AlertsApiResponse>(
         dataKey: 'alerts',
         height: 350,
         cartesianGrid: { vertical: false, horizontal: false },
-        margin: { top: 50, right: 10, left: 10, bottom: 35 },
+        margin: { top: 50, right: 10, left: 10, bottom: 55 },
         label: 'alerts',
         xKey: 'name',
         chartBase: {
@@ -341,7 +312,16 @@ export function useAlerts<TRaw = AlertsApiResponse>(
             },
           },
         },
-        xAxis: { tick: TickSmall, type: 'category' },
+        xAxis: {
+          // Vertical month labels with tick marks (no axis line), per design.
+          tick: <ChartTick fontSize={10} angle={-90} />,
+          type: 'category',
+          // A tick mark at every month; ChartTick thins the labels so they don't crowd.
+          interval: 0,
+          axisLine: false,
+          tickLine: { stroke: 'rgba(0,0,0,0.3)' },
+          tickSize: 6,
+        },
         yAxis: {
           tick: { fontSize: 10, fill: 'rgba(0,0,0,0.54)' },
           width: 40,
@@ -414,7 +394,7 @@ export function useAlerts<TRaw = AlertsApiResponse>(
           },
         },
         xAxis: {
-          tick: DefaultTick,
+          tick: <ChartTick />,
           ticks: Array.from(new Set(fixedXAxis)),
           interval: 0,
           type: 'category',

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -16,6 +16,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
+import ChartTick from '@/components/chart/chart-tick';
 import CustomTooltip from '@/components/chart/tooltip';
 import { Visibility } from '@/types/layers';
 import { env } from 'env.mjs';
@@ -51,35 +52,13 @@ export const applyMockGainLoss = (rows: Data[] = []): Data[] =>
     ? rows.map((row) => (row.gain == null ? { ...row, ...mockGainLoss(row.net_change) } : row))
     : rows;
 
-// Axis tick used by the brush track — matches the alerts widget so both
-// brushes render identically. recharts draws the tick line for every tick;
-// this only decides whether to render the label, thinning labels when they
-// would crowd (a tick stays at every date, but not every date gets a label).
-const MAX_TICK_LABELS = 8;
-const DefaultTick = ({
-  x,
-  y,
-  payload,
-  index = 0,
-  visibleTicksCount = 1,
-}: {
-  x: number;
-  y: number;
-  payload: { value: number };
-  index?: number;
-  visibleTicksCount?: number;
-}) => {
-  const step = Math.max(1, Math.ceil(visibleTicksCount / MAX_TICK_LABELS));
-  const showLabel = index % step === 0 || index === visibleTicksCount - 1;
-  return (
-    <g transform={`translate(${x},${y})`}>
-      {showLabel && (
-        <text x={0} y={16} textAnchor="middle" fill="#3A3F59" opacity={0.5} fontSize="12px">
-          {payload.value}
-        </text>
-      )}
-    </g>
-  );
+// Shared axis label style (design spec): Open Sans 12/20, weight 400, black 56%.
+// Used for recharts' built-in tick text (main chart); the brush uses <ChartTick />.
+const AXIS_TICK = {
+  fontSize: 12,
+  fontFamily: 'Open Sans',
+  fontWeight: 400,
+  fill: 'rgba(0, 0, 0, 0.56)',
 };
 
 export const getFormat = (v) => {
@@ -218,9 +197,14 @@ export function useMangroveNetChange(
 
   const change = DATA[DATA.length - 1]?.['Net result'];
 
-  // Brush selection indices (positions of the selected years in the full series).
-  const startIndex = Math.max(years?.indexOf(currentStartYear) ?? 0, 0);
-  const endIndex = years?.indexOf(currentEndYear) ?? Math.max((years?.length ?? 1) - 1, 0);
+  // Brush selection indices — positions within the FULL brush series (DATA_FULL),
+  // which is what the brush chart actually plots. The metadata `years` list can be
+  // shorter/different, which mislocates the selection box (e.g. only covering the
+  // first fraction of the track).
+  const fullYears = DATA_FULL.map((d) => d.year);
+  const startIndex = Math.max(fullYears.indexOf(currentStartYear), 0);
+  const endIndexRaw = fullYears.indexOf(currentEndYear);
+  const endIndex = endIndexRaw === -1 ? Math.max(fullYears.length - 1, 0) : endIndexRaw;
 
   // Shared by the main chart and the brush track. Same stackId stacks gain/loss
   // per year at the same x; gain is always positive and loss negative, so
@@ -235,6 +219,13 @@ export function useMangroveNetChange(
     },
   };
 
+  // Even, never-clipped year labels for the main chart: derived from the visible
+  // window so gaps stay uniform whatever the selected range.
+  const xTicks = getEvenlySpacedTicks(
+    DATA.map((d) => d.year),
+    5
+  );
+
   const chartConfig = {
     type: 'composed',
     data: DATA,
@@ -245,19 +236,30 @@ export function useMangroveNetChange(
     // Bars sit flush — no gap between categories or between the gain/loss pair.
     barCategoryGap: 0,
     barGap: 0,
-    margin: { top: 40, right: 20, bottom: 20, left: 0 },
-    referenceLines: [{ y: 0, label: null, stroke: 'rgba(0,0,0,0.5)' }],
+    // Left/right room so the first and last year labels are never clipped.
+    margin: { top: 40, right: 24, bottom: 20, left: 16 },
     xAxis: {
       type: 'category',
-      tick: { fontSize: 12, fill: 'rgba(0, 0, 0, 0.54)' },
-      interval: 'equidistantPreserveStart',
+      tick: { ...AXIS_TICK },
+      // Explicit, evenly spaced ticks; no tick marks or baseline on the top chart.
+      ticks: xTicks,
+      interval: 0,
+      // Even-by-index spacing (point scale) so labels are equidistant regardless of
+      // gaps in the data years.
+      scale: 'point',
+      tickLine: false,
+      axisLine: false,
+      // Inset first/last ticks so their labels never overflow the axis edges.
+      padding: { left: 16, right: 16 },
     },
     yAxis: {
-      tick: { fontSize: 12, fill: 'rgba(0, 0, 0, 0.54)' },
+      tick: { ...AXIS_TICK },
       tickFormatter: (v) => {
         const parsedNumber = unit === 'ha' ? v * 100 : v;
         const result = Number(getFormat(Math.abs(parsedNumber)));
-        return result === 0 ? 0 : result;
+        if (result === 0) return 0;
+        // Loss sits below the zero baseline — keep the sign so negative levels read as "-N".
+        return v < 0 ? `-${result}` : result;
       },
       tickMargin: 10,
       orientation: 'right',
@@ -290,27 +292,19 @@ export function useMangroveNetChange(
     cartesianGrid: { vertical: false, horizontal: false },
     // Wider side margins so the centered first/last year labels aren't clipped.
     margin: { top: 20, right: 40, left: 24, bottom: 5 },
-    patterns: {
-      diagonal: {
-        attributes: {
-          id: 'diagonal-stripe-1',
-          patternUnits: 'userSpaceOnUse',
-          patternTransform: 'rotate(-45)',
-          width: 4,
-          height: 6,
-        },
-        children: {
-          rect2: { tag: 'rect', x: 0, y: 0, width: 4, height: 6, fill: '#d2d2d2' },
-          rect: { tag: 'rect', x: 0, y: 0, width: 3, height: 6, fill: '#fff' },
-        },
-      },
-    },
+    // Brush hatch for the unselected region is provided by the shared Brush
+    // component itself (see components/chart/brush), so no per-widget pattern here.
     xKey: 'year',
     xAxis: {
-      tick: DefaultTick,
-      ticks: years,
+      tick: <ChartTick />,
+      // Evenly spaced subset of the full brush series so year labels never crowd
+      // and always sit on real categories the chart plots.
+      ticks: getEvenlySpacedTicks(fullYears, 6),
       interval: 0,
       type: 'category',
+      // Even-by-index spacing so bars + labels align with the index-based brush
+      // overlay (otherwise a numeric year axis spaces them by value and misaligns).
+      scale: 'point',
       dataKey: 'year',
       axisLine: false,
       tickLine: { stroke: 'rgba(0,0,0,0.3)' },
@@ -318,10 +312,14 @@ export function useMangroveNetChange(
     },
     // Hidden, padded y-domain so the bars/line stay inset rather than filling
     // the full height.
-    yAxis: { hide: true, domain: [(min: number) => min * 1.4, (max: number) => max * 1.4] },
+    // Extra padding keeps the bars inset within the selection box (bars fill ~55%
+    // of the height, leaving even space above/below like the design).
+    yAxis: { hide: true, domain: [(min: number) => min * 1.9, (max: number) => max * 1.9] },
     chartBase,
     tooltip: false,
-    customBrush: { margin: { top: 60, right: 20, left: 15, bottom: 80 }, startIndex, endIndex },
+    // Horizontal margins match the composed chart above (left 24 / right 40) so the
+    // selection box and draggers line up with the bars and year labels.
+    customBrush: { margin: { top: 60, right: 40, left: 24, bottom: 80 }, startIndex, endIndex },
   };
 
   const direction = change > 0 ? 'increased' : 'decreased';
@@ -330,6 +328,9 @@ export function useMangroveNetChange(
     configBrush,
     location,
     years,
+    // Full series the brush plots (can differ from metadata `years`); the widget
+    // maps brush drag indices back to years through this so the window updates.
+    brushYears: fullYears,
     currentStartYear,
     currentEndYear,
     netChange: numberFormat(Math.abs(change)),
@@ -338,6 +339,19 @@ export function useMangroveNetChange(
     noData,
     ...query,
   };
+}
+
+// Evenly spaced x-axis year ticks: uniform pixel gaps (ticks picked at even
+// index steps) with the first and last year always included so edge labels are
+// never clipped. Falls back to the full list when it already fits.
+export function getEvenlySpacedTicks(values: number[], maxTicks = 5): number[] {
+  const n = values?.length ?? 0;
+  if (n <= maxTicks) return values ?? [];
+  const ticks: number[] = [];
+  for (let i = 0; i < maxTicks; i++) {
+    ticks.push(values[Math.round((i * (n - 1)) / (maxTicks - 1))]);
+  }
+  return Array.from(new Set(ticks));
 }
 
 // Pure source-builder: one combined gain/loss v4 raster per year in the

--- a/src/containers/datasets/net-change/legend.tsx
+++ b/src/containers/datasets/net-change/legend.tsx
@@ -19,7 +19,7 @@ const labelsForLayer = [
 ];
 
 const NetChangeLegend = () => (
-  <ul className="flex space-x-4 py-4">
+  <ul className="flex flex-wrap gap-x-8 gap-y-1 py-4">
     {labelsForLayer?.map((d) => (
       <li key={`item-${d.label}`} className="inline-flex items-center space-x-2">
         <div

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -55,6 +55,7 @@ const NetChangeWidget = () => {
     location,
     unitOptions,
     years,
+    brushYears,
     data,
     isFetching,
     currentEndYear,
@@ -81,8 +82,9 @@ const NetChangeWidget = () => {
   // fires analytics, mirroring the alerts widget.
   const handleBrushEnd = useCallback(
     ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) => {
-      const newStartYear = years?.[startIndex];
-      const newEndYear = years?.[endIndex];
+      // Map through the brush's own series (what the drag indices reference).
+      const newStartYear = brushYears?.[startIndex];
+      const newEndYear = brushYears?.[endIndex];
 
       if (newStartYear != null) {
         trackEvent('Widget iteration - net change - change start year', {
@@ -103,7 +105,7 @@ const NetChangeWidget = () => {
         setEndYear(newEndYear);
       }
     },
-    [years, setStartYear, setEndYear]
+    [brushYears, setStartYear, setEndYear]
   );
 
   const contextualLayers = useMemo(

--- a/src/containers/widget/applicability.tsx
+++ b/src/containers/widget/applicability.tsx
@@ -37,7 +37,7 @@ const WidgetApplicability: FC<ApplicabilityProps> = (props: ApplicabilityProps) 
         block: !isCollapsed,
       })}
     >
-      <span className="font-normal">Data applicability:</span>{' '}
+      <span className="font-semibold">Data applicability:</span>{' '}
       <span className="font-light">{applicability}.</span>{' '}
       <Dialog>
         <DialogTrigger asChild>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -135,3 +135,10 @@
   scrollbar-width: thin;
   scrollbar-color: var(--secondary) var(--primary);
 }
+
+/* Brush charts: don't clip axis labels that overflow the plot. The first/last year
+   labels are centered on edge ticks and would otherwise be cut by the svg surface
+   (e.g. the alerts brush). No-op for charts whose labels already sit within bounds. */
+.chart-overflow-visible .recharts-surface {
+  overflow: visible;
+}

--- a/src/svgs/ui/dragger.tsx
+++ b/src/svgs/ui/dragger.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from 'react';
+
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const SvgDragger = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 16 16"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <rect width={16} height={16} fill="#000" fillOpacity={0.85} rx={8} />
+    <path fill="#fff" d="M11 11 8 8.75 5 11V5l3 2.25L11 5z" />
+  </svg>
+);
+export default SvgDragger;

--- a/tests/unit/components/chart/chart-tick.test.ts
+++ b/tests/unit/components/chart/chart-tick.test.ts
@@ -1,0 +1,34 @@
+import { shouldShowTickLabel, MAX_TICK_LABELS } from '@/components/chart/chart-tick';
+
+describe('shouldShowTickLabel', () => {
+  it('shows every label when the tick count fits within maxLabels', () => {
+    const count = 5;
+    const shown = Array.from({ length: count }, (_, i) => shouldShowTickLabel(i, count, 8));
+    expect(shown.every(Boolean)).toBe(true);
+  });
+
+  it('thins labels evenly when there are more ticks than maxLabels', () => {
+    const count = 16;
+    // step = ceil(16 / 8) = 2 -> labels on even indices
+    const shownIndices = Array.from({ length: count }, (_, i) => i).filter((i) =>
+      shouldShowTickLabel(i, count, 8)
+    );
+    expect(shownIndices).toContain(0);
+    expect(shownIndices).toContain(2);
+    expect(shownIndices).not.toContain(1);
+    expect(shownIndices).not.toContain(3);
+  });
+
+  it('always shows the first and last tick', () => {
+    const count = 30;
+    expect(shouldShowTickLabel(0, count, 8)).toBe(true);
+    expect(shouldShowTickLabel(count - 1, count, 8)).toBe(true);
+  });
+
+  it('defaults maxLabels to MAX_TICK_LABELS', () => {
+    const count = MAX_TICK_LABELS * 3;
+    const withDefault = shouldShowTickLabel(MAX_TICK_LABELS, count);
+    const withExplicit = shouldShowTickLabel(MAX_TICK_LABELS, count, MAX_TICK_LABELS);
+    expect(withDefault).toBe(withExplicit);
+  });
+});

--- a/tests/unit/containers/datasets/net-change/hooks.test.ts
+++ b/tests/unit/containers/datasets/net-change/hooks.test.ts
@@ -1,4 +1,5 @@
 import {
+  getEvenlySpacedTicks,
   getFormat,
   getNetChangeSources,
   getWidgetData,
@@ -62,6 +63,35 @@ describe('getWidgetData', () => {
     expect(result[0]['Net result']).toBe(0);
     expect(result[1]['Net result']).toBe(5);
     expect(result[2]['Net result']).toBe(3);
+  });
+});
+
+describe('getEvenlySpacedTicks', () => {
+  it('returns the values unchanged when they already fit within maxTicks', () => {
+    expect(getEvenlySpacedTicks([1996, 2000, 2004], 5)).toEqual([1996, 2000, 2004]);
+  });
+
+  it('always includes the first and last value', () => {
+    const years = [1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, 2025];
+    const ticks = getEvenlySpacedTicks(years, 5);
+    expect(ticks[0]).toBe(1985);
+    expect(ticks[ticks.length - 1]).toBe(2025);
+  });
+
+  it('returns at most maxTicks evenly spaced (by index) values', () => {
+    const years = Array.from({ length: 40 }, (_, i) => 1986 + i); // 1986..2025
+    const ticks = getEvenlySpacedTicks(years, 5);
+    expect(ticks).toEqual([1986, 1996, 2006, 2015, 2025]);
+  });
+
+  it('dedupes when rounding lands on the same index', () => {
+    const ticks = getEvenlySpacedTicks([2019, 2020, 2021, 2022], 6);
+    expect(ticks).toEqual([...new Set(ticks)]);
+  });
+
+  it('is safe for empty/nullish input', () => {
+    expect(getEvenlySpacedTicks([], 5)).toEqual([]);
+    expect(getEvenlySpacedTicks(undefined as unknown as number[], 5)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Context

[GMW-845](https://vizzuality.atlassian.net/browse/GMW-845) — implement the new Mangrove Net Change widget design. The work also refactors the shared chart tick + brush so the net-change and alerts widgets render consistently.

## Net Change widget

- **X-axis labels**: evenly spaced, never clipped (`getEvenlySpacedTicks` + point scale).
- **Y-axis**: signed negative ticks (`-90`, `-180`); removed the dark `y=0` reference line.
- **Brush → chart**: dragging the brush now updates the top chart — indices map through the brush's own series (`brushYears`) instead of the shorter metadata `years`, which previously mismatched (1985–2025 vs 1996–2020).
- **Brush visuals**: bars inset within a rounded selection box whose border sits on the tick middle; SVG draggers.
- **Legend** wraps (no overflow in narrow/print layouts); **MAP TIP** card + **applicability** label pixel-aligned to the design.

## Shared chart

- **New `ChartTick`** (`src/components/chart/chart-tick.tsx`): consistent tick↔label padding + typography (Open Sans / `rgba(0,0,0,.56)`), label thinning (`shouldShowTickLabel`), optional rotation (`angle`). Used by net-change, alerts and alerts-staging — replaces three duplicated tick components.
- **Brush**: dedicated thin-diagonal hatch pattern and SVG dragger (`src/svgs/ui/dragger.tsx`).
- **Overflow**: axis labels that overflow the plot stay visible (recharts surface `overflow: visible` via `.chart-overflow-visible`) so edge labels are centered and not clipped.

## Alerts

- Main chart: **vertical month labels** with a **tick mark at every month** and no axis baseline (matches design).
- Brush + main now share `ChartTick`; consistent padding, no clipped edge labels.

## Tests

- Unit tests for `getEvenlySpacedTicks` and `shouldShowTickLabel` (22 tests pass).

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm lint` clean (pre-existing `opacity` warning only)
- [x] `pnpm test:unit` — 22/22 pass
- [x] Verified in-browser (Mexico): net-change labels/brush/box/draggers, brush selection updates chart, alerts vertical labels + ticks + line, no clipped labels

[GMW-845]: https://vizzuality.atlassian.net/browse/GMW-845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ