### PR TITLE
chore: remove release-as override now that v8.0.0-rc.0 is cut

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "prerelease": true,
       "prerelease-type": "rc",
-      "versioning": "prerelease",
-      "release-as": "8.0.0-rc.0"
+      "versioning": "prerelease"
     }
   }
 }


### PR DESCRIPTION
## What

Remove `"release-as": "8.0.0-rc.0"` from `release-please-config.json` (the only change).

## Why

The pin forced release-please to cut exactly `v8.0.0-rc.0` — done, the tag + release exist. If left in place, **every** subsequent release-please run would keep re-cutting `8.0.0-rc.0` instead of incrementing.

## Effect

Prerelease bumping resumes normally: the next releasable commit on develop bumps to `8.0.0-rc.1`, then `rc.2`, …. The rc config (`prerelease: true`, `prerelease-type: rc`, `versioning: prerelease`) is untouched.

## Follow-up

Merge this **before** landing more feature/fix work, so the next release PR targets `8.0.0-rc.1` rather than re-proposing `8.0.0-rc.0`.