### PR TITLE
fix: pin tmp to ^0.2.7 in analysis cloud function (security)

### DIFF
--- a/cloud-functions/analysis/package-lock.json
+++ b/cloud-functions/analysis/package-lock.json
@@ -5043,9 +5043,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/cloud-functions/analysis/package.json
+++ b/cloud-functions/analysis/package.json
@@ -29,6 +29,6 @@
     "@types/validator": "^13.15.2"
   },
   "overrides": {
-    "tmp": "0.2.5"
+    "tmp": "^0.2.7"
   }
 }


### PR DESCRIPTION
## Summary

Dependabot reported `security_update_not_possible` for `tmp` in `cloud-functions/analysis`:

> tmp can't be updated to a non-vulnerable version ... external-editor@3.1.0 requires tmp@0.2.5 (pulled in via gts). To resolve this, ... add an override/resolution pinning tmp to a non-vulnerable version.
> latest-resolvable: 0.2.5 · lowest-non-vulnerable: 0.2.7

Root cause: the package already had `overrides.tmp` — but it was **pinned to the vulnerable `0.2.5`**, which is what blocked Dependabot from bumping it. `tmp` is pulled transitively via `gts` (lint tooling) → `external-editor`.

Fix: change the override from `0.2.5` → `^0.2.7` (latest published, Dependabot's lowest non-vulnerable) and update `package-lock.json` (tmp node → 0.2.7 with new tarball + integrity).

Scope: dev-only dependency chain (`gts` lint tooling); no runtime impact on the deployed cloud function.

## Test plan

- [x] `package-lock.json` tmp node updated to 0.2.7 (verified integrity against npm registry)
- [ ] `npm ci` in `cloud-functions/analysis` succeeds (was blocked locally by sandbox perms — verify in CI / locally)
- [ ] `npm run lint` (gts) still works
- [ ] Dependabot alert for tmp clears after merge

## Notes

- Lockfile edited by hand (npm install blocked in this environment); re-run `npm install` in `cloud-functions/analysis` to confirm no drift before/after merge.