### PR TITLE
fix: popup and widget control accessibility amendments

### DIFF
--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -189,7 +189,11 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
                   {...DEFAULTVALUES[type]}
                 >
                   {data.map((d, i) => (
-                    <Cell key={`cell-${i}`} fill={d.color} />
+                    <Cell
+                      key={`cell-${i}`}
+                      fill={d.color}
+                      aria-label={d.label ?? d.name ?? `${key}: ${d[key]}`}
+                    />
                   ))}
                   {pies[key].customLabel && (
                     <Label width={30} position="center" content={pies[key].customLabel} />

--- a/src/components/ui/switch/index.tsx
+++ b/src/components/ui/switch/index.tsx
@@ -37,8 +37,7 @@ const SwitchRoot = ({
 }) => (
   <SwitchRadix.Root
     className={cn(className, {
-      'border-brand-800/20 data-[state=checked]:bg-brand-800 relative h-7.5 w-12 cursor-pointer rounded-full border-2 bg-transparent outline-none':
-        true,
+      'border-brand-800/20 data-[state=checked]:bg-brand-800 relative h-7.5 w-12 cursor-pointer rounded-full border-2 bg-transparent outline-none': true,
       [SIZE['root'][size]]: true,
     })}
     {...props}
@@ -54,8 +53,7 @@ const SwitchThumb = ({
 }: SwitchThumbProps & { size?: 'sm' | 'md' }) => (
   <SwitchRadix.Thumb
     className={cn(className, {
-      'bg-brand-800 data-[state=checked]:text-brand-800 block h-5 w-5 translate-x-[3px] rounded-full text-white transition-transform duration-400 will-change-transform data-[state=checked]:translate-x-6 data-[state=checked]:bg-white':
-        true,
+      'bg-brand-800 data-[state=checked]:text-brand-800 block h-5 w-5 translate-x-[3px] rounded-full text-white transition-transform duration-400 will-change-transform data-[state=checked]:translate-x-6 data-[state=checked]:bg-white': true,
       [SIZE['thumb'][size]]: true,
     })}
   >
@@ -66,12 +64,17 @@ const SwitchThumb = ({
 );
 
 const SwitchWrapper = ({ id, label, children, className }: WrapperProps) => {
+  const labelId = `${id}-label`;
   const childWithId = isValidElement(children)
-    ? cloneElement(children as ReactElement<{ id?: string }>, { id })
+    ? cloneElement(children as ReactElement<{ id?: string; 'aria-labelledby'?: string }>, {
+        id,
+        'aria-labelledby': labelId,
+      })
     : children;
   return (
     <div className="flex items-center">
       <label
+        id={labelId}
         className={cn(className, {
           'sr-only pr-[15px] text-[15px] leading-none text-white': true,
         })}

--- a/src/components/widget-controls/layer-toggle.tsx
+++ b/src/components/widget-controls/layer-toggle.tsx
@@ -5,6 +5,7 @@ import { useSyncActiveLayers } from '@/store/layers';
 import { updateLayers } from 'hooks/layers';
 
 import Helper from '@/containers/help/helper';
+import { widgets } from '@/containers/widgets/constants';
 
 import { SwitchRoot, SwitchThumb, SwitchWrapper } from '@/components/ui/switch';
 import type { WidgetSlugType } from 'types/widget';
@@ -45,6 +46,9 @@ const LayerToggle = ({ id }: WidgetControlsType) => {
 
   if (!id) return null;
 
+  const layerName = widgets.find((w) => w.slug === id)?.name;
+  const label = layerName ? `Toggle ${layerName} map layer` : 'Toggle map layer';
+
   const HELPER_ID = id === activeLayers?.[0]?.id;
   return (
     <Helper
@@ -55,7 +59,7 @@ const LayerToggle = ({ id }: WidgetControlsType) => {
       tooltipPosition={{ top: -35, left: 0 }}
       message="Use this icon to toggle the map layer on or off. If a widget does not have this icon, it means that there is no associated map layer."
     >
-      <SwitchWrapper id={id as string} label="Toggle map layer">
+      <SwitchWrapper id={id as string} label={label}>
         <SwitchRoot
           data-testid={id}
           onClick={handleClick}

--- a/src/containers/datasets/habitat-extent/info.mdx
+++ b/src/containers/datasets/habitat-extent/info.mdx
@@ -20,7 +20,10 @@ describing the Global Coastline Vector dataset:
 <a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/1755876X.2018.1529714">
   https://doi.org/10.1080/1755876X.2018.1529714
 </a>
-## Date of content: {props.minYear} to {props.maxYear} ## License:
+## Date of content: {props.minYear} to {props.maxYear}
+
+## License:
+
 <a target="_blank" rel="noopener noreferrer" href="https://creativecommons.org/licenses/by/4.0/">
   CC-BY 4.0
 </a>

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -81,7 +81,7 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
               <button
                 type="button"
                 aria-label="Drag to reorder"
-                className="cursor-grab active:cursor-grabbing"
+                className="flex min-h-6 min-w-6 cursor-grab items-center justify-center active:cursor-grabbing"
               >
                 <DRAG_SVG role="img" title="Order layer" />
               </button>
@@ -91,7 +91,11 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
             <Tooltip>
               <DialogTrigger asChild>
                 <TooltipTrigger asChild>
-                  <button type="button" aria-label="Layer statistics">
+                  <button
+                    type="button"
+                    aria-label="Layer statistics"
+                    className="flex min-h-6 cursor-pointer items-center"
+                  >
                     <p className="pl-4 text-left text-xs font-semibold tracking-wider text-black/85 uppercase md:pl-0">
                       {title}
                     </p>

--- a/src/containers/widgets/widgets-cards-controls/expand-collapse-widgets/index.tsx
+++ b/src/containers/widgets/widgets-cards-controls/expand-collapse-widgets/index.tsx
@@ -45,8 +45,7 @@ const ExpandCollapseWidgets: FC = () => {
         type="button"
         data-testid="expand-collapse-button"
         className={cn({
-          'text-brand-800 shadow-control disabled:text-opacity-60 h-8 w-full rounded-4xl bg-white px-4 py-1 font-sans text-sm font-semibold transition-colors md:ml-0 md:w-[262px]':
-            true,
+          'text-brand-800 shadow-control hover:shadow-card focus-visible:shadow-control-focus disabled:bg-grey-400 disabled:text-brand-800/60 h-8 w-full cursor-pointer rounded-4xl bg-white px-4 py-1 font-sans text-sm font-semibold transition-shadow focus-visible:outline-none disabled:cursor-default disabled:shadow-none md:ml-0 md:w-[262px]': true,
           'bg-white': widgetsCollapsedChecker,
         })}
         disabled={widgets.length <= 1}

--- a/src/containers/widgets/widgets-cards-controls/widgets-deck/index.tsx
+++ b/src/containers/widgets/widgets-cards-controls/widgets-deck/index.tsx
@@ -43,8 +43,7 @@ const WidgetsDeck: FC = () => {
             type="button"
             data-testid="widgets-deck-trigger"
             className={cn({
-              'text-brand-800 shadow-control ml-1 flex h-8 w-full items-center justify-center rounded-4xl bg-white px-10 py-1 font-sans text-sm font-semibold transition-colors md:ml-0 md:w-[262px]':
-                true,
+              'text-brand-800 shadow-control hover:shadow-card focus-visible:shadow-control-focus ml-1 flex h-8 w-full cursor-pointer items-center justify-center rounded-4xl bg-white px-10 py-1 font-sans text-sm font-semibold transition-shadow focus-visible:outline-none md:ml-0 md:w-[262px]': true,
             })}
           >
             <p>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -60,6 +60,10 @@ const tailwindConfig = {
         medium: '0px 4px 12px 0px rgba(168, 168, 168, 0.25)',
         '3xl': '0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 4px 12px rgba(0, 0, 0, 0.08)',
         control: '0px 4px 12px 0px rgba(0, 0, 0, 0.08)',
+        // White button focus state: keep the control drop shadow, then an inset
+        // white gap + a 2px brand ring at 40% opacity (Figma Button/White/A focused).
+        'control-focus':
+          '0px 4px 12px 0px rgba(0, 0, 0, 0.08), inset 0 0 0 2px #fff, inset 0 0 0 4px rgba(0, 133, 127, 0.4)',
         border: '0px 40px 80px 0px rgba(0, 60, 57, 0.15), 0px 0px 0px 1px rgba(0, 0, 0, 0.10)',
       },
       width: {

--- a/tests/component/components/chart/pie-accessibility.test.tsx
+++ b/tests/component/components/chart/pie-accessibility.test.tsx
@@ -1,0 +1,53 @@
+import { cloneElement, isValidElement } from 'react';
+
+import { render } from '@testing-library/react';
+
+import Chart from '@/components/chart';
+
+// Recharts' ResponsiveContainer measures 0x0 under jsdom, so nothing renders.
+// Replace it with a passthrough that hands the chart a fixed size.
+vi.mock('recharts', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('recharts');
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) =>
+      isValidElement(children)
+        ? cloneElement(children as React.ReactElement, { width: 200, height: 200 })
+        : children,
+  };
+});
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
+
+const data = [
+  { label: 'Mangroves', percentage: 70, color: '#EE4D5A' },
+  { label: 'Non mangroves', percentage: 30, color: '#ECECEF' },
+];
+
+const config = {
+  type: 'pie',
+  width: 200,
+  height: 200,
+  data,
+  // Disable the enter animation so the sector paths are drawn on first render.
+  chartBase: { pies: { percentage: { isAnimationActive: false } } },
+};
+
+describe('Pie chart accessibility', () => {
+  it('gives each sector an accessible name from its data label', () => {
+    const { container } = render(<Chart config={config} />);
+    const sectors = Array.from(container.querySelectorAll('path.recharts-sector'));
+
+    expect(sectors).toHaveLength(data.length);
+    expect(sectors.map((s) => s.getAttribute('aria-label'))).toEqual([
+      'Mangroves',
+      'Non mangroves',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Accessibility and design amendments for popups and widget controls.

- **Extent info popup** — split *Date of content* and *License* into separate headings.
- **Layer toggle switches** — Radix Switch renders a `<button>`, which cannot be named via `<label htmlFor>`. Wire `aria-labelledby` from the switch to its label and build a descriptive per-layer name from the widget registry (e.g. *"Toggle Mangrove Habitat Extent map layer"*), so each switch has a unique accessible name.
- **Legend controls touch targets** — enforce a 24×24px minimum on the drag-to-reorder and layer-statistics buttons (WCAG 2.5.8).
- **Pie chart sectors** — give each Recharts sector an accessible name via `aria-label` on the `Cell`, so the `role="img"` sectors are no longer flagged as missing alt text.
- **Widgets deck / expand-collapse buttons** — implement the Figma `Button/White/A` hover and focus states:
  - hover raises elevation (`shadow-card`) instead of the previous opacity change
  - `focus-visible` shows the inset brand ring via a new `shadow-control-focus` token (white gap + 2px `brand-800/40` ring)
  - disabled expand/collapse uses the grey filled treatment

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm test:unit tests/component/components/chart/pie-accessibility.test.tsx` — new test asserts pie sectors expose an accessible name
- [ ] Tab to the widgets deck / expand-collapse buttons → inset brand focus ring appears (keyboard only)
- [ ] Hover the buttons → shadow elevates, no opacity change
- [ ] Screen reader: each layer toggle announces its layer name; pie sectors announce their labels
- [ ] Verify legend drag / statistics buttons meet 24×24px in devtools