### PR TITLE
perf: fix CLS from client-only layout switch (GMW)

### DIFF
--- a/src/containers/main-app/index.tsx
+++ b/src/containers/main-app/index.tsx
@@ -1,19 +1,51 @@
 'use client';
 
-import { useWindowSize } from 'usehooks-ts';
+import dynamic from 'next/dynamic';
+
+import cn from '@/lib/classnames';
+
+import { mapViewAtom } from '@/store/sidebar';
+
+import { useAtomValue } from 'jotai';
 
 import DesktopLayout from '@/layouts/desktop';
 import MobileLayout from '@/layouts/mobile';
 
-import { breakpoints } from '@/styles/styles.config';
+import WidgetsContainer from '@/containers/widgets';
+
+import { Media } from '@/components/media-query';
+
+const WelcomeIntroMessage = dynamic(() => import('@/containers/welcome-message'), { ssr: false });
 
 export default function MainApp() {
-  const { width: screenWidth } = useWindowSize();
+  // `mapView` toggles map-only vs widgets on mobile; desktop always shows the
+  // widgets. Default is `true`, so the visibility is expressed with responsive
+  // CSS (`hidden lg:block`) rather than a JS/viewport check.
+  const mapView = useAtomValue(mapViewAtom);
 
   return (
     <>
-      {screenWidth >= breakpoints.lg && <DesktopLayout />}
-      {screenWidth < breakpoints.lg && <MobileLayout />}
+      {/*
+        Both layouts are rendered server-side; fresnel's media-query CSS shows
+        the right one. Gating the layout on useWindowSize() previously left the
+        first paint with the wrong layout until hydration, causing a large
+        layout shift on desktop. The widgets list is rendered once here (not per
+        layout) so its test ids and data hooks are not duplicated in the DOM.
+      */}
+      <Media greaterThanOrEqual="lg">
+        <DesktopLayout />
+      </Media>
+      <Media lessThan="lg">
+        <MobileLayout />
+      </Media>
+
+      <main id="main-content" className="pointer-events-none relative h-screen w-screen">
+        <div className={cn({ 'hidden lg:block': mapView })}>
+          <WidgetsContainer />
+        </div>
+      </main>
+
+      <WelcomeIntroMessage />
     </>
   );
 }

--- a/src/containers/widgets/index.tsx
+++ b/src/containers/widgets/index.tsx
@@ -4,7 +4,6 @@ import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
 import { useSyncActiveWidgets } from '@/store/widgets';
 
 import { useAtom } from 'jotai';
-import { useWindowSize } from 'usehooks-ts';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
@@ -15,7 +14,6 @@ import AppTools from '@/containers/navigation';
 import { widgets, ANALYSIS_WIDGETS_SLUGS } from '@/containers/widgets/constants';
 
 import { Dialog } from '@/components/ui/dialog';
-import { breakpoints } from '@/styles/styles.config';
 import { WidgetTypes } from 'types/widget';
 
 import PrintReportButton from './print-report-button';
@@ -28,7 +26,6 @@ const WidgetsContainer: FC = () => {
   const [{ customGeojson }] = useAtom(drawingToolAtom);
   const [{ uploadedGeojson }] = useAtom(drawingUploadToolAtom);
 
-  const { width: screenWidth } = useWindowSize();
   const [activeWidgets] = useSyncActiveWidgets();
   const { type: locationType } = useSyncLocation();
   const currentLocation = locationType || 'worldwide';
@@ -45,8 +42,6 @@ const WidgetsContainer: FC = () => {
   }, [activeWidgets, currentLocation, customGeojson, uploadedGeojson]) satisfies WidgetTypes[];
 
   const isCustomArea = !!(customGeojson || uploadedGeojson);
-  const isMobile = screenWidth > 0 && screenWidth < breakpoints.lg;
-  const showList = screenWidth > 0;
 
   return (
     <WidgetsLayout>
@@ -54,16 +49,15 @@ const WidgetsContainer: FC = () => {
       <CloseHelpGuide />
       <WidgetsCardsControls />
 
-      {showList && (
-        <div
-          data-testid="widgets-wrapper"
-          className={isMobile ? 'mt-5 pb-16 lg:mt-0 lg:pb-0' : undefined}
-        >
-          {widgetsAvailable.map((widget) => (
-            <WidgetCard key={widget.slug} widget={widget} />
-          ))}
-        </div>
-      )}
+      {/* Always rendered so the list is in the SSR/first paint. The mobile
+          spacing is applied via Tailwind responsive utilities (reset at lg)
+          rather than a JS width check, which previously delayed the list until
+          hydration and caused a layout shift. */}
+      <div data-testid="widgets-wrapper" className="mt-5 pb-16 lg:mt-0 lg:pb-0">
+        {widgetsAvailable.map((widget) => (
+          <WidgetCard key={widget.slug} widget={widget} />
+        ))}
+      </div>
 
       <Dialog>
         <WidgetsDeckButton />

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -2,14 +2,11 @@ import { useCallback } from 'react';
 
 import { useMap } from 'react-map-gl';
 
-import dynamic from 'next/dynamic';
-
-import WidgetsContainer from '@/containers/widgets';
-
-const WelcomeIntroMessage = dynamic(() => import('@/containers/welcome-message'), { ssr: false });
-
 import Logo from 'components/logo';
 
+// Chrome only. The widgets list and welcome message are rendered once by
+// MainApp so they are not duplicated across the desktop/mobile layouts (which
+// are both present in the DOM under fresnel).
 const DesktopLayout = () => {
   const map = useMap();
 
@@ -32,12 +29,6 @@ const DesktopLayout = () => {
         height={216}
         onClick={handleReset}
       />
-
-      <main id="main-content" className="relative h-screen w-screen">
-        <WidgetsContainer />
-
-        <WelcomeIntroMessage />
-      </main>
     </div>
   );
 };

--- a/src/layouts/mobile/index.tsx
+++ b/src/layouts/mobile/index.tsx
@@ -2,23 +2,17 @@ import { useCallback } from 'react';
 
 import { useMap } from 'react-map-gl';
 
-import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import { mapViewAtom } from '@/store/sidebar';
-
-import { useAtomValue } from 'jotai';
-
 import NavigationBar from '@/containers/navigation/mobile';
-import WidgetsContainer from '@/containers/widgets';
-
-const WelcomeIntroMessage = dynamic(() => import('@/containers/welcome-message'), { ssr: false });
 
 import LOGO_MOBILE_SVG from '@/svgs/logo-mobile';
 
+// Chrome only. The widgets list and welcome message are rendered once by
+// MainApp (which also owns the mobile map-view visibility toggle) so they are
+// not duplicated across the desktop/mobile layouts.
 const MobileLayout = () => {
-  const mapView = useAtomValue(mapViewAtom);
   const map = useMap();
 
   const handleReset = useCallback(() => {
@@ -45,10 +39,6 @@ const MobileLayout = () => {
         />
       </Link>
       <NavigationBar />
-      <WelcomeIntroMessage />
-      <main id="main-content" className="h-full">
-        {!mapView && <WidgetsContainer />}
-      </main>
     </div>
   );
 };

--- a/tests/fixtures/test.ts
+++ b/tests/fixtures/test.ts
@@ -1,4 +1,5 @@
 import { test as base, expect } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 /**
  * Custom test fixture providing two invariants for every test:
@@ -71,3 +72,14 @@ export const test = base.extend({
 });
 
 export { expect };
+
+/**
+ * Scope a test-id lookup to the visible element.
+ *
+ * Both layouts are rendered into the DOM (fresnel SSR-safe layout switch); the
+ * non-matching one is hidden with CSS, not unmounted. Nav chrome shared by both
+ * layouts (e.g. `news-button`) therefore appears twice, tripping Playwright's
+ * strict mode. Filtering to the visible node selects the active layout's copy.
+ */
+export const visibleByTestId = (page: Page, testId: string): Locator =>
+  page.getByTestId(testId).filter({ visible: true });

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './fixtures/test';
+import { expect, test, visibleByTestId } from './fixtures/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
@@ -17,7 +17,7 @@ test('test menu links', async ({ page, browserName }) => {
 test.describe('Blog navigation', () => {
   test('Open blog dialog', async ({ page, browserName }) => {
     test.fixme(browserName === 'firefox', 'Firefox: Recoil/hydration instability');
-    const newsButton = page.getByTestId('news-button');
+    const newsButton = visibleByTestId(page, 'news-button');
     await newsButton.click();
     const postsList = page.getByTestId('posts-list');
     await expect(postsList).toBeVisible();
@@ -25,7 +25,7 @@ test.describe('Blog navigation', () => {
   test('Open first post', async ({ page, browserName }) => {
     test.fixme(browserName === 'firefox', 'Firefox: Recoil/hydration instability');
     // Click on the news button
-    const newsButton = page.getByTestId('news-button');
+    const newsButton = visibleByTestId(page, 'news-button');
     await newsButton.click();
 
     // Wait for posts list to be visible


### PR DESCRIPTION
## Context

Lighthouse showed a layout-shift problem on the app. The dominant runtime shift measured was on the net-change widget, but a structural CLS source is the layout system itself: the desktop/mobile layout choice and the widget list were gated on `useWindowSize()`, which is `0` during SSR and first paint. Result: the first paint rendered no/wrong layout and an **empty widget column**, then the real content popped in after hydration — a large shift on desktop.

The app already ships `@artsy/fresnel` (SSR-safe responsive; `MediaContextProvider` in `providers.tsx`, `mediaStyles` injected in `<head>`) but the main layout + widget list bypassed it.

## Changes

- **`containers/main-app`** — layout choice now via fresnel `<Media greaterThanOrEqual="lg">` / `<lessThan="lg">`. Both layouts are server-rendered; CSS shows the right one. No JS/viewport gate.
- **`containers/widgets`** — removed the `showList = screenWidth > 0` gate and the `isMobile` JS check. The widget list is now in SSR/first paint; mobile spacing uses Tailwind `lg:` utilities.
- **`layouts/desktop` + `layouts/mobile`** — reduced to chrome only (logo/nav). The widget list and welcome message now render **once** in `MainApp`.
- Mobile map-view visibility preserved via responsive CSS (`hidden lg:block` on the widgets wrapper; default `mapView=true`, desktop always shows widgets).

## Why render the widget list once

Fresnel keeps **both** layout subtrees in the DOM. Rendering the widget tree per-layout would duplicate every `data-testid` (`widgets-wrapper`, layer switchers, legend items) and break Playwright strict-mode locators in `layers.spec.ts`. Rendering it once in `MainApp` avoids that.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [ ] Re-run Lighthouse — confirm CLS drop vs baseline
- [ ] Desktop: widgets always visible; skip-link → `#main-content`
- [ ] Mobile: map-view ⇄ widgets toggle still works; header/nav intact
- [ ] `npx playwright test tests/layers.spec.ts` — no duplicate-testid strict violations

## Notes

- Scope is the structural layout-switch CLS (finding #1 of the audit). The net-change widget reserved-height fix (largest single measured shift) is **not** in this PR — separate follow-up.