### PR TITLE
fix: allow selecting roles in profile dropdown inside dialog (GMW-1043)

### DIFF
--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -29,7 +29,11 @@ const RolesSelect = ({ id, placeholder, options, values, onChange }: RolesSelect
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    // modal: this is used inside the modal menu Dialog on the profile page,
+    // which sets pointer-events:none on the body. A non-modal popover portals
+    // to the body and never re-enables them, so options open but can't be
+    // clicked. modal makes the popover manage pointer events for its own layer.
+    <Popover open={open} onOpenChange={setOpen} modal>
       <PopoverTrigger asChild>
         <button
           id={id}


### PR DESCRIPTION
## What

Follow-up to [GMW-1043](https://vizzuality.atlassian.net/browse/GMW-1043) (after #1584). On the profile page the role dropdown now opens and shows options, but **options couldn't be selected**.

## Cause

The profile form lives inside the menu `Dialog`, which is **modal** and sets `pointer-events: none` on `<body>`. The role popover portals to the body and, being non-modal, never re-enabled pointer events — so the list rendered but clicks never landed.

## Fix

Mark the popover `modal` (`<Popover ... modal>`) so it manages pointer events for its own layer.

## Test plan

- [x] `pnpm check-types` / lint clean
- [x] Signup: multi-select still registers (trigger shows "Scientist, NGO"), no crash — verified in browser
- [ ] **Profile (logged in)**: options now selectable inside the dialog — needs a manual pass with a session (can't authenticate in the test harness)

Part of GMW-1043


[GMW-1043]: https://vizzuality.atlassian.net/browse/GMW-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ