### PR TITLE
fix: alerts widget axis labels and monitored areas outline

### DIFF
--- a/src/components/chart/chart-tick.tsx
+++ b/src/components/chart/chart-tick.tsx
@@ -4,14 +4,18 @@ import type { FC } from 'react';
 export const MAX_TICK_LABELS = 8;
 
 // Whether a tick at `index` should render its label: evenly spaced positions plus
-// the last tick, so a dense axis shows a readable, non-overlapping subset.
+// the last tick, so a dense axis shows a readable, non-overlapping subset. Step
+// multiples closer than half a step to the end are skipped so they don't crowd
+// the always-shown last label.
 export function shouldShowTickLabel(
   index: number,
   visibleTicksCount: number,
   maxLabels: number = MAX_TICK_LABELS
 ): boolean {
   const step = Math.max(1, Math.ceil(visibleTicksCount / maxLabels));
-  return index % step === 0 || index === visibleTicksCount - 1;
+  const last = visibleTicksCount - 1;
+  if (index === last) return true;
+  return index % step === 0 && last - index > step / 2;
 }
 
 export type ChartTickProps = {
@@ -32,6 +36,10 @@ export type ChartTickProps = {
   // render all ticks with an evenly spaced subset of labels. Falls back to the
   // maxLabels thinning when omitted.
   labelValues?: (string | number)[];
+  // Explicit set of tick indices to label. Takes precedence over labelValues —
+  // use it when tick values repeat across the axis (e.g. one point per month
+  // labelled by year), where matching by value would label every duplicate.
+  labelIndices?: number[];
 };
 
 // Shared axis tick used across widget charts/brushes so tick↔label padding and
@@ -48,10 +56,13 @@ const ChartTick: FC<ChartTickProps> = ({
   maxLabels = MAX_TICK_LABELS,
   angle,
   labelValues,
+  labelIndices,
 }) => {
-  const showLabel = labelValues
-    ? payload?.value != null && labelValues.includes(payload.value)
-    : shouldShowTickLabel(index, visibleTicksCount, maxLabels);
+  const showLabel = labelIndices
+    ? labelIndices.includes(index)
+    : labelValues
+      ? payload?.value != null && labelValues.includes(payload.value)
+      : shouldShowTickLabel(index, visibleTicksCount, maxLabels);
   if (!showLabel) {
     return <g transform={`translate(${x},${y})`} />;
   }

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -24,7 +24,7 @@ import { useSyncLocation } from 'hooks/use-sync-location';
 
 import { useLocation } from '@/containers/datasets/locations/hooks';
 
-import ChartTick from '@/components/chart/chart-tick';
+import ChartTick, { MAX_TICK_LABELS } from '@/components/chart/chart-tick';
 import { Visibility } from '@/types/layers';
 
 import API_cloud_functions from 'services/cloud-functions';
@@ -176,6 +176,30 @@ const getData = (data) =>
 
 const getTotal = (data: { count: number }[]) =>
   data?.reduce((previous: number, current: { count: number }) => current.count + previous, 0);
+
+// Brush x-axis labelling for sparse monthly series. Year values repeat per data
+// point and months can be missing, so labelling each year at its first point
+// bunches labels wherever the data is dense. Instead pick evenly spaced slot
+// indices and keep a year only where it differs from the previously kept one:
+// an even label grid at the cost of some years being skipped or a label
+// sitting mid-year.
+export const getBrushYearLabelIndices = (
+  years: number[],
+  maxLabels = MAX_TICK_LABELS
+): number[] => {
+  const n = years.length;
+  if (n === 0) return [];
+  const m = Math.min(maxLabels, n);
+  const slots =
+    m === 1
+      ? [0]
+      : [...new Set(Array.from({ length: m }, (_, k) => Math.round((k * (n - 1)) / (m - 1))))];
+  const kept: number[] = [];
+  for (const i of slots) {
+    if (kept.length === 0 || years[i] !== years[kept[kept.length - 1]]) kept.push(i);
+  }
+  return kept;
+};
 
 type DateOption = { label: string; value: string };
 
@@ -394,8 +418,10 @@ export function useAlerts<TRaw = AlertsApiResponse>(
           },
         },
         xAxis: {
-          tick: <ChartTick />,
-          ticks: Array.from(new Set(fixedXAxis)),
+          // A tick mark per data point (like the main chart) with year labels at
+          // evenly spaced slots — year-per-first-occurrence ticks bunch up when
+          // months are missing from the series.
+          tick: <ChartTick labelIndices={getBrushYearLabelIndices(fixedXAxis)} />,
           interval: 0,
           type: 'category',
           axisLine: false,

--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -17,6 +17,7 @@ import type {
   CircleLayerSpecification,
   ExpressionSpecification,
   FilterSpecification,
+  LineLayerSpecification,
 } from 'mapbox-gl';
 import { CartesianViewBox } from 'recharts/types/util/types';
 
@@ -466,12 +467,19 @@ export function useAlerts<TRaw = AlertsApiResponse>(
 }
 
 // dataset layer
-export function useSource(): SourceProps {
-  return {
-    id: 'alerts-heatmap-vector',
-    type: 'vector',
-    url: 'mapbox://globalmangrovewatch.0vowa2i9',
-  };
+export function useSources(): SourceProps[] {
+  return [
+    {
+      id: 'alerts-dots',
+      type: 'vector',
+      url: 'mapbox://globalmangrovewatch.0vowa2i9',
+    },
+    {
+      id: 'monitored-alerts',
+      type: 'vector',
+      url: 'mapbox://globalmangrovewatch.c5dgz6m3',
+    },
+  ];
 }
 
 export function useLayers({
@@ -482,7 +490,10 @@ export function useLayers({
   id: string;
   opacity?: number;
   visibility?: Visibility;
-}): CircleLayerSpecification[] {
+}): {
+  'alerts-dots': CircleLayerSpecification[];
+  'monitored-alerts': LineLayerSpecification[];
+} {
   const startDate = useAtomValue(alertsStartDate);
   const endDate = useAtomValue(alertsEndDate);
 
@@ -506,7 +517,7 @@ export function useLayers({
 
   const layerProps: Omit<CircleLayerSpecification, 'id' | 'filter' | 'paint'> = {
     type: 'circle',
-    source: 'alerts-heatmap-vector',
+    source: 'alerts-dots',
     'source-layer': 'alerts',
     minzoom: 0,
     maxzoom: 18,
@@ -518,64 +529,83 @@ export function useLayers({
     'circle-opacity': opacity ?? 1,
   };
 
-  return [
-    {
-      ...layerProps,
-      id: `${id}-gt24`,
-      filter: [
-        'all',
-        ['has', 'scr5_obs_date'],
-        ['<', ['get', 'scr5_obs_date'], cutoff24],
-        ...dateRangeFilter,
-      ] as FilterSpecification,
-      paint: { ...paintProps, 'circle-color': '#FFC201' },
-    },
-    {
-      ...layerProps,
-      id: `${id}-12-24`,
-      filter: [
-        'all',
-        ['has', 'scr5_obs_date'],
-        ['>=', ['get', 'scr5_obs_date'], cutoff24],
-        ['<', ['get', 'scr5_obs_date'], cutoff12],
-        ...dateRangeFilter,
-      ] as FilterSpecification,
-      paint: { ...paintProps, 'circle-color': '#F78E1C' },
-    },
-    {
-      ...layerProps,
-      id: `${id}-6-12`,
-      filter: [
-        'all',
-        ['has', 'scr5_obs_date'],
-        ['>=', ['get', 'scr5_obs_date'], cutoff12],
-        ['<', ['get', 'scr5_obs_date'], cutoff6],
-        ...dateRangeFilter,
-      ] as FilterSpecification,
-      paint: { ...paintProps, 'circle-color': '#ED4F3F' },
-    },
-    {
-      ...layerProps,
-      id: `${id}-3-6`,
-      filter: [
-        'all',
-        ['has', 'scr5_obs_date'],
-        ['>=', ['get', 'scr5_obs_date'], cutoff6],
-        ['<', ['get', 'scr5_obs_date'], cutoff3],
-        ...dateRangeFilter,
-      ] as FilterSpecification,
-      paint: { ...paintProps, 'circle-color': '#DC3982' },
-    },
-    {
-      ...layerProps,
-      id: `${id}-lt3`,
-      filter: [
-        'all',
-        ['has', 'scr5_obs_date'],
-        ['>=', ['get', 'scr5_obs_date'], cutoff3],
-        ...dateRangeFilter,
-      ] as FilterSpecification,
-      paint: { ...paintProps, 'circle-color': '#C62AD6' },
-    },
-  ];
+  return {
+    'monitored-alerts': [
+      {
+        id: `${id}-line`,
+        type: 'line',
+        source: 'monitored-alerts',
+        'source-layer': 'alert_region_tiles',
+        minzoom: 0,
+        paint: {
+          'line-color': '#00857F',
+          'line-opacity': opacity ?? 1,
+          'line-width': 1,
+        },
+        layout: {
+          visibility,
+        },
+      },
+    ],
+    'alerts-dots': [
+      {
+        ...layerProps,
+        id: `${id}-gt24`,
+        filter: [
+          'all',
+          ['has', 'scr5_obs_date'],
+          ['<', ['get', 'scr5_obs_date'], cutoff24],
+          ...dateRangeFilter,
+        ] as FilterSpecification,
+        paint: { ...paintProps, 'circle-color': '#FFC201' },
+      },
+      {
+        ...layerProps,
+        id: `${id}-12-24`,
+        filter: [
+          'all',
+          ['has', 'scr5_obs_date'],
+          ['>=', ['get', 'scr5_obs_date'], cutoff24],
+          ['<', ['get', 'scr5_obs_date'], cutoff12],
+          ...dateRangeFilter,
+        ] as FilterSpecification,
+        paint: { ...paintProps, 'circle-color': '#F78E1C' },
+      },
+      {
+        ...layerProps,
+        id: `${id}-6-12`,
+        filter: [
+          'all',
+          ['has', 'scr5_obs_date'],
+          ['>=', ['get', 'scr5_obs_date'], cutoff12],
+          ['<', ['get', 'scr5_obs_date'], cutoff6],
+          ...dateRangeFilter,
+        ] as FilterSpecification,
+        paint: { ...paintProps, 'circle-color': '#ED4F3F' },
+      },
+      {
+        ...layerProps,
+        id: `${id}-3-6`,
+        filter: [
+          'all',
+          ['has', 'scr5_obs_date'],
+          ['>=', ['get', 'scr5_obs_date'], cutoff6],
+          ['<', ['get', 'scr5_obs_date'], cutoff3],
+          ...dateRangeFilter,
+        ] as FilterSpecification,
+        paint: { ...paintProps, 'circle-color': '#DC3982' },
+      },
+      {
+        ...layerProps,
+        id: `${id}-lt3`,
+        filter: [
+          'all',
+          ['has', 'scr5_obs_date'],
+          ['>=', ['get', 'scr5_obs_date'], cutoff3],
+          ...dateRangeFilter,
+        ] as FilterSpecification,
+        paint: { ...paintProps, 'circle-color': '#C62AD6' },
+      },
+    ],
+  };
 }

--- a/src/containers/datasets/alerts/layer.tsx
+++ b/src/containers/datasets/alerts/layer.tsx
@@ -6,13 +6,13 @@ import { useSyncActiveLayers } from '@/store/layers';
 
 import type { LayerProps } from 'types/layers';
 
-import { useLayers, useSource } from './hooks';
+import { useLayers, useSources } from './hooks';
 
 const MangrovesAlertsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => {
   const [activeLayers] = useSyncActiveLayers();
   const activeLayer = activeLayers?.find((l) => l.id === id);
 
-  const source = useSource();
+  const SOURCES = useSources();
   const LAYERS = useLayers({
     id,
     opacity: parseFloat(activeLayer.opacity),
@@ -20,21 +20,24 @@ const MangrovesAlertsLayer = ({ beforeId, id, onAdd, onRemove }: LayerProps) => 
   });
 
   useEffect(() => {
-    const ids = LAYERS.map((l) => l.id);
+    const ids = Object.values(LAYERS)
+      .flat()
+      .map((l) => l.id);
     onAdd(ids);
     return () => onRemove(ids);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [onAdd, onRemove]);
 
-  if (!source || !LAYERS) return null;
+  if (!SOURCES || !LAYERS) return null;
 
-  return (
-    <Source key={source.id} {...source}>
-      {LAYERS.map((layer) => (
-        <Layer key={layer.id} {...layer} beforeId={beforeId} />
-      ))}
+  return SOURCES.map((SOURCE) => (
+    <Source key={SOURCE.id} {...SOURCE}>
+      {SOURCE.id &&
+        LAYERS[SOURCE.id as keyof typeof LAYERS]?.map((LAYER) => (
+          <Layer key={LAYER.id} {...LAYER} beforeId={beforeId} />
+        ))}
     </Source>
-  );
+  ));
 };
 
 export default MangrovesAlertsLayer;

--- a/tests/unit/components/chart/chart-tick.test.ts
+++ b/tests/unit/components/chart/chart-tick.test.ts
@@ -25,6 +25,13 @@ describe('shouldShowTickLabel', () => {
     expect(shouldShowTickLabel(count - 1, count, 8)).toBe(true);
   });
 
+  it('skips step multiples that would crowd the always-shown last label', () => {
+    const count = 27; // step = ceil(27 / 8) = 4, last = 26
+    expect(shouldShowTickLabel(24, count, 8)).toBe(false); // 2 ticks from the end
+    expect(shouldShowTickLabel(20, count, 8)).toBe(true);
+    expect(shouldShowTickLabel(26, count, 8)).toBe(true);
+  });
+
   it('defaults maxLabels to MAX_TICK_LABELS', () => {
     const count = MAX_TICK_LABELS * 3;
     const withDefault = shouldShowTickLabel(MAX_TICK_LABELS, count);

--- a/tests/unit/containers/datasets/alerts/hooks.test.ts
+++ b/tests/unit/containers/datasets/alerts/hooks.test.ts
@@ -1,0 +1,28 @@
+import { getBrushYearLabelIndices } from '@/containers/datasets/alerts/hooks';
+
+describe('getBrushYearLabelIndices', () => {
+  it('returns no indices for an empty series', () => {
+    expect(getBrushYearLabelIndices([])).toEqual([]);
+  });
+
+  it('labels every point when there are fewer points than maxLabels', () => {
+    expect(getBrushYearLabelIndices([2019, 2020, 2021])).toEqual([0, 1, 2]);
+  });
+
+  it('picks evenly spaced slots and drops consecutive repeated years', () => {
+    // Sparse monthly series (à la The Gambia): 27 points, months missing, so
+    // years cover uneven index ranges.
+    const years = [
+      2019, 2019, 2019, 2020, 2020, 2021, 2021, 2021, 2021, 2021, 2021, 2021, 2021, 2022, 2022,
+      2022, 2022, 2023, 2023, 2023, 2023, 2024, 2024, 2024, 2024, 2024, 2024,
+    ];
+    // 8 slots over 27 points -> indices [0, 4, 7, 11, 15, 19, 22, 26]; 11 and
+    // 26 repeat the year of the previously kept slot and are dropped, leaving
+    // every year labelled once on an even grid.
+    expect(getBrushYearLabelIndices(years)).toEqual([0, 4, 7, 15, 19, 22]);
+  });
+
+  it('collapses to a single label when every point shares one year', () => {
+    expect(getBrushYearLabelIndices([2020, 2020, 2020, 2020])).toEqual([0]);
+  });
+});


### PR DESCRIPTION
## Summary

Two alerts-widget improvements, one commit each.

### Even axis labels for sparse series (`bce1dd66`)

For locations whose alerts series has months without data (e.g. The Gambia), the axes labelled unevenly: the **brush** placed each year label at that year's first data point (labels bunched wherever data was dense), and the **main chart** crowded its last two labels. The series is intentionally left as-is (no zero/gap filling); only labelling changes:

- `ChartTick` gains a `labelIndices` prop for axes whose tick values repeat (a year per monthly point) — matching by value (`labelValues`) would label every duplicate.
- The alerts brush drops its unique-years `ticks` override: a tick mark per data point (consistent with the main chart), year labels at evenly spaced slots via `getBrushYearLabelIndices`, skipping consecutive duplicate years. On sparse series a year label can sit mid-year or a year can be skipped — accepted trade-off for an even grid.
- `shouldShowTickLabel` skips step multiples closer than half a step to the end so they don't crowd the always-shown last label (benefits every widget using the default thinning).

### Monitored areas outline on the alerts layer (`0844c09d`)

The tileset-based alerts variant lost the monitoring-region outlines the legacy variant had. Layers are now grouped per source, like the staging variant:

- `useSources` serves both `alerts-heatmap-vector` (age-bucket circles, date-range filtered) and `monitored-alerts` (`alert_region_tiles` line layer, `#00857F`).
- `useLayers` returns `{ 'alerts-heatmap-vector': CircleLayerSpecification[]; 'monitored-alerts': LineLayerSpecification[] }`; `layer.tsx` renders each source with its own layers and registers all layer ids.

## Test plan

- [x] Unit tests: `getBrushYearLabelIndices` (empty, short, sparse Gambia-like, single-year) and the end-crowding rule in `shouldShowTickLabel` — full vitest suite 85/85.
- [x] Runtime, Gambia (`/country/GMB`, 27 sparse points): main chart labels every ~60px, crowded end pair gone; brush ticks per point with year labels `2019/2020/2021/2023/2024` on an even grid (previously `2019`@10px, `2020`@56, `2021`@87, `2022`@257, `2023`@288, `2024`@366).
- [x] Runtime, worldwide (89 continuous points): main chart labels Jan of every year + May '26; brush all years 2019–2026 on a uniform ~55px grid.
- [x] Runtime, map: `mangrove_alerts-line` present in the style, monitoring-region outlines render alongside the circles, and the age-bucket date-range filters are unchanged.
- [x] `tsc`, ESLint clean.