### PR TITLE
fix: unify mobile bottom-toolbar icons

### DIFF
--- a/src/containers/navigation/mobile/language-selector/index.tsx
+++ b/src/containers/navigation/mobile/language-selector/index.tsx
@@ -1,7 +1,5 @@
 import { MouseEvent, useCallback, useEffect, useState } from 'react';
 
-import { LuLanguages } from 'react-icons/lu';
-
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,7 +8,7 @@ import {
 } from '@/components/ui/dropdown';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-const LuLanguagesIcon = LuLanguages as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
+import LANGUAGE_SVG from '@/svgs/sidebar/language';
 
 interface Transifex {
   live: {
@@ -56,7 +54,7 @@ const LanguageSelector = () => {
             aria-label="Language"
             className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
           >
-            <LuLanguagesIcon className="h-8 w-8" />
+            <LANGUAGE_SVG className="h-8 w-8 fill-current text-white" role="img" title="Language" />
             <span className="text-xxs font-sans leading-none text-white">{currentLanguage}</span>
           </DropdownMenuTrigger>
         </TooltipTrigger>

--- a/src/containers/navigation/mobile/locations/index.tsx
+++ b/src/containers/navigation/mobile/locations/index.tsx
@@ -35,11 +35,7 @@ const LocationsMobile = () => {
               aria-label="Locations"
               className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
             >
-              <GLASS_SVG
-                className="h-8 w-8 fill-current fill-white stroke-white"
-                role="img"
-                title="Glass"
-              />
+              <GLASS_SVG className="h-8 w-8 fill-current stroke-white" role="img" title="Glass" />
               <span className="text-xxs font-sans leading-none text-white">Locations</span>
             </button>
           </DialogTrigger>

--- a/src/containers/navigation/news/index.tsx
+++ b/src/containers/navigation/news/index.tsx
@@ -36,21 +36,25 @@ const NewsButton = ({
       data-testid="news-button"
       aria-label="Open news and updates"
       onClick={onClick}
-      className="relative flex h-full cursor-pointer items-center rounded px-2 transition outline-none"
+      className="relative flex h-full w-14 cursor-pointer items-center justify-center rounded transition outline-none lg:w-auto lg:px-2"
     >
       <Helper
         className={{ button: '-top-2.5 -right-4 z-20', tooltip: 'w-fit-content' }}
         tooltipPosition={{ top: -40, left: 0 }}
         message="Latest news from the Global Mangrove Alliance"
       >
-        <div className="flex flex-col items-center space-y-2 lg:flex-row lg:space-y-0 lg:space-x-2">
+        <div className="flex flex-col items-center space-y-1 lg:flex-row lg:space-y-0 lg:space-x-2">
           {hasSeenWelcome && (
-            <span className="relative inline-block h-6 w-6">
-              <NEWS_SVG className="h-6 w-6 fill-current text-white" role="img" title="News" />
+            <span className="relative inline-block h-8 w-8 lg:h-6 lg:w-6">
+              <NEWS_SVG
+                className="h-8 w-8 fill-current text-white lg:h-6 lg:w-6"
+                role="img"
+                title="News"
+              />
               {showIndicator && (
                 <span
                   aria-hidden
-                  className="border-brand-800 absolute -top-[2.5px] -right-0.5 h-3.5 w-3.5 rounded-full border-[2.5px] bg-white"
+                  className="border-brand-800 absolute top-[-2.5px] -right-0.5 h-3.5 w-3.5 rounded-full border-[2.5px] bg-white"
                 />
               )}
             </span>

--- a/src/svgs/sidebar/glass.tsx
+++ b/src/svgs/sidebar/glass.tsx
@@ -9,7 +9,7 @@ const SvgGlass = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRPr
     xmlns="http://www.w3.org/2000/svg"
     width="32"
     height="32"
-    viewBox="0 0 32 32"
+    viewBox="1.33 1.33 29.33 29.33"
     fill="none"
     {...props}
   >

--- a/src/svgs/sidebar/language.tsx
+++ b/src/svgs/sidebar/language.tsx
@@ -1,0 +1,16 @@
+import type { SVGProps } from 'react';
+
+interface SVGRProps {
+  title?: string;
+  titleId?: string;
+}
+const SvgLanguage = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="-3.67 -4.67 29.33 29.33" fill="none" {...props}>
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path
+      d="M11.87 13.07L9.33 10.56L9.36 10.53C11.1 8.59 12.34 6.36 13.07 4H16V2H9V0H7V2H0V3.99H11.17C10.5 5.92 9.44 7.75 8 9.35C7.07 8.32 6.3 7.19 5.69 6H3.69C4.42 7.63 5.42 9.17 6.67 10.56L1.58 15.58L3 17L8 12L11.11 15.11L11.87 13.07ZM17.5 8H15.5L11 20H13L14.12 17H18.87L20 20H22L17.5 8ZM14.88 15L16.5 10.67L18.12 15H14.88Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+export default SvgLanguage;

--- a/src/svgs/tools-bar/news.tsx
+++ b/src/svgs/tools-bar/news.tsx
@@ -9,7 +9,7 @@ const SvgNews = ({ title, titleId, ...props }: SVGProps<SVGSVGElement> & SVGRPro
     xmlns="http://www.w3.org/2000/svg"
     width="24"
     height="24"
-    viewBox="0 0 24 24"
+    viewBox="-1 -1 26 26"
     fill="none"
     {...props}
   >


### PR DESCRIPTION
## Summary

Unifies the icons in the mobile bottom toolbar (`MobileNavbar`) so all five items — Locations · News · Configure · Language · Map — render at the same visual size and share one style spec (icon ~24px artwork in an `h-8 w-8` box, uniform white, label `text-xxs`, `w-14` centered column).

Branch is rebased on the latest `develop` (includes #1579 CLS fix — the fresnel `<Media>` layout switch — which stops the mobile toolbar from flashing on desktop during first paint).

## Changes

- **Icon size normalization** — the toolbar SVGs had mismatched viewBoxes, so at the shared `h-8 w-8` box the artwork rendered at different sizes (Glass 22px, News 26px, Configure 24px, Language 32px). Normalized each viewBox to a centered ~0.75 fill so all render ≈24px:
  - `svgs/sidebar/glass.tsx` → `viewBox="1.33 1.33 29.33 29.33"`
  - `svgs/tools-bar/news.tsx` → `viewBox="-1 -1 26 26"`
  - `svgs/sidebar/language.tsx` → `viewBox="-3.67 -4.67 29.33 29.33"`
- **Language icon** — replaced `react-icons` `LuLanguages` with a local SVG component `@/svgs/sidebar/language` (translate glyph), following the existing `@/svgs/*` pattern (`fill="currentColor"` + `text-white`). First step of migrating off `react-icons`; the dep stays (still used elsewhere: loading, radio-group, timeline-slider, etc.).
- **News icon** — was `h-6 w-6` with different spacing/wrapper than siblings. Now `h-8 w-8` on mobile with `space-y-1` in a `w-14` centered column. `News` is shared with the desktop top bar, so desktop is preserved via `lg:` variants (`lg:h-6 lg:w-6`, `lg:flex-row`, `lg:px-2`).
- **Locations** — trimmed redundant `fill-white` on the glass icon.
- **News unread indicator** — minor position class adjustment.

Verified icon sizes via Playwright (getBBox measurement) at mobile viewport: Glass/News/Configure/Language all render ≈24px artwork.

## Test plan

- [x] Mobile (<lg): all 5 bottom-bar icons same size, aligned, uniform white
- [ ] Desktop (`lg`): top `AppTools` News icon proportional (viewBox change is ~1.5px smaller, no layout impact); glass in find-locations unaffected
- [x] `pnpm lint && pnpm check-types` (clean via pre-commit hook)
- [ ] `npx playwright test tests/navigation.spec.ts`