### PR TITLE
chore: drop release-as bootstrap (v2.0.0-rc.0 is cut)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
       "prerelease-type": "rc",
-      "versioning": "prerelease",
-      "release-as": "2.0.0-rc.0"
+      "versioning": "prerelease"
     }
   }
 }


### PR DESCRIPTION
Now that `v2.0.0-rc.0` is tagged, remove the `release-as` bootstrap so release-please computes versions from the manifest. Further commits increment the rc (`v2.0.0-rc.1`, …). Graduate to stable via a `Release-As: 2.0.0` footer commit.