### PR TITLE
fix: fly map to worldwide on Reset page (GMW-1037)

### DIFF
--- a/src/containers/navigation/menu-tools/index.tsx
+++ b/src/containers/navigation/menu-tools/index.tsx
@@ -36,8 +36,11 @@ const LocationTools = () => {
     resetDrawingState();
     resetAnalysisState();
     resetDrawingUploadState();
-    // See layouts/desktop: chain through the keyed ref, not just `map`.
-    map?.['default-desktop-no-print']?.flyTo({
+    // The main map registers with react-map-gl as id `default` (see
+    // containers/map MapContainer mapId="default"). Chain through that keyed
+    // ref — the old `default-desktop-no-print` key matched no mounted map, so
+    // flyTo silently no-oped and the map never returned to worldwide.
+    map?.['default']?.flyTo({
       center: [0, 20],
       zoom: 2,
     });


### PR DESCRIPTION
## Context

[GMW-1037](https://vizzuality.atlassian.net/browse/GMW-1037): clicking **Reset page** after selecting a location appeared to do nothing.

In fact the widgets and selected location *did* reset (the button is also a `<Link href="/">`, so location/widget state re-syncs from the URL). The one thing that failed was the **map camera** — it never flew back to the zoomed-out worldwide view.

## Root cause

The reset handler in `src/containers/navigation/menu-tools/index.tsx` targeted the wrong react-map-gl map id:

```
map?.['default-desktop-no-print']?.flyTo({ center: [0, 20], zoom: 2 })
```

The main map is mounted with id `default`, so `map['default-desktop-no-print']` is `undefined` and the optional chaining silently skipped `flyTo` — no error, camera stays put.

## Fix

Point `flyTo` at the correct key `map?.['default']`, matching the working sibling handlers in `layouts/desktop` and `layouts/mobile`. Reset now flies the map to worldwide (`center [0, 20]`, `zoom 2`).

> Note (out of scope): the same dead-key pattern exists in `src/containers/alert/index.tsx` (`'default-desktop'`) — a likely latent no-op if that path is exercised. Not touched here.

## Test plan

- [x] `pnpm check-types` clean
- [ ] `pnpm dev`: select a location (map zooms in) → click **Reset page** → map flies back to worldwide, widgets + location reset
- [ ] Repeat after drawing/uploading an area (analysis state) → reset also flies to worldwide

[GMW-1037]: https://vizzuality.atlassian.net/browse/GMW-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ