### PR TITLE
fix: preserve logo aspect ratio to silence next/image warning

### DIFF
--- a/src/components/logo/index.tsx
+++ b/src/components/logo/index.tsx
@@ -5,7 +5,6 @@ type LogoProps = {
   src?: string;
   onClick?: () => void;
   width?: number;
-  height?: number;
   position?: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 };
 
@@ -16,11 +15,17 @@ const POSITION_CLASSES: Record<string, string> = {
   'bottom-right': 'bottom-0 right-0',
 };
 
+// Intrinsic dimensions of logo.webp — kept constant so next/image always has
+// the correct aspect ratio. Display size is driven by CSS (width prop + height
+// auto), which avoids the "width/height modified but not the other" warning
+// when responsive rules constrain one dimension.
+const INTRINSIC_WIDTH = 186;
+const INTRINSIC_HEIGHT = 216;
+
 const Logo = ({
   src = '/images/logo.webp',
   onClick,
-  width = 186,
-  height = 216,
+  width = INTRINSIC_WIDTH,
   position = 'top-right',
 }: LogoProps) => {
   return (
@@ -31,7 +36,14 @@ const Logo = ({
       data-testid="desktop-logo"
       {...(onClick && { onClick })}
     >
-      <Image src={src} alt="Global Mangrove Watch" width={width} height={height} priority={true} />
+      <Image
+        src={src}
+        alt="Global Mangrove Watch"
+        width={INTRINSIC_WIDTH}
+        height={INTRINSIC_HEIGHT}
+        priority={true}
+        style={{ width, height: 'auto' }}
+      />
     </Link>
   );
 };

--- a/src/layouts/desktop/index.tsx
+++ b/src/layouts/desktop/index.tsx
@@ -22,13 +22,7 @@ const DesktopLayout = () => {
 
   return (
     <div className="pointer-events-none">
-      <Logo
-        src="/images/logo-bg.png"
-        position="top-right"
-        width={186}
-        height={216}
-        onClick={handleReset}
-      />
+      <Logo src="/images/logo-bg.png" position="top-right" width={186} onClick={handleReset} />
     </div>
   );
 };


### PR DESCRIPTION
## What

Silences the browser console warning:

> Image with src "/images/logo.webp" has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.

## Cause

`Logo` passed `width`/`height` straight to `next/image`. Callers overrode `width` (e.g. `360` on signup) while `height` stayed `216`, and responsive CSS constrains one dimension — breaking the intrinsic ratio (186×216) and distorting the logo.

## Fix

- Pass the constant intrinsic dimensions (186×216) to `next/image` so it always has the correct ratio.
- Drive display size via CSS: `style={{ width, height: 'auto' }}`.
- Drop the now-unused `height` prop from `Logo` and its one caller.

## Test plan

- [x] `pnpm check-types` / lint clean
- [x] Signup: **0** logo warnings (was firing before); logo renders with correct aspect ratio (360×425 vs the previous distorted 360×216) — verified in browser
