### PR TITLE
feat: user profile role field + required-field markers (GMW-1043)

### DIFF
--- a/src/app/auth/password/reset/page.tsx
+++ b/src/app/auth/password/reset/page.tsx
@@ -107,7 +107,9 @@ function ResetPasswordForm() {
                     name="password"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Password</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Password
+                        </FormLabel>
                         <FormControl>
                           <Input
                             type="password"
@@ -125,7 +127,9 @@ function ResetPasswordForm() {
                     name="password_confirmation"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Confirm Password</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Confirm Password
+                        </FormLabel>
                         <FormControl>
                           <Input
                             type="password"

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -7,20 +7,29 @@ import { useRouter } from 'next/navigation';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
+import { OTHER_ROLE_VALUE, ROLE_OPTIONS } from '@/containers/auth/constants';
 import { useSignup } from '@/containers/auth/hooks';
 import LandingNavigation from '@/containers/navigation/landing';
 
 import FooterSignin from '@/components/auth/footer-signin';
+import RolesSelect from '@/components/auth/roles-select';
 import Logo from 'components/logo';
 import { Button } from 'components/ui/button';
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from 'components/ui/form';
 import { Input } from 'components/ui/input';
+
+const ROLE_VALUES = ROLE_OPTIONS.map((o) => o.value);
 
 const formSchema = z
   .object({
     username: z.string().min(1, { message: 'Please enter your name' }),
     email: z.string().email({ message: 'Please enter a valid email address' }),
     organization: z.string().optional(),
+    roles: z
+      .array(z.string().refine((v) => ROLE_VALUES.includes(v)))
+      .optional()
+      .default([]),
+    'other-role': z.string().optional(),
     password: z.string().nonempty({ message: 'Please enter your password' }).min(6, {
       message: 'Please enter a password with at least 6 characters',
     }),
@@ -37,6 +46,13 @@ const formSchema = z
         path: ['confirm-password'],
       });
     }
+    if (data.roles?.includes(OTHER_ROLE_VALUE) && !data['other-role']?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Please describe your role',
+        path: ['other-role'],
+      });
+    }
   });
 
 export default function SignupPage() {
@@ -51,16 +67,30 @@ export default function SignupPage() {
       password: '',
       'confirm-password': '',
       organization: '',
+      roles: [],
+      'other-role': '',
     },
   });
 
+  const showOtherRole = form.watch('roles')?.includes(OTHER_ROLE_VALUE);
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const { email, password, username } = values;
+    const { email, password, username, organization, roles } = values;
+    const otherRole = values['other-role']?.trim();
 
     form.clearErrors();
 
     signup.mutate(
-      { user: { email, password, name: username } },
+      {
+        user: {
+          email,
+          password,
+          name: username,
+          ...(organization?.trim() ? { organization: organization.trim() } : {}),
+          ...(roles?.length ? { roles } : {}),
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { other_role: otherRole } : {}),
+        },
+      },
       {
         onSuccess: () => {
           router.push('/auth/signin?verified=pending');
@@ -101,7 +131,7 @@ export default function SignupPage() {
         <LandingNavigation />
         <div className="flex h-full w-full flex-col justify-center space-y-10">
           <h1 className="text-brand-800 font-sans text-[40px] font-light">Sign up</h1>
-          <div className="divide-text-gray-200 space-y-6 divide-y">
+          <div className="space-y-6">
             <Form {...form}>
               <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
                 <fieldset className="space-y-4">
@@ -110,7 +140,9 @@ export default function SignupPage() {
                     name="username"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Name</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Name
+                        </FormLabel>
                         <FormControl>
                           <Input
                             {...field}
@@ -128,7 +160,9 @@ export default function SignupPage() {
                     name="email"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Email</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Email
+                        </FormLabel>
                         <FormControl>
                           <Input
                             {...field}
@@ -161,10 +195,60 @@ export default function SignupPage() {
 
                   <FormField
                     control={form.control}
+                    name="roles"
+                    render={({ field }) => (
+                      <FormItem className="space-y-1.5">
+                        <FormLabel className="text-xs font-semibold">What is your role?</FormLabel>
+                        {/* No FormControl: RolesSelect does not forward refs, and Slot
+                            would warn. FormMessage still picks up the field error. */}
+                        <RolesSelect
+                          id="signup-roles"
+                          placeholder="Select the roles that describe you"
+                          options={ROLE_OPTIONS}
+                          values={field.value ?? []}
+                          onChange={(selection) => {
+                            field.onChange(selection);
+                            if (!selection.includes(OTHER_ROLE_VALUE)) {
+                              form.setValue('other-role', '');
+                              form.clearErrors('other-role');
+                            }
+                          }}
+                        />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+
+                  {showOtherRole && (
+                    <FormField
+                      control={form.control}
+                      name="other-role"
+                      render={({ field }) => (
+                        <FormItem className="space-y-1.5">
+                          <FormLabel className="text-xs font-semibold" required>
+                            Other role
+                          </FormLabel>
+                          <FormControl>
+                            <Input
+                              {...field}
+                              className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                              placeholder="Tell us your role"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+
+                  <FormField
+                    control={form.control}
                     name="password"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Password</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Password
+                        </FormLabel>
                         <FormControl>
                           <Input
                             type="password"
@@ -182,7 +266,9 @@ export default function SignupPage() {
                     name="confirm-password"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
-                        <FormLabel className="text-xs font-semibold">Confirm Password</FormLabel>
+                        <FormLabel className="text-xs font-semibold" required>
+                          Confirm Password
+                        </FormLabel>
                         <FormControl>
                           <Input
                             type="password"
@@ -208,6 +294,8 @@ export default function SignupPage() {
                 </Button>
               </form>
             </Form>
+
+            <hr className="border-black/10" />
 
             <FooterSignin />
           </div>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -87,8 +87,8 @@ export default function SignupPage() {
           password,
           name: username,
           ...(organization?.trim() ? { organization: organization.trim() } : {}),
-          ...(roles?.length ? { roles } : {}),
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { other_role: otherRole } : {}),
+          ...(roles?.length ? { user_roles: roles } : {}),
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_role_other: otherRole } : {}),
         },
       },
       {

--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState } from 'react';
+
+import cn from '@/lib/classnames';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+
+import ARROW_SVG from '@/svgs/ui/arrow';
+import CHECK_SVG from '@/svgs/ui/check-light';
+
+type RoleOption = { label: string; value: string };
+
+type RolesSelectProps = {
+  id?: string;
+  placeholder: string;
+  options: RoleOption[];
+  values: string[];
+  onChange: (values: string[]) => void;
+};
+
+const RolesSelect = ({ id, placeholder, options, values, onChange }: RolesSelectProps) => {
+  const [open, setOpen] = useState(false);
+
+  const selectedLabels = options.filter((o) => values.includes(o.value)).map((o) => o.label);
+
+  const toggle = (value: string) => {
+    onChange(values.includes(value) ? values.filter((v) => v !== value) : [...values, value]);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          type="button"
+          className="focus:border-brand-800 flex w-full cursor-pointer items-center justify-between space-x-4 rounded-[100px] border border-black/10 py-2 pr-2 pl-3 text-left text-sm focus:outline-none"
+        >
+          <span className={cn('truncate', { 'text-zinc-400': !selectedLabels.length })}>
+            {selectedLabels.length ? selectedLabels.join(', ') : placeholder}
+          </span>
+          <ARROW_SVG
+            className={cn('text-brand-800 h-3.5 w-3.5 shrink-0 fill-current', {
+              'rotate-180': open,
+            })}
+            aria-hidden="true"
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-h-60 w-[var(--radix-popover-trigger-width)] space-y-0 rounded-2xl p-2"
+      >
+        <div role="listbox" aria-multiselectable="true">
+          {options.map((option) => {
+            const checked = values.includes(option.value);
+            return (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={checked}
+                onClick={() => toggle(option.value)}
+                className="flex w-full cursor-pointer items-center space-x-2 rounded-lg px-2 py-1.5 text-left text-sm hover:bg-black/5"
+              >
+                {/* Visual checkbox only (span, not the Radix Checkbox): the row is
+                  already a <button>, and a nested interactive element is invalid
+                  HTML and breaks hydration. */}
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    'border-brand-800/50 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border-2',
+                    { 'border-4': checked }
+                  )}
+                >
+                  {checked && <CHECK_SVG className="fill-brand-800/70 h-2.5 w-2.5 fill-current" />}
+                </span>
+                <span>{option.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default RolesSelect;

--- a/src/components/ui/form/index.tsx
+++ b/src/components/ui/form/index.tsx
@@ -84,6 +84,8 @@ function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
 
 function FormLabel({
   className,
+  required,
+  children,
   ...props
 }: React.ComponentProps<typeof LabelPrimitive.Root> & { required?: boolean }) {
   const { error, formItemId } = useFormField();
@@ -95,7 +97,17 @@ function FormLabel({
       className={cn('data-[error=true]:text-destructive mb-1 block text-black/85', className)}
       htmlFor={formItemId}
       {...props}
-    />
+    >
+      {children}
+      {required && (
+        <>
+          {' '}
+          <span title="required field" aria-label="required field">
+            *
+          </span>
+        </>
+      )}
+    </Label>
   );
 }
 

--- a/src/containers/auth/constants.ts
+++ b/src/containers/auth/constants.ts
@@ -1,0 +1,17 @@
+// Predefined role options for the "What is your role?" profile field (GMW-1042).
+// There is no API endpoint exposing this list — the backend validates against the
+// same enum, so keep values in sync with the backend when the list changes.
+// `label` is what the user sees; `value` is the enum persisted by the API.
+export const ROLE_OPTIONS: { label: string; value: string }[] = [
+  { label: 'Scientist', value: 'scientist' },
+  { label: 'Academic', value: 'academic' },
+  { label: 'NGO', value: 'ngo' },
+  { label: 'Government / Policy', value: 'government_policy' },
+  { label: 'Natural Resource Managers', value: 'natural_resource_manager' },
+  { label: 'Industry', value: 'industry' },
+  { label: 'Education (student or educator)', value: 'education' },
+  { label: 'Legal / Enforcement', value: 'legal_enforcement' },
+  { label: 'Other', value: 'other' },
+];
+
+export const OTHER_ROLE_VALUE = 'other';

--- a/src/containers/auth/login-form.tsx
+++ b/src/containers/auth/login-form.tsx
@@ -109,7 +109,9 @@ function LoginForm() {
             name="email"
             render={({ field }) => (
               <FormItem className="space-y-1.5">
-                <FormLabel className="text-xs font-semibold">Email</FormLabel>
+                <FormLabel className="text-xs font-semibold" required>
+                  Email
+                </FormLabel>
                 <FormControl>
                   <Input
                     {...field}
@@ -129,7 +131,9 @@ function LoginForm() {
             name="password"
             render={({ field }) => (
               <FormItem className="space-y-1.5">
-                <FormLabel className="text-xs font-semibold">Password</FormLabel>
+                <FormLabel className="text-xs font-semibold" required>
+                  Password
+                </FormLabel>
                 <FormControl>
                   <Input
                     {...field}

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -99,8 +99,8 @@ const AccountContent = () => {
           name: username,
           current_password,
           organization,
-          roles: roles ?? [],
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { other_role: otherRole } : {}),
+          user_roles: roles ?? [],
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_role_other: otherRole } : {}),
         },
       },
       {

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -6,8 +6,10 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { signOut, useSession } from 'next-auth/react';
 import { z } from 'zod';
 
+import { OTHER_ROLE_VALUE, ROLE_OPTIONS } from '@/containers/auth/constants';
 import { usePutUpdateUser } from '@/containers/auth/hooks';
 
+import RolesSelect from '@/components/auth/roles-select';
 import {
   Form,
   FormControl,
@@ -22,26 +24,43 @@ import { Checkbox, CheckboxIndicator } from 'components/ui/checkbox';
 
 import CHECK_SVG from '@/svgs/ui/check';
 
-const formSchema = z.object({
-  username: z.string().min(1, { message: 'Please enter your name' }).optional(),
-  email: z.string().email({ message: 'Please enter a valid email address' }).optional(),
-  organization: z.string().optional(),
-  password: z
-    .string()
-    .nonempty({ message: 'Please enter your password' })
-    .min(6, {
-      message: 'Please enter a password with at least 6 characters',
-    })
-    .optional(),
-  current_password: z
-    .string()
-    .nonempty({ message: 'Please enter your password' })
-    .min(6, { message: 'Please enter your password' }),
-  delete_account: z.boolean().optional(),
-});
+const ROLE_VALUES = ROLE_OPTIONS.map((o) => o.value);
+
+const formSchema = z
+  .object({
+    username: z.string().min(1, { message: 'Please enter your name' }).optional(),
+    email: z.string().email({ message: 'Please enter a valid email address' }).optional(),
+    organization: z.string().optional(),
+    roles: z
+      .array(z.string().refine((v) => ROLE_VALUES.includes(v)))
+      .optional()
+      .default([]),
+    'other-role': z.string().optional(),
+    password: z
+      .string()
+      .nonempty({ message: 'Please enter your password' })
+      .min(6, {
+        message: 'Please enter a password with at least 6 characters',
+      })
+      .optional(),
+    current_password: z
+      .string()
+      .nonempty({ message: 'Please enter your password' })
+      .min(6, { message: 'Please enter your password' }),
+    delete_account: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.roles?.includes(OTHER_ROLE_VALUE) && !data['other-role']?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Please describe your role',
+        path: ['other-role'],
+      });
+    }
+  });
 
 const AccountContent = () => {
-  const { data: session } = useSession();
+  const { data: session, update: updateSession } = useSession();
 
   const user = session?.user;
   const updateUser = usePutUpdateUser(user?.accessToken || '');
@@ -57,13 +76,18 @@ const AccountContent = () => {
       username: user?.name || '',
       organization: user?.organization || '',
       email: user?.email || '',
+      roles: user?.roles ?? [],
+      'other-role': user?.other_role || '',
       password: undefined,
       current_password: '',
     },
   });
 
+  const showOtherRole = form.watch('roles')?.includes(OTHER_ROLE_VALUE);
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const { email, password, username, organization, current_password } = values;
+    const { email, password, username, organization, roles, current_password } = values;
+    const otherRole = values['other-role']?.trim();
 
     form.clearErrors();
 
@@ -75,9 +99,19 @@ const AccountContent = () => {
           name: username,
           current_password,
           organization,
+          roles: roles ?? [],
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { other_role: otherRole } : {}),
         },
       },
       {
+        onSuccess: () => {
+          void updateSession({
+            name: username,
+            organization,
+            roles: roles ?? [],
+            other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
+          });
+        },
         onError: (error: any) => {
           const apiErrors = error?.response?.data?.errors;
 
@@ -158,6 +192,54 @@ const AccountContent = () => {
               </FormItem>
             )}
           />
+
+          <FormField
+            control={form.control}
+            name="roles"
+            render={({ field }) => (
+              <FormItem className="gap-0">
+                <FormLabel className="text-xs font-semibold">What is your role?</FormLabel>
+                {/* No FormControl: RolesSelect does not forward refs, and Slot
+                    would warn. FormMessage still picks up the field error. */}
+                <RolesSelect
+                  id="account-roles"
+                  placeholder="Select the roles that describe you"
+                  options={ROLE_OPTIONS}
+                  values={field.value ?? []}
+                  onChange={(selection) => {
+                    field.onChange(selection);
+                    if (!selection.includes(OTHER_ROLE_VALUE)) {
+                      form.setValue('other-role', '');
+                      form.clearErrors('other-role');
+                    }
+                  }}
+                />
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {showOtherRole && (
+            <FormField
+              control={form.control}
+              name="other-role"
+              render={({ field }) => (
+                <FormItem className="gap-0">
+                  <FormLabel className="text-xs font-semibold" required>
+                    Other role
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                      placeholder="Tell us your role"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
 
           <div className="flex w-full items-center gap-6">
             <FormField

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -7,13 +7,18 @@ declare module 'next-auth/jwt' {
     accessToken?: string;
     name?: string | null;
     email?: string | null;
+    organization?: string | null;
+    roles?: string[];
+    otherRole?: string | null;
   }
 }
 
 declare module 'next-auth' {
   interface User {
     accessToken: string;
-    organization?: string;
+    organization?: string | null;
+    roles?: string[];
+    other_role?: string | null;
     id?: string;
   }
   interface Session {
@@ -72,6 +77,8 @@ export const authOptions: NextAuthOptions = {
           email: credentials.email,
           name: data?.username || credentials.email,
           organization: data?.organization || null,
+          roles: data?.roles ?? [],
+          other_role: data?.other_role || null,
           accessToken: token,
         };
       },
@@ -102,6 +109,8 @@ export const authOptions: NextAuthOptions = {
           email: data.email,
           name: data.name || data.username,
           organization: data.organization || null,
+          roles: data.roles ?? [],
+          other_role: data.other_role || null,
           accessToken: credentials.token,
         };
       },
@@ -109,13 +118,24 @@ export const authOptions: NextAuthOptions = {
   ],
 
   callbacks: {
-    async jwt({ token, user }) {
+    async jwt({ token, user, trigger, session }) {
       if (user) {
         token.userId = user.id;
         token.accessToken = user.accessToken;
         token.name = user.name;
         token.organization = user.organization;
+        token.roles = user.roles ?? [];
+        token.otherRole = user.other_role;
         token.email = user.email;
+      }
+
+      // Reflect profile edits (name/organization/roles) into the JWT without a
+      // re-login, so the account form shows saved values when reopened.
+      if (trigger === 'update' && session) {
+        if (session.name !== undefined) token.name = session.name;
+        if (session.organization !== undefined) token.organization = session.organization;
+        if (session.roles !== undefined) token.roles = session.roles;
+        if (session.other_role !== undefined) token.otherRole = session.other_role;
       }
 
       return token;
@@ -126,6 +146,8 @@ export const authOptions: NextAuthOptions = {
       if (token.userId) (session.user as any).id = token.userId as string;
       if (token.accessToken) (session.user as any).accessToken = token.accessToken as string;
       if (token.organization) (session.user as any).organization = token.organization as string;
+      (session.user as any).roles = (token.roles as string[]) ?? [];
+      (session.user as any).other_role = (token.otherRole as string) ?? null;
       if (token.name) session.user.name = token.name as string;
       if (token.email) session.user.email = token.email as string;
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -77,8 +77,8 @@ export const authOptions: NextAuthOptions = {
           email: credentials.email,
           name: data?.username || credentials.email,
           organization: data?.organization || null,
-          roles: data?.roles ?? [],
-          other_role: data?.other_role || null,
+          roles: data?.user_roles ?? [],
+          other_role: data?.user_role_other || null,
           accessToken: token,
         };
       },
@@ -109,8 +109,8 @@ export const authOptions: NextAuthOptions = {
           email: data.email,
           name: data.name || data.username,
           organization: data.organization || null,
-          roles: data.roles ?? [],
-          other_role: data.other_role || null,
+          roles: data.user_roles ?? [],
+          other_role: data.user_role_other || null,
           accessToken: credentials.token,
         };
       },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -6,7 +6,16 @@ export type ResetPasswordUpdatePayload = {
   user: { password: string; password_confirmation: string; reset_password_token: string };
 };
 type ResetPasswordResponse = { message?: string };
-export type SignupPayload = { user: { email: string; password: string; name: string } };
+export type SignupPayload = {
+  user: {
+    email: string;
+    password: string;
+    name: string;
+    organization?: string;
+    roles?: string[];
+    other_role?: string;
+  };
+};
 export type SignupResponse =
   | { ok: true; data?: any; message?: string }
   | { ok: false; error?: string; message?: string; errors?: Record<string, string[]> };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -25,6 +25,8 @@ export type UpdateUserPayload = {
     password?: string;
     name?: string;
     organization?: string;
+    roles?: string[];
+    other_role?: string;
     current_password: string;
   };
 };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -12,8 +12,8 @@ export type SignupPayload = {
     password: string;
     name: string;
     organization?: string;
-    roles?: string[];
-    other_role?: string;
+    user_roles?: string[];
+    user_role_other?: string;
   };
 };
 export type SignupResponse =
@@ -25,8 +25,8 @@ export type UpdateUserPayload = {
     password?: string;
     name?: string;
     organization?: string;
-    roles?: string[];
-    other_role?: string;
+    user_roles?: string[];
+    user_role_other?: string;
     current_password: string;
   };
 };


### PR DESCRIPTION
## What

Implements the **"What is your role?"** field on the User Profile ([GMW-1043](https://vizzuality.atlassian.net/browse/GMW-1043)), on both **signup** and the **account/profile edit** form. Also adds required-field markers across the auth forms.

## Changes

### Role field (GMW-1043)
- Optional multi-select role field with the predefined role list (label → backend enum: `scientist`, `academic`, `ngo`, `government_policy`, `natural_resource_manager`, `industry`, `education`, `legal_enforcement`, `other`). There is no API endpoint exposing the list — it lives in `src/containers/auth/constants.ts` and must stay in sync with the backend enum.
- Selecting **Other** reveals a required free-text input; the custom value is sent only when Other is selected and cleared otherwise.
- Payload uses the API keys **`user_roles`** and **`user_role_other`** on create and update.
- **Profile edit**: field is prefilled from the session; `roles`/`other_role` are threaded through the NextAuth JWT + session (both the credentials and shared-token providers), and profile edits are reflected into the JWT via the `update` trigger so saved values show without re-login.

### New `RolesSelect` component
- Radix Popover + option list. Built instead of reusing `ui/select-multi`, whose Headless UI 1.7 Listbox infinite-loops ("Maximum update depth exceeded") under the React 19 that ships with Next 16. (The existing restoration-sites filter that uses `select-multi` is likely affected too — worth a separate ticket.)

### Required-field markers
- `FormLabel` gained a working `required` prop (it previously declared the prop but rendered nothing, leaking an invalid DOM attribute). Renders ` *` with `title="required field"` + `aria-label`.
- Marked as required: Name/Email/Password/Confirm Password on **signup**, Email/Password on **login**, Password/Confirm Password on **reset-password**. Forgot-password already passed `required` and now works.

### Misc
- Replaced a bogus `divide-text-gray-200 divide-y` utility on signup with a semantic `<hr>` (border `rgba(0,0,0,0.10)`), fixing the divider sitting too close to the Register button.
- Signup now also sends `organization` (it was collected but silently dropped).

## Test plan

- [x] `pnpm check-types` clean
- [x] `pnpm lint` — no new errors (pre-existing warnings only)
- [x] Signup: role dropdown, conditional Other input, validation states, required markers — verified in browser
- [x] Login / reset-password required markers — verified in browser
- [ ] **Account/profile edit** — not screenshot-verified: the panel is behind a live authenticated session (login feature flag + auth), and the repo's Playwright storage-state is unauthenticated. Reuses the signup-verified components. Needs a manual pass logged in.
- [ ] End-to-end against the backend once BE ([GMW-1044](https://vizzuality.atlassian.net/browse/GMW-1044)) is deployed — confirm `user_roles`/`user_role_other` round-trip on create, update, and GET.

Closes GMW-1043


[GMW-1043]: https://vizzuality.atlassian.net/browse/GMW-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GMW-1044]: https://vizzuality.atlassian.net/browse/GMW-1044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ