### PR TITLE
feat: add monitored area legend to alerts widget and map legends

### DIFF
--- a/src/containers/datasets/alerts-staging/map-legend.tsx
+++ b/src/containers/datasets/alerts-staging/map-legend.tsx
@@ -10,6 +10,16 @@ const AlertsMapLegend = () => {
         />
         <p>Alerts</p>
       </div>
+      <div className="flex space-x-2">
+        <div className="flex">
+          <div className="flex flex-col">
+            <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+            <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+          </div>
+          <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+        </div>
+        <p className="text-sm font-normal">Monitored area</p>
+      </div>
     </div>
   );
 };

--- a/src/containers/datasets/alerts/map-legend.tsx
+++ b/src/containers/datasets/alerts/map-legend.tsx
@@ -10,6 +10,16 @@ const AlertsMapLegend = () => {
         />
         <p>Alerts</p>
       </div>
+      <div className="flex space-x-2">
+        <div className="flex">
+          <div className="flex flex-col">
+            <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+            <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+          </div>
+          <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+        </div>
+        <p className="text-sm font-normal">Monitored area</p>
+      </div>
     </div>
   );
 };

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -251,9 +251,21 @@ const AlertsWidget = () => {
         </div>
       )}
       {!isError && !isLoading && (
-        <p className="items-center pt-6 font-sans text-lg leading-7 font-light">
-          There are <span className="font-bold"> 535</span> areas monitored in the world.
-        </p>
+        <>
+          <p className="items-center pt-6 font-sans text-lg leading-7 font-light">
+            There are <span className="font-bold"> 535</span> areas monitored in the world.
+          </p>
+          <div className="flex space-x-2">
+            <div className="flex">
+              <div className="flex flex-col">
+                <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+                <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+              </div>
+              <div className="text-brand-900 border-brand-800 h-2 w-2 border-2" />
+            </div>
+            <p className="text-sm font-normal">Monitored area</p>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Companion to #1592 (which added the monitored-areas outline layer to the alerts map): add a "Monitored area" legend entry so the teal region outlines are identifiable.

- Map legend (both `alerts` and `alerts-staging` variants): outline swatch + "Monitored area" label under the existing Alerts entry.
- Alerts widget: same legend row under the "areas monitored in the world" sentence.

## Test plan

- [x] Lint + `tsc` clean (pre-commit).
- [ ] Visual: alerts layer active → map legend shows Alerts + Monitored area; widget shows the legend under the monitored-areas sentence.