### PR TITLE
fix: popup docking behavior and widget accessibility improvements

### DIFF
--- a/src/containers/datasets/carbon-market-potential/widget.tsx
+++ b/src/containers/datasets/carbon-market-potential/widget.tsx
@@ -50,14 +50,14 @@ const CarbonMarketPotentialWidget = () => {
             The extent of investible blue carbon (ha) at{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {label}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent className="shadow-border rounded-2xl px-2">
@@ -93,14 +93,14 @@ const CarbonMarketPotentialWidget = () => {
             in <span className="font-bold"> {location}</span> is {investibleBlueCarbonValue}{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {unit.label}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     title="Arrow"
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent className="shadow-border rounded-2xl px-2">

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -184,14 +184,14 @@ const FloodProtection = ({
             during {selectedPeriod === 'annual' ? 'an' : 'a'}{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {LABELS[selectedPeriod].short}
                   <ARROW_SVG
                     className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
                     role="img"
                     title="Arrow"
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent>

--- a/src/containers/datasets/habitat-change/widget.tsx
+++ b/src/containers/datasets/habitat-change/widget.tsx
@@ -72,7 +72,7 @@ const HabitatExtent = () => {
               {' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                  <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                     {' '}
                     {currentStartYear}
                     <TRIANGLE_SVG
@@ -80,7 +80,7 @@ const HabitatExtent = () => {
                       role="img"
                       title="Arrow"
                     />
-                  </span>
+                  </button>
                 </PopoverTrigger>
                 <PopoverContent className="shadow-border rounded-2xl px-2">
                   <ul className="z-20 max-h-56 space-y-0.5">
@@ -121,14 +121,14 @@ const HabitatExtent = () => {
             <span className="notranslate font-bold">
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                  <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                     {currentEndYear}
                     <TRIANGLE_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
-                  </span>
+                  </button>
                 </PopoverTrigger>
 
                 <PopoverContent className="shadow-border rounded-2xl px-2">

--- a/src/containers/datasets/habitat-extent/info.mdx
+++ b/src/containers/datasets/habitat-extent/info.mdx
@@ -20,7 +20,9 @@ describing the Global Coastline Vector dataset:
 <a target="_blank" rel="noopener noreferrer" href="https://doi.org/10.1080/1755876X.2018.1529714">
   https://doi.org/10.1080/1755876X.2018.1529714
 </a>
-## Date of content: {props.minYear} to {props.maxYear}
+## Date of content:
+
+{props.minYear} to {props.maxYear}
 
 ## License:
 

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -166,14 +166,14 @@ const HabitatExtent = () => {
                 {area}{' '}
                 <Popover>
                   <PopoverTrigger asChild>
-                    <span className={`${WIDGET_SELECT_STYLES}`}>
+                    <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                       {selectedUnitAreaExtent}
                       <ARROW_SVG
                         className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                         role="img"
                         title="Arrow"
                       />
-                    </span>
+                    </button>
                   </PopoverTrigger>
                   <PopoverContent className="shadow-border rounded-2xl px-2">
                     <ul className="z-20 max-h-32 space-y-0.5">
@@ -201,14 +201,14 @@ const HabitatExtent = () => {
               in{' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                  <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                     {year || defaultYear}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
-                  </span>
+                  </button>
                 </PopoverTrigger>
                 <PopoverContent className="shadow-border rounded-2xl px-2">
                   <ul className="z-20 max-h-56 space-y-0.5">
@@ -270,14 +270,14 @@ const HabitatExtent = () => {
                 {area}{' '}
                 <Popover>
                   <PopoverTrigger asChild>
-                    <span className={`${WIDGET_SELECT_STYLES}`}>
+                    <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                       {selectedUnitAreaExtent}
                       <ARROW_SVG
                         className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                         role="img"
                         title="Arrow"
                       />
-                    </span>
+                    </button>
                   </PopoverTrigger>
                   <PopoverContent className="shadow-border rounded-2xl px-2">
                     <ul className="z-20 max-h-32 space-y-0.5">
@@ -305,14 +305,14 @@ const HabitatExtent = () => {
               in{' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                  <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                     {currentYear}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       title="Arrow"
                     />
-                  </span>
+                  </button>
                 </PopoverTrigger>
                 <PopoverContent className="shadow-border rounded-2xl px-2">
                   <ul className="z-20 max-h-56 space-y-0.5">

--- a/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
+++ b/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
@@ -46,14 +46,14 @@ const MangrovesInProtectedAreas = () => {
               {data.protectedArea}{' '}
               <Popover>
                 <PopoverTrigger asChild>
-                  <span className={`${WIDGET_SELECT_STYLES}`}>
+                  <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                     {selectedUnit}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                       role="img"
                       aria-hidden={true}
                     />
-                  </span>
+                  </button>
                 </PopoverTrigger>
                 <PopoverContent>
                   <ul className="max-h-56 space-y-2">
@@ -89,14 +89,14 @@ const MangrovesInProtectedAreas = () => {
             out of a total <span className="font-bold">{data.totalArea}</span>{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedUnit}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
-                </span>
+                </button>
               </PopoverTrigger>
               .
               <PopoverContent>

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -151,14 +151,14 @@ const NetChangeWidget = () => {
             <span className="font-bold"> {netChange}</span>{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {selectedUnit}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent className="shadow-border rounded-2xl px-2">
@@ -194,14 +194,14 @@ const NetChangeWidget = () => {
             between{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {currentStartYear}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent className="shadow-border rounded-2xl px-2">
@@ -231,14 +231,14 @@ const NetChangeWidget = () => {
             and{' '}
             <Popover>
               <PopoverTrigger asChild>
-                <span className={`${WIDGET_SELECT_STYLES}`}>
+                <button type="button" className={`${WIDGET_SELECT_STYLES}`}>
                   {currentEndYear}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
                     role="img"
                     aria-hidden={true}
                   />
-                </span>
+                </button>
               </PopoverTrigger>
 
               <PopoverContent className="shadow-border rounded-2xl px-2">

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { trackEvent } from '@/lib/analytics/ga';
+import cn from '@/lib/classnames';
 
 import { SpeciesLocationState } from '@/store/widgets/species-location';
 
-import * as RadioGroup from '@radix-ui/react-radio-group';
 import type { PrimitiveAtom } from 'jotai';
 import { useAtom } from 'jotai';
+import { CgRadioCheck } from 'react-icons/cg';
+import type { IconBaseProps } from 'react-icons/lib';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
@@ -23,12 +25,12 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import Loading from '@/components/ui/loading';
-import RadioGroupItem from '@/components/ui/radio-group/radio-group-item';
-import type { RadioOption } from '@/components/ui/radio-group/types';
 import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from '@/styles/widgets';
 
 import { useMangroveSpeciesLocation } from './hooks';
 import type { DataResponse, Specie } from './types';
+
+const RadioCheckIcon = CgRadioCheck as unknown as (p: IconBaseProps) => JSX.Element;
 
 const SpeciesLocation = () => {
   const { type: locationType, id } = useSyncLocation();
@@ -59,7 +61,7 @@ const SpeciesLocation = () => {
   );
 
   const onSelectSpecies = useCallback(
-    (specieName: RadioOption['value']) => {
+    (specieName: string) => {
       const specie = species.find(({ scientific_name }) => scientific_name === specieName);
       if (specie) setSpecie(specie);
       // Google Analytics tracking
@@ -74,6 +76,24 @@ const SpeciesLocation = () => {
   );
 
   const totalLocations = useMemo(() => specieSelected?.location_ids?.length || 0, [specieSelected]);
+
+  // Show the top/bottom fade overlays only when there is scrollable content in that direction.
+  const listRef = useRef<HTMLDivElement>(null);
+  const [fade, setFade] = useState({ top: false, bottom: false });
+
+  const updateFade = useCallback(() => {
+    const el = listRef.current;
+    if (!el) return;
+    const { scrollTop, scrollHeight, clientHeight } = el;
+    setFade({
+      top: scrollTop > 0,
+      bottom: Math.ceil(scrollTop + clientHeight) < scrollHeight,
+    });
+  }, []);
+
+  useEffect(() => {
+    updateFade();
+  }, [updateFade, specieOptions]);
 
   if (isFetched && !species.length) return <NoData />;
 
@@ -115,25 +135,49 @@ const SpeciesLocation = () => {
             <div className="w-full pt-6">
               <CommandInput
                 placeholder="Search species..."
+                onValueChange={() => requestAnimationFrame(updateFade)}
                 className="border-brand-400 w-full rounded-3xl text-sm placeholder:text-sm placeholder:text-black/85"
               />
             </div>
-            <CommandList className="relative mt-2">
+            <CommandList className="relative mt-2" aria-label="Species">
               <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup className="before:content after:content relative before:pointer-events-none before:absolute before:top-0 before:right-4 before:left-0 before:z-10 before:h-5 before:w-full before:bg-linear-to-b before:from-white after:pointer-events-none after:absolute after:bottom-3 after:left-0 after:h-5 after:w-full after:bg-linear-to-t after:from-white">
-                <RadioGroup.Root
-                  aria-label="Species"
-                  className="space-y mb-2 flex h-full max-h-[170px] flex-col overflow-y-auto py-2"
-                  onValueChange={onSelectSpecies}
-                >
-                  {specieOptions.map((specie) => (
-                    <CommandItem key={specie.value}>
-                      <div className="flex items-center">
-                        <RadioGroupItem option={specie} />
-                      </div>
+              <CommandGroup
+                ref={listRef}
+                onScroll={updateFade}
+                className={cn(
+                  'space-y relative mb-2 flex h-full max-h-[170px] flex-col overflow-y-auto py-2',
+                  {
+                    'before:content before:pointer-events-none before:absolute before:top-0 before:right-4 before:left-0 before:z-10 before:h-5 before:w-full before:bg-linear-to-b before:from-white':
+                      fade.top,
+                    'after:content after:pointer-events-none after:absolute after:bottom-3 after:left-0 after:h-5 after:w-full after:bg-linear-to-t after:from-white':
+                      fade.bottom,
+                  }
+                )}
+              >
+                {specieOptions.map((specie) => {
+                  const isSelected = specieSelected?.scientific_name === specie.value;
+                  return (
+                    <CommandItem
+                      key={specie.value}
+                      value={specie.value}
+                      onSelect={() => onSelectSpecies(specie.value)}
+                      className="flex cursor-pointer items-center space-x-4 py-1"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          'flex h-3 w-3 shrink-0 items-center justify-center rounded-full border border-black/85',
+                          { 'border-brand-800 border-4': isSelected }
+                        )}
+                      >
+                        {isSelected && <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" />}
+                      </span>
+                      <span className="text-brand-800 text-sm leading-none font-semibold">
+                        {specie.label}
+                      </span>
                     </CommandItem>
-                  ))}
-                </RadioGroup.Root>
+                  );
+                })}
               </CommandGroup>
             </CommandList>
           </Command>

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -17,6 +17,7 @@ import {
   mapCursorAtom,
   coordinatesAtom,
   mapDraggableTooltipDimensionsAtom,
+  mapDraggableTooltipPinnedAtom,
   mapDraggableTooltipPositionAtom,
   tmpCameraAtom,
   useSyncBasemap,
@@ -26,7 +27,7 @@ import { mapViewAtom } from '@/store/sidebar';
 
 import { useQueryClient } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import type { GeoJSONFeature, LngLatBoundsLike } from 'mapbox-gl';
 import { useOnClickOutside, useWindowSize } from 'usehooks-ts';
 
@@ -72,6 +73,7 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
   const mapPopUpDimensions = useAtomValue(mapDraggableTooltipDimensionsAtom);
 
   const [coordinates, setCoordinates] = useAtom(coordinatesAtom);
+  const setPin = useSetAtom(mapDraggableTooltipPinnedAtom);
   const mapRef = useRef(null);
   const [loaded, setLoaded] = useState(false);
 
@@ -298,6 +300,9 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
     const y = Math.max(0, Math.min(e.point.y, window.innerHeight - h));
 
     setPosition({ x, y });
+    // A fresh map click opens a new (undocked) popup — clear any leftover
+    // pinned/docked state so the pin control docks on first click.
+    setPin(false);
     if (locationFeature) {
       const protectedAreas = protectedAreaFeature?.map((feature) => ({
         ...feature.properties,
@@ -635,6 +640,7 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
                       e.stopPropagation();
                       setCoordinates(null);
                       setPosition(null);
+                      setPin(false);
                     }}
                   >
                     <Image src="/images/MapMarker.png" alt="Map Marker" width={24} height={40} />

--- a/src/containers/map/pop-up/pop-up-controls/drag.tsx
+++ b/src/containers/map/pop-up/pop-up-controls/drag.tsx
@@ -31,10 +31,7 @@ const MapPopupDragHandler = ({
           onMouseDown={(e) => e.stopPropagation()}
           onDoubleClick={handleClickToDocker}
         >
-          <MdOutlineDragHandleIcon
-            className="text-brand-800 mt-3 ml-6 h-6 w-6"
-            onClick={handleClickToDocker}
-          />
+          <MdOutlineDragHandleIcon className="text-brand-800 mt-3 ml-6 h-6 w-6" />
         </button>
       </TooltipTrigger>
       <TooltipContent className="bg-gray-600 px-2 text-white">

--- a/src/containers/widgets/widgets-deck-button.tsx
+++ b/src/containers/widgets/widgets-deck-button.tsx
@@ -42,13 +42,13 @@ export default function WidgetsDeckButton() {
       tooltipPosition={{ top: -50, left: 0 }}
       message={HELPER_MESSAGE}
     >
-      <DialogTrigger asChild>
-        <motion.div
-          initial="rest"
-          whileHover="hover"
-          animate="rest"
-          className="fixed bottom-3 left-1/2 z-20 -translate-x-1/2 lg:left-[calc((572px-48px)/2)] lg:translate-x-0"
-        >
+      <motion.div
+        initial="rest"
+        whileHover="hover"
+        animate="rest"
+        className="fixed bottom-3 left-1/2 z-20 -translate-x-1/2 lg:left-[calc((572px-48px)/2)] lg:translate-x-0"
+      >
+        <DialogTrigger asChild>
           <motion.button
             type="button"
             aria-label="Open widgets deck"
@@ -60,8 +60,8 @@ export default function WidgetsDeckButton() {
               Widgets deck
             </motion.span>
           </motion.button>
-        </motion.div>
-      </DialogTrigger>
+        </DialogTrigger>
+      </motion.div>
     </Helper>
   );
 }


### PR DESCRIPTION
## Summary

Accessibility improvements across widgets and map popup, plus popup docking-state fixes.

### Accessibility
- Convert widget popover triggers from `<span>` to `<button type="button">` across 6 widgets (carbon-market-potential, flood-protection, habitat-change, habitat-extent, mangroves-in-protected-areas, net-change) — keyboard focusable / screen-reader actionable.
- Replace species-location Radix `RadioGroup` with keyboard-navigable `CommandItem` list, ARIA labels, and conditional scroll fade overlays.
- Accessible per-layer labels on layer toggle switches.
- Chart + legend control accessibility; pie-chart accessibility test added.
- Hover/focus states on widgets-deck buttons.
- Split "Date of content" and "License" into separate headings in extent info popup.

### Popup behavior
- Clear pinned/docked popup state on fresh map click and marker close (`map/index.tsx`).
- Remove redundant drag-handle icon `onClick` (`drag.tsx`).
- Fix `widgets-deck-button` `DialogTrigger`/`motion.div` nesting.

## Versioning
All commits use Conventional Commit `fix:` type → release-please bumps a **patch** on merge to `develop`.

## Test plan
- [x] `pnpm check-types` (pre-commit hook)
- [x] `pnpm lint` (pre-commit hook)
- [ ] Keyboard-only: tab through widget popover triggers + species list, confirm focus/activation
- [ ] Screen reader: verify ARIA labels on species list and layer toggles
- [ ] Map: click sets undocked popup; double-click drag handle docks; marker close resets state