### PR TITLE
fix: role dropdown hidden behind menu dialog on profile (GMW-1043)

### DIFF
--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -47,9 +47,12 @@ const RolesSelect = ({ id, placeholder, options, values, onChange }: RolesSelect
           />
         </button>
       </PopoverTrigger>
+      {/* z-[70] overrides the default popover z-50 so the dropdown renders
+          above the menu Dialog (portal wrapper z-60) on the profile page —
+          otherwise it paints behind the dialog panel and looks empty. */}
       <PopoverContent
         align="start"
-        className="max-h-60 w-[var(--radix-popover-trigger-width)] space-y-0 rounded-2xl p-2"
+        className="z-[70] max-h-60 w-[var(--radix-popover-trigger-width)] space-y-0 rounded-2xl p-2"
       >
         <div role="listbox" aria-multiselectable="true">
           {options.map((option) => {

--- a/src/components/ui/popover/index.tsx
+++ b/src/components/ui/popover/index.tsx
@@ -17,10 +17,13 @@ const PopoverContent = React.forwardRef<
       ref={ref}
       align={align}
       sideOffset={sideOffset}
-      className={cn(className, {
-        'text-popover-foreground w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85 outline-none':
-          true,
-      })}
+      // className is passed last so consumers can override the defaults
+      // (e.g. z-index when nested inside a higher-stacked Dialog) — twMerge
+      // keeps the last conflicting utility.
+      className={cn(
+        'text-popover-foreground w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85 outline-none',
+        className
+      )}
       {...props}
     />
   </PopoverPrimitive.Portal>


### PR DESCRIPTION
## What

Follow-up to [GMW-1043](https://vizzuality.atlassian.net/browse/GMW-1043) / #1583. On the profile page the **role dropdown appeared empty**.

## Cause

The profile form renders inside the menu `Dialog`, whose portal wrapper is `z-60` (`dialog/index.tsx`). The shared `PopoverContent` is `z-50` (`popover/index.tsx`). Both portal to `<body>`, so z-index decides paint order — the dropdown opened but rendered *behind* the dialog panel, looking empty. On signup (no dialog) it worked.

## Fix

Instead of forking the component, made `PopoverContent` overridable and reused it:

- `PopoverContent` now passes `className` **last** into `cn()`, so `twMerge` lets any consumer override the defaults (previously the hardcoded classes came last and always won). This makes the shared component scalable for any nesting context.
- `RolesSelect` reuses `PopoverContent` and just overrides `z-[70]` (above the dialog's `z-60`).

## Test plan

- [x] `pnpm check-types` / lint clean
- [x] Signup: still renders all 9 options, no regression (verified in browser)
- [x] Rendered popover computes `z-index: 70`, `z-50` dropped by twMerge (verified)
- [ ] **Profile (logged in)**: dropdown now visible above the dialog — needs a manual pass with a session (can't authenticate in the test harness)

Part of GMW-1043


[GMW-1043]: https://vizzuality.atlassian.net/browse/GMW-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ