### PR TITLE
fix: filter alerts map layer by widget date range

### DIFF
--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import type { SourceProps } from 'react-map-gl';
 
@@ -422,24 +422,19 @@ export function useAlerts<TRaw = AlertsApiResponse>(
     ...queryOptions,
   });
 
-  // Keep refs current so the effect below can read latest values without being in its dep array
-  const startDateRef = useRef(startDate);
-  startDateRef.current = startDate;
-  const endDateRef = useRef(endDate);
-  endDateRef.current = endDate;
-
-  // Initialize atoms from API defaults — only when atom is null (user hasn't picked yet).
+  // Initialize atoms from API defaults — only when atom is unset (user hasn't picked yet).
   // Use primitive .value strings as deps to avoid re-firing when select() returns a new object
-  // reference on every render (which would cause an infinite loop).
+  // reference on every render (which would cause an infinite loop). Re-runs on user picks are
+  // harmless: the unset guards turn them into no-ops.
   const defaultStartValue = query.data?.defaultStartDate?.value;
   const defaultEndValue = query.data?.defaultEndDate?.value;
   useEffect(() => {
     if (!query.data) return;
     const { defaultStartDate, defaultEndDate } = query.data;
-    if (!startDateRef.current && defaultStartDate) setStartDate(defaultStartDate);
-    if (!endDateRef.current && defaultEndDate) setEndDate(defaultEndDate);
+    if (!startDate && defaultStartDate) setStartDate(defaultStartDate);
+    if (!endDate && defaultEndDate) setEndDate(defaultEndDate);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultStartValue, defaultEndValue, setStartDate, setEndDate]);
+  }, [defaultStartValue, defaultEndValue, startDate, endDate, setStartDate, setEndDate]);
 
   return query;
 }
@@ -462,10 +457,24 @@ export function useLayers({
   opacity?: number;
   visibility?: Visibility;
 }): CircleLayerSpecification[] {
+  const startDate = useAtomValue(alertsStartDate);
+  const endDate = useAtomValue(alertsEndDate);
+
   const cutoff3 = monthsAgoYMD(3);
   const cutoff6 = monthsAgoYMD(6);
   const cutoff12 = monthsAgoYMD(12);
   const cutoff24 = monthsAgoYMD(24);
+
+  // Restrict alerts to the widget's selected date range; until the user (or the
+  // widget defaults) pick one, show everything.
+  const dateRangeFilter: ExpressionSpecification[] = [
+    ...(startDate?.value
+      ? [['>=', ['get', 'scr5_obs_date'], startDate.value] as ExpressionSpecification]
+      : []),
+    ...(endDate?.value
+      ? [['<=', ['get', 'scr5_obs_date'], endDate.value] as ExpressionSpecification]
+      : []),
+  ];
 
   const radius: ExpressionSpecification = ['interpolate', ['linear'], ['zoom'], 0, 2, 9, 6, 14, 10];
 
@@ -491,6 +500,7 @@ export function useLayers({
         'all',
         ['has', 'scr5_obs_date'],
         ['<', ['get', 'scr5_obs_date'], cutoff24],
+        ...dateRangeFilter,
       ] as FilterSpecification,
       paint: { ...paintProps, 'circle-color': '#FFC201' },
     },
@@ -502,6 +512,7 @@ export function useLayers({
         ['has', 'scr5_obs_date'],
         ['>=', ['get', 'scr5_obs_date'], cutoff24],
         ['<', ['get', 'scr5_obs_date'], cutoff12],
+        ...dateRangeFilter,
       ] as FilterSpecification,
       paint: { ...paintProps, 'circle-color': '#F78E1C' },
     },
@@ -513,6 +524,7 @@ export function useLayers({
         ['has', 'scr5_obs_date'],
         ['>=', ['get', 'scr5_obs_date'], cutoff12],
         ['<', ['get', 'scr5_obs_date'], cutoff6],
+        ...dateRangeFilter,
       ] as FilterSpecification,
       paint: { ...paintProps, 'circle-color': '#ED4F3F' },
     },
@@ -524,6 +536,7 @@ export function useLayers({
         ['has', 'scr5_obs_date'],
         ['>=', ['get', 'scr5_obs_date'], cutoff6],
         ['<', ['get', 'scr5_obs_date'], cutoff3],
+        ...dateRangeFilter,
       ] as FilterSpecification,
       paint: { ...paintProps, 'circle-color': '#DC3982' },
     },
@@ -534,6 +547,7 @@ export function useLayers({
         'all',
         ['has', 'scr5_obs_date'],
         ['>=', ['get', 'scr5_obs_date'], cutoff3],
+        ...dateRangeFilter,
       ] as FilterSpecification,
       paint: { ...paintProps, 'circle-color': '#C62AD6' },
     },


### PR DESCRIPTION
## Summary

Fixes [GMW-1048](https://vizzuality.atlassian.net/browse/GMW-1048): changing the date range in the alerts widget did not affect the alerts shown on the map — all alerts stayed visible regardless of the selected timeframe.

The production alerts variant (feature flag `mangrove_alerts: true`) renders a single static vector tileset and builds its age-bucket circle layers client-side in `useLayers` (`src/containers/datasets/alerts/hooks.tsx`), which never read the `alertsStartDate`/`alertsEndDate` atoms written by the widget. The filter only affected the chart. (The legacy `alerts-staging` variant passed the dates to the tiler URL, which is why this regressed with the tileset-based approach.)

Changes:

- `useLayers` now reads both date atoms and appends `scr5_obs_date >= start` / `<= end` clauses to all five age-bucket layer filters. While the atoms are unset (before widget defaults load), no clause is added and all alerts render, matching previous behavior.
- Replaced a render-time ref mutation in `useAlerts` with guarded effect deps — pre-existing `react-hooks/refs` lint error that blocked committing; same semantics (defaults only initialize unset atoms, re-runs on user picks are no-ops).

## Test plan

Verified end-to-end with a headed browser (`NEXT_PUBLIC_FEATURED_FLAGS` with `mangrove_alerts: true`, Tarakan/Borneo view):

- [x] Defaults (Jan 2019–May 2026): map filters contain the full range, all buckets render (63,667 features).
- [x] End = Dec 2019: only the >24-months bucket (yellow) renders, 17,143 features, all other buckets 0 — map matches chart.
- [x] Start = Feb 2026: zero dots — correct: the tileset's `scr5_obs_date` ends 2026-01-31 at that view (see note).
- [x] `tsc` and ESLint clean.

## Note for QA

The static tileset (`globalmangrovewatch.0vowa2i9`) currently ends at 2026-01-31 while the fetch-alerts API serves data through May 2026, so selecting only the most recent months correctly renders an empty map until the tileset is refreshed. That is a data-pipeline gap, not part of this fix.

[GMW-1048]: https://vizzuality.atlassian.net/browse/GMW-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ