### PR TITLE
chore: cut 8.0.0-rc.0 via release-as override

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
       "prerelease-type": "rc",
-      "versioning": "prerelease"
+      "versioning": "prerelease",
+      "release-as": "8.0.0-rc.0"
     }
   }
 }


### PR DESCRIPTION
## What

Add `"release-as": "8.0.0-rc.0"` to the `.` package in `release-please-config.json`. Nothing else changes — baseline stays `2.0.0-rc.0`; release-please bumps the manifest + `package.json` when it cuts the release.

## Why

Move the project to the **8.0.0** line and cut **exactly `8.0.0-rc.0`** as the first tag (not `rc.1`). Matches the GMW `8.0.0` Jira version already set as fixVersion on in-flight tickets (e.g. GMW-1039).

`release-as` overrides the computed prerelease bump and forces the exact version string, so it works regardless of merge method (squash/merge) — more robust than a `Release-As:` commit footer, which a squash could drop.

## ⚠️ Follow-up required

**Remove `release-as` immediately after `v8.0.0-rc.0` is cut.** If it stays, every subsequent release-please run keeps re-cutting `8.0.0-rc.0` instead of incrementing to `8.0.0-rc.1`, `rc.2`, … (same footgun as the old bootstrap override).

## Effect

- release-please opens/updates its release PR targeting exactly **`8.0.0-rc.0`**; merging it tags `v8.0.0-rc.0` and updates manifest + package.json to `8.0.0-rc.0`.
- `main` ff-mirror intact.

## Test plan

- [ ] Merge → release-please release PR shows version `8.0.0-rc.0`
- [ ] After the tag is cut, land a follow-up removing `release-as`
- [ ] Confirm the next post-rc.0 commit then bumps to `8.0.0-rc.1`