### PR TITLE
feat: Transifex Live only + server-rendered snippet

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "@react-email/render": "2.0.9",
     "@t3-oss/env-nextjs": "0.13.11",
     "@tanstack/react-query": "5.101.2",
-    "@transifex/native": "7.1.5",
-    "@transifex/react": "7.1.5",
     "@turf/bbox": "6.5.0",
     "@types/mdx": "2.0.14",
     "axios": "1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,12 +106,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.2
         version: 5.101.2(react@18.2.0)
-      '@transifex/native':
-        specifier: 7.1.5
-        version: 7.1.5
-      '@transifex/react':
-        specifier: 7.1.5
-        version: 7.1.5(@transifex/native@7.1.5)(prop-types@15.8.1)(react@18.2.0)
       '@turf/bbox':
         specifier: 6.5.0
         version: 6.5.0
@@ -593,21 +587,6 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
-  '@formatjs/ecma402-abstract@2.3.6':
-    resolution: {integrity: sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==}
-
-  '@formatjs/fast-memoize@2.2.7':
-    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
-
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    resolution: {integrity: sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==}
-
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    resolution: {integrity: sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==}
-
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
 
   '@headlessui/react@1.7.15':
     resolution: {integrity: sha512-OTO0XtoRQ6JPB1cKNFYBZv2Q0JMqMGNhYP1CjPvcJvjz8YGokz8oAj89HIYZGN0gZzn/4kk9iUpmMF4Q21Gsqw==}
@@ -2368,18 +2347,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@transifex/native@7.1.5':
-    resolution: {integrity: sha512-W/5opTTjlVAgniiRz4cN+86VaUApbzCsCGzJVDPw2PBG594GFzx38s4L5OBwMDIM5Ns0xhxtrEfJWju7/jNzDA==}
-    engines: {node: '>=16.0.0'}
-
-  '@transifex/react@7.1.5':
-    resolution: {integrity: sha512-Dkk54xfXat7LHYa8rDm8FYBjBCtUef3HiV/XnSSWqT0RuKe7SVHMxU1u9R0hbITgG19WhHmM2zB/eRAU/cm/AQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@transifex/native': ^7.0.0
-      prop-types: ^15.0.0
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@turf/bbox@6.5.0':
     resolution: {integrity: sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==}
 
@@ -2960,9 +2927,6 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
-  charenc@0.0.2:
-    resolution: {integrity: sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==}
-
   chroma-js@2.6.0:
     resolution: {integrity: sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==}
 
@@ -3034,15 +2998,9 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cross-fetch@4.1.0:
-    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
-
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
-
-  crypt@0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
@@ -3788,9 +3746,6 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
-  intl-messageformat@10.7.18:
-    resolution: {integrity: sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==}
-
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -3812,9 +3767,6 @@ packages:
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
     engines: {node: '>= 0.4'}
-
-  is-buffer@1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==}
 
   is-bun-module@2.0.0:
     resolution: {integrity: sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==}
@@ -4198,9 +4150,6 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
-  md5@2.3.0:
-    resolution: {integrity: sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==}
-
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
 
@@ -4449,15 +4398,6 @@ packages:
   node-exports-info@1.6.2:
     resolution: {integrity: sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==}
     engines: {node: '>= 0.4'}
-
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -5226,9 +5166,6 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -5478,9 +5415,6 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -5495,9 +5429,6 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5858,32 +5789,6 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
 
   '@floating-ui/utils@0.2.11': {}
-
-  '@formatjs/ecma402-abstract@2.3.6':
-    dependencies:
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/intl-localematcher': 0.6.2
-      decimal.js: 10.6.0
-      tslib: 2.8.1
-
-  '@formatjs/fast-memoize@2.2.7':
-    dependencies:
-      tslib: 2.8.1
-
-  '@formatjs/icu-messageformat-parser@2.11.4':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/icu-skeleton-parser': 1.8.16
-      tslib: 2.8.1
-
-  '@formatjs/icu-skeleton-parser@1.8.16':
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      tslib: 2.8.1
-
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
 
   '@headlessui/react@1.7.15(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -7448,20 +7353,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@transifex/native@7.1.5':
-    dependencies:
-      cross-fetch: 4.1.0
-      intl-messageformat: 10.7.18
-      md5: 2.3.0
-    transitivePeerDependencies:
-      - encoding
-
-  '@transifex/react@7.1.5(@transifex/native@7.1.5)(prop-types@15.8.1)(react@18.2.0)':
-    dependencies:
-      '@transifex/native': 7.1.5
-      prop-types: 15.8.1
-      react: 18.2.0
-
   '@turf/bbox@6.5.0':
     dependencies:
       '@turf/helpers': 6.5.0
@@ -8067,8 +7958,6 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
-  charenc@0.0.2: {}
-
   chroma-js@2.6.0: {}
 
   class-variance-authority@0.7.1:
@@ -8127,19 +8016,11 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cross-fetch@4.1.0:
-    dependencies:
-      node-fetch: 2.7.0
-    transitivePeerDependencies:
-      - encoding
-
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  crypt@0.0.2: {}
 
   css-tree@3.2.1:
     dependencies:
@@ -9113,13 +8994,6 @@ snapshots:
 
   internmap@2.0.3: {}
 
-  intl-messageformat@10.7.18:
-    dependencies:
-      '@formatjs/ecma402-abstract': 2.3.6
-      '@formatjs/fast-memoize': 2.2.7
-      '@formatjs/icu-messageformat-parser': 2.11.4
-      tslib: 2.8.1
-
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -9149,8 +9023,6 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       has-tostringtag: 1.0.2
-
-  is-buffer@1.1.6: {}
 
   is-bun-module@2.0.0:
     dependencies:
@@ -9506,12 +9378,6 @@ snapshots:
   marked@15.0.12: {}
 
   math-intrinsics@1.1.0: {}
-
-  md5@2.3.0:
-    dependencies:
-      charenc: 0.0.2
-      crypt: 0.0.2
-      is-buffer: 1.1.6
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -9937,10 +9803,6 @@ snapshots:
       es-errors: 1.3.0
       object.entries: 1.1.9
       semver: 6.3.1
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-releases@2.0.50: {}
 
@@ -10785,8 +10647,6 @@ snapshots:
     dependencies:
       tldts: 7.4.2
 
-  tr46@0.0.3: {}
-
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -11063,8 +10923,6 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  webidl-conversions@3.0.1: {}
-
   webidl-conversions@8.0.1: {}
 
   wgs84@0.0.0: {}
@@ -11078,11 +10936,6 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,6 +46,20 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             __html: `:root { --font-sans: ${OpenSansFont.style.fontFamily}; --font-inter: ${InterFont.style.fontFamily}; }`,
           }}
         />
+        {/*
+          Transifex Live snippet. Rendered as plain server-side <script> tags in
+          <head> (not next/script) so it lands in the raw SSR HTML — Transifex's
+          verification crawler doesn't run JS, and afterInteractive injection is
+          invisible to it, which blocks "Publish to production". Settings must be
+          defined before live.js loads.
+        */}
+        <script
+          id="transifex-live-settings"
+          dangerouslySetInnerHTML={{
+            __html: `window.liveSettings = { api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}', detectlang: true, autocollect: true, dynamic: true, manual_init: false, translate_urls: false };`,
+          }}
+        />
+        <script id="transifex-live" src="//cdn.transifex.com/live.js" async />
       </head>
       <body className="bg-brand-400 print:bg-white">
         <a
@@ -73,23 +87,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             `,
           }}
         />
-        <Script
-          id="transifex-live-settings"
-          strategy="beforeInteractive"
-          dangerouslySetInnerHTML={{
-            __html: `
-              window.liveSettings = {
-                api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}',
-                detectlang: true,
-                autocollect: true,
-                dynamic: true,
-                manual_init: false,
-                translate_urls: false,
-              };
-            `,
-          }}
-        />
-        <Script id="transifex-live" src="//cdn.transifex.com/live.js" strategy="afterInteractive" />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { MapProvider } from 'react-map-gl';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { tx, PseudoTranslationPolicy } from '@transifex/native';
-import { TXProvider } from '@transifex/react';
 import { SessionProvider } from 'next-auth/react';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
@@ -30,32 +28,21 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       })
   );
 
-  useEffect(() => {
-    tx.init({
-      token: process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY,
-      ...(process.env.NEXT_PUBLIC_VERCEL_ENV === 'development'
-        ? { missingPolicy: new PseudoTranslationPolicy() }
-        : {}),
-    });
-  }, []);
-
   return (
-    <TXProvider token={process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}>
-      <NuqsAdapter>
-        <QueryClientProvider client={queryClient}>
-          <MediaContextProvider disableDynamicMediaQueries>
-            <MapProvider>
-              <TooltipProvider delayDuration={200}>
-                <SessionProvider>
-                  <SessionSync />
-                  {children}
-                </SessionProvider>
-              </TooltipProvider>
-            </MapProvider>
-            <Toaster position="top-right" />
-          </MediaContextProvider>
-        </QueryClientProvider>
-      </NuqsAdapter>
-    </TXProvider>
+    <NuqsAdapter>
+      <QueryClientProvider client={queryClient}>
+        <MediaContextProvider disableDynamicMediaQueries>
+          <MapProvider>
+            <TooltipProvider delayDuration={200}>
+              <SessionProvider>
+                <SessionSync />
+                {children}
+              </SessionProvider>
+            </TooltipProvider>
+          </MapProvider>
+          <Toaster position="top-right" />
+        </MediaContextProvider>
+      </QueryClientProvider>
+    </NuqsAdapter>
   );
 }


### PR DESCRIPTION
## Summary

Consolidates i18n onto **Transifex Live** and fixes why publishing was blocked.

- **Remove dead `@transifex/native` / `@transifex/react`.** The app has zero `useT`/`<T>` calls, so Native never translated any UI. Translation happens exclusively through Transifex Live's DOM auto-collection. Dropped the packages and the `tx.init` / `TXProvider` wiring in `providers.tsx`.
- **Server-render the Live snippet.** Moved `liveSettings` + `live.js` from `next/script` (injected after hydration) to plain `<script>` tags in `<head>`. Transifex's publish-verification crawler does not run JS, so the `afterInteractive` snippet was invisible to it — leaving *Publish to production* gated. Rendering in raw SSR HTML lets Transifex detect the snippet.

## Why

The Live "Publish to production" control stayed disabled with a persistent "install snippet" banner even though the snippet worked client-side (manifest loaded in DevTools). Root cause: the snippet was not present in the server-rendered HTML the Transifex crawler scans.

## Notes / follow-ups (not in this PR)

- This unblocks snippet **verification** once deployed; a successful **Publish** is still required to restore published languages on prod.
- The Live resource is ~0% translated — existing translations live in a different Transifex resource and must be **migrated into the Live resource** before published languages show real content.
- `live.js` uses `async` (satisfies `@next/next/no-sync-scripts`); it still emits in SSR HTML. Inline `liveSettings` runs first, so ordering holds.

## Test plan

- [ ] `pnpm check-types` passes (verified locally)
- [ ] `pnpm lint` passes (verified via pre-commit)
- [ ] View Source on the Vercel preview shows `liveSettings`, `id="transifex-live-settings"`, and `cdn.transifex.com/live.js` in raw HTML
- [ ] Transifex Live detects the snippet on the preview URL and enables *Publish*
- [ ] Language selector still populates from `window.Transifex.live.getAllLanguages()`