### PR TITLE
fix: data-driven year range in extent & net-change info + dropdowns (GMW-1039)

### DIFF
--- a/src/components/widget-controls/info.tsx
+++ b/src/components/widget-controls/info.tsx
@@ -1,9 +1,12 @@
 import { trackEvent } from '@/lib/analytics/ga';
 
 import { activeGuideAtom } from '@/store/guide';
+import { netChangeEndYear, netChangeStartYear } from '@/store/widgets/net-change';
 
 import { useAtomValue } from 'jotai';
 
+import { useMangroveHabitatExtent } from '@/containers/datasets/habitat-extent/hooks';
+import { useMangroveNetChange } from '@/containers/datasets/net-change/hooks';
 import { INFO } from '@/containers/datasets/registries';
 import Helper from '@/containers/help/helper';
 
@@ -20,8 +23,40 @@ import INFO_SVG from '@/svgs/ui/info';
 
 import { HELPER_POSITION } from './constants';
 
+// Widgets whose info panel shows a data-driven year range (GMW-1039). The year
+// list is not hardcoded in the .mdx — each resolver reads the widget's own React
+// Query cache (already warm from the mounted widget; the query key excludes year
+// params, so `{}` hits the same cache with no extra request) and passes min/max
+// years as props into the MDX component.
+type YearInfoProps = { Info: React.FC<Record<string, unknown>> };
+
+const toYearProps = (years?: number[]) => {
+  const sorted = [...(years ?? [])].sort((a, b) => a - b);
+  return { years: sorted, minYear: sorted[0], maxYear: sorted.at(-1) };
+};
+
+const HabitatExtentYearInfo = ({ Info }: YearInfoProps) => {
+  const { data } = useMangroveHabitatExtent({});
+  return <Info {...toYearProps(data?.years)} />;
+};
+
+const NetChangeYearInfo = ({ Info }: YearInfoProps) => {
+  // Mirror useSources: params carry the selected range, but the query key omits
+  // it, so this reads the same cached response regardless of the values.
+  const startYear = useAtomValue(netChangeStartYear);
+  const endYear = useAtomValue(netChangeEndYear);
+  const { years } = useMangroveNetChange({ startYear, endYear });
+  return <Info {...toYearProps(years)} />;
+};
+
+const YEAR_INFO: Record<string, React.FC<YearInfoProps>> = {
+  mangrove_habitat_extent: HabitatExtentYearInfo,
+  mangrove_net_change: NetChangeYearInfo,
+};
+
 const Info = ({ id, content }) => {
   const Info = INFO[id];
+  const YearInfo = id ? YEAR_INFO[id] : undefined;
   const isHelpGuideActive = useAtomValue(activeGuideAtom);
   if (!Info && !content) return null;
 
@@ -58,7 +93,7 @@ const Info = ({ id, content }) => {
         <DialogTitle className="sr-only">Info</DialogTitle>
         <div className="no-scrollbar overflow-y-auto">
           {/* Supports external content or look by id for static info about widgets */}
-          {id && <Info />}
+          {id && (YearInfo ? <YearInfo Info={Info} /> : <Info />)}
           {content && <>{decodedContent}</>}
         </div>
         <DialogClose />

--- a/src/containers/datasets/habitat-extent/info.mdx
+++ b/src/containers/datasets/habitat-extent/info.mdx
@@ -1,10 +1,10 @@
 import LayoutMdx from '@/layouts/mdx';
 
-# Global extent of mangroves for select years from 1996 to 2020.
+# Global extent of mangroves for select years from {props.minYear} to {props.maxYear}.
 
 ## Overview:
 
-This layer depicts the global extent and change of mangrove forests in the years 1996, 2007 - 2010 and 2015 - 2020. The data set was generated within the framework of the Global Mangrove Watch (GMW) , an initiative convened by Aberystwyth University, soloEO, The Nature Conservancy and Wetlands International.
+This layer depicts the global extent and change of mangrove forests from {props.minYear} to {props.maxYear}. The data set was generated within the framework of the Global Mangrove Watch (GMW) , an initiative convened by Aberystwyth University, soloEO, The Nature Conservancy and Wetlands International.
 
 The paper describing the mangrove extent and change dataset is available at:
 
@@ -20,7 +20,7 @@ describing the Global Coastline Vector dataset:
 <a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/1755876X.2018.1529714">
   https://doi.org/10.1080/1755876X.2018.1529714
 </a>
-## Date of content: 1996, 2007, 2008, 2009, 2010, 2015, 2016, 2017, 2018, 2019, 2020 ## License:
+## Date of content: {props.minYear} to {props.maxYear} ## License:
 <a target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/4.0/">
   CC-BY 4.0
 </a>

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -43,27 +43,6 @@ const BRUSH_Y_PAD = 1.1;
 const Y_AXIS_WIDTH = 60;
 const X_INSET = 16;
 
-// The API currently returns `gain`/`loss` as null. When the `mockNetChange`
-// feature flag is on, derive display-only gain/loss values from `net_change`.
-// Deterministic (no Math.random) so SSR and tests stay stable.
-export const mockNetChangeEnabled =
-  JSON.parse(process.env.NEXT_PUBLIC_FEATURED_FLAGS || '{}').mockNetChange === true;
-
-export const mockGainLoss = (net_change: number) => {
-  // baseline churn proportional to the magnitude, so bars are visible even when
-  // net change is small; gain - loss === net_change exactly.
-  const base = Math.abs(net_change) * 0.5 + 50;
-  return {
-    gain: base + Math.max(net_change, 0),
-    loss: base + Math.max(-net_change, 0),
-  };
-};
-
-export const applyMockGainLoss = (rows: Data[] = []): Data[] =>
-  mockNetChangeEnabled
-    ? rows.map((row) => (row.gain == null ? { ...row, ...mockGainLoss(row.net_change) } : row))
-    : rows;
-
 // Shared axis label style (design spec): Open Sans 12/20, weight 400, black 56%.
 // Used for recharts' built-in tick text (main chart); the brush uses <ChartTick />.
 const AXIS_TICK = {
@@ -182,27 +161,29 @@ export function useMangroveNetChange(
   });
 
   const { data, isFetched } = query;
-
   const noData =
     location_id === 'custom-area'
       ? isFetched && data?.data?.reduce((acc, value) => acc + value.net_change, 0) === 0
       : isFetched && !data?.data?.length;
 
-  const years = data?.metadata?.year.sort();
+  // Derive years from the actual data series (source of truth) rather than
+  // metadata.year, which can lag the response. Keeps the dropdowns, default
+  // range, brush, and info panel in sync. Falls back to metadata if present.
+  const years = data?.data?.length
+    ? [...new Set(data.data.map((d) => d.year))].sort((a, b) => a - b)
+    : [...(data?.metadata?.year ?? [])].sort((a, b) => a - b);
   const unit = selectedUnit || data.metadata?.units.net_change;
   const currentStartYear = startYear || years?.[0];
   const currentEndYear = endYear || years?.[years?.length - 1];
 
   // Mocked gain/loss (flag-gated) applied once to the full series.
-  const allData = applyMockGainLoss(data?.data);
-
   // Main chart shows the selected [startYear, endYear] window; the brush below
   // shows the full series and drives the selection (same as the alerts widget).
-  const dataFiltered = allData?.filter(
+  const dataFiltered = data?.data?.filter(
     (d) => d.year >= currentStartYear && d.year <= currentEndYear
   );
   const DATA = getWidgetData(dataFiltered, unit) || [];
-  const DATA_FULL = getWidgetData(allData, unit) || [];
+  const DATA_FULL = getWidgetData(data?.data, unit) || [];
   const TooltipData = {
     content: (properties) => <CustomTooltip {...properties} />,
   };

--- a/src/containers/datasets/net-change/info.mdx
+++ b/src/containers/datasets/net-change/info.mdx
@@ -1,6 +1,6 @@
 import LayoutMdx from '@/layouts/mdx';
 
-# Global change in extent of mangroves for select years from 1996 to 2020.
+# Global change in extent of mangroves for select years from {props.minYear} to {props.maxYear}.
 
 ## Overview:
 
@@ -12,13 +12,12 @@ Bunting P., Rosenqvist A., Lucas R., Rebelo L-M., Hilarides L., Thomas N., Hardy
 
 ## Date of content:
 
-1996, 2007, 2008, 2009, 2010, 2015, 2016, 2017, 2018, 2019, 2020
+{props.minYear} to {props.maxYear}
 
 ## License:
 
 <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener noreferrer">
   CC-BY 4.0
 </a>
-,
 
 export default ({ children, ...props }) => <LayoutMdx {...props}>{children}</LayoutMdx>;

--- a/tests/unit/containers/datasets/net-change/hooks.test.ts
+++ b/tests/unit/containers/datasets/net-change/hooks.test.ts
@@ -3,7 +3,6 @@ import {
   getFormat,
   getNetChangeSources,
   getWidgetData,
-  mockGainLoss,
 } from '@/containers/datasets/net-change/hooks';
 import type { Data } from '@/containers/datasets/net-change/types';
 
@@ -140,22 +139,5 @@ describe('getNetChangeSources', () => {
 
   it('excludes the start year and returns empty when the window is degenerate', () => {
     expect(getNetChangeSources(years, 2025, 2025)).toEqual([]);
-  });
-});
-
-describe('mockGainLoss', () => {
-  it('produces gain/loss whose difference equals net_change', () => {
-    for (const net of [-2631.47, -1.5, 0, 51.08, 293.95]) {
-      const { gain, loss } = mockGainLoss(net);
-      expect(gain - loss).toBeCloseTo(net, 6);
-    }
-  });
-
-  it('returns non-negative, deterministic values', () => {
-    const a = mockGainLoss(-433.07);
-    const b = mockGainLoss(-433.07);
-    expect(a).toEqual(b);
-    expect(a.gain).toBeGreaterThanOrEqual(0);
-    expect(a.loss).toBeGreaterThanOrEqual(0);
   });
 });


### PR DESCRIPTION
## Context

[GMW-1039](https://vizzuality.atlassian.net/browse/GMW-1039): the info-button panels for the **extent** and **net change** widgets showed a hardcoded date range (`1996 to 2020`, `Date of content: 1996, 2007 … 2020`). The API now returns a continuous annual series (net-change confirmed **1985–2025**, one row per year), so the displayed years must reflect the data — no hardcoding.

While verifying, the **net-change year dropdowns** were also stale: they mapped over `metadata.year` (which lags the response) while the chart/brush already used the row-derived series.

## Changes

- **Info panels data-driven** — `src/components/widget-controls/info.tsx` resolves each widget's cached React Query years and passes `minYear`/`maxYear` into the MDX; `habitat-extent/info.mdx` and `net-change/info.mdx` now render `{props.minYear} to {props.maxYear}` instead of literal years. Citation years in net-change prose left untouched.
- **Dropdowns/brush/defaults unified** — `net-change/hooks.tsx` derives `years` from the data series rather than `metadata.year`, so dropdowns, default range, brush, and info panel all agree (1985–2025).
- **Cleanup** — removed the obsolete mock gain/loss helper + a debug `console.log` now that the API returns real annual gain/loss; dropped its dead unit test.

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm test:unit` — 17/17 pass
- [ ] `pnpm dev`: expand **Mangrove extent** and **Net change** widgets, open the "i" panel — title + "Date of content" read the live range (1985–2025)
- [ ] Net-change start/end dropdowns list years through 2025; brush + chart align
- [ ] Switch location (country) and re-open — range matches that location's returned years

## Versioning / Jira

Conventional `fix:` commit → release-please (develop line) will bump the patch and set the GMW fixVersion; released to develop and mirrored to main.

[GMW-1039]: https://vizzuality.atlassian.net/browse/GMW-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ