### PR TITLE
fix: only require current password when changing password in account form (GMW-1046)

### DIFF
--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -17,10 +17,25 @@ type RolesSelectProps = {
   options: RoleOption[];
   values: string[];
   onChange: (values: string[]) => void;
+  // Notified when the dropdown opens/closes, e.g. to disable a submit button
+  // while the user is still picking.
+  onOpenChange?: (open: boolean) => void;
 };
 
-const RolesSelect = ({ id, placeholder, options, values, onChange }: RolesSelectProps) => {
+const RolesSelect = ({
+  id,
+  placeholder,
+  options,
+  values,
+  onChange,
+  onOpenChange,
+}: RolesSelectProps) => {
   const [open, setOpen] = useState(false);
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    onOpenChange?.(nextOpen);
+  };
 
   const selectedLabels = options.filter((o) => values.includes(o.value)).map((o) => o.label);
 
@@ -33,7 +48,7 @@ const RolesSelect = ({ id, placeholder, options, values, onChange }: RolesSelect
     // which sets pointer-events:none on the body. A non-modal popover portals
     // to the body and never re-enables them, so options open but can't be
     // clicked. modal makes the popover manage pointer events for its own layer.
-    <Popover open={open} onOpenChange={setOpen} modal>
+    <Popover open={open} onOpenChange={handleOpenChange} modal>
       <PopoverTrigger asChild>
         <button
           id={id}

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useState } from 'react';
+
 import { useForm } from 'react-hook-form';
 
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -36,17 +38,15 @@ const formSchema = z
       .optional()
       .default([]),
     'other-role': z.string().optional(),
+    // Empty string means "not changing the password".
     password: z
       .string()
-      .nonempty({ message: 'Please enter your password' })
       .min(6, {
         message: 'Please enter a password with at least 6 characters',
       })
-      .optional(),
-    current_password: z
-      .string()
-      .nonempty({ message: 'Please enter your password' })
-      .min(6, { message: 'Please enter your password' }),
+      .optional()
+      .or(z.literal('')),
+    current_password: z.string().optional(),
     delete_account: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
@@ -57,10 +57,19 @@ const formSchema = z
         path: ['other-role'],
       });
     }
+    // Current password is only needed to change the password.
+    if (data.password && !data.current_password) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Please enter your current password',
+        path: ['current_password'],
+      });
+    }
   });
 
 const AccountContent = () => {
   const { data: session, update: updateSession } = useSession();
+  const [rolesOpen, setRolesOpen] = useState(false);
 
   const user = session?.user;
   const updateUser = usePutUpdateUser(user?.accessToken || '');
@@ -78,12 +87,19 @@ const AccountContent = () => {
       email: user?.email || '',
       roles: user?.roles ?? [],
       'other-role': user?.other_role || '',
-      password: undefined,
+      password: '',
       current_password: '',
     },
   });
 
   const showOtherRole = form.watch('roles')?.includes(OTHER_ROLE_VALUE);
+  const changingPassword = !!form.watch('password');
+
+  // current_password is a confirmation, not a profile change — typing it alone
+  // shouldn't enable saving.
+  const hasChanges = Object.keys(form.formState.dirtyFields).some(
+    (field) => field !== 'current_password'
+  );
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const { email, password, username, organization, roles, current_password } = values;
@@ -95,11 +111,11 @@ const AccountContent = () => {
       {
         user: {
           email,
-          password: password || current_password,
           name: username,
-          current_password,
           organization,
           user_roles: roles ?? [],
+          // Only send password fields when the user is actually changing it.
+          ...(password ? { password, current_password } : {}),
           ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_role_other: otherRole } : {}),
         },
       },
@@ -206,6 +222,7 @@ const AccountContent = () => {
                   placeholder="Select the roles that describe you"
                   options={ROLE_OPTIONS}
                   values={field.value ?? []}
+                  onOpenChange={setRolesOpen}
                   onChange={(selection) => {
                     field.onChange(selection);
                     if (!selection.includes(OTHER_ROLE_VALUE)) {
@@ -252,30 +269,44 @@ const AccountContent = () => {
                     <Input
                       type="password"
                       {...field}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        // Back to "not changing the password": drop the
+                        // confirmation field state along with the input.
+                        if (!e.target.value) {
+                          form.setValue('current_password', '');
+                          form.clearErrors('current_password');
+                        }
+                      }}
                       className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
-                      placeholder="Enter your new password"
+                      // Masked dots so the (unknown) stored password reads as set.
+                      placeholder="••••••••"
                     />
                   </FormControl>
                 </FormItem>
               )}
             />
-            <FormField
-              control={form.control}
-              name="current_password"
-              render={({ field }) => (
-                <FormItem className="flex-1 gap-0">
-                  <FormLabel className="text-xs font-semibold">Current Password</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="password"
-                      {...field}
-                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
-                      placeholder="Enter your current password"
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
+            {changingPassword && (
+              <FormField
+                control={form.control}
+                name="current_password"
+                render={({ field }) => (
+                  <FormItem className="flex-1 gap-0">
+                    <FormLabel className="text-xs font-semibold" required>
+                      Current Password
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        {...field}
+                        className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                        placeholder="Enter your current password"
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            )}
           </div>
         </fieldset>
         <div className="flex w-full items-center gap-6 pb-9">
@@ -320,7 +351,11 @@ const AccountContent = () => {
         />
 
         <div className="flex items-center justify-between">
-          <Button type="submit" disabled={updateUser.isPending} className="h-9 font-semibold">
+          <Button
+            type="submit"
+            disabled={updateUser.isPending || !hasChanges || rolesOpen}
+            className="h-9 font-semibold"
+          >
             {updateUser.isPending ? 'Saving…' : 'Save changes'}
           </Button>
           <Button

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -27,7 +27,8 @@ export type UpdateUserPayload = {
     organization?: string;
     user_roles?: string[];
     user_role_other?: string;
-    current_password: string;
+    // Only required by the API when changing the password.
+    current_password?: string;
   };
 };
 export type UpdateUserResponse =


### PR DESCRIPTION
## Summary

Fixes [GMW-1046](https://vizzuality.atlassian.net/browse/GMW-1046): 500 error when saving the account form.

The form always sent `current_password` and, when no new password was typed, fell back to `password: current_password` — so saving any profile change without touching the password fields sent empty/garbage password data to the API and failed.

Changes:

- **Payload**: `password` + `current_password` are only included when the user actually enters a new password; profile-only updates no longer send password fields at all (`UpdateUserPayload.current_password` is now optional).
- **Validation**: `current_password` is optional in the schema and enforced via `superRefine` only when a new password is set ("Please enter your current password"). The password field accepts empty = "not changing it" (previously `nonempty` broke the form once the field was touched and cleared).
- **UX**:
  - Password input shows masked dots (`••••••••`) so the stored password reads as set; the **Current Password** input only appears while a new password is being typed (required label), and hides + resets when the password field is cleared.
  - **Save changes** is disabled when there are no changes (typing only `current_password` doesn't count), while the roles dropdown is open (new `onOpenChange` prop on `RolesSelect`), or while saving.

## Test plan

- [x] `tsc` + ESLint clean (pre-commit).
- [ ] Logged in: save with only name/organization/role changes → no 500, no password prompt.
- [ ] Type a new password → Current Password field appears and is required; clearing the new password hides it again.
- [ ] Save disabled on open, enabled after an edit, disabled while the roles dropdown is open.

Note: could not drive the logged-in flow headlessly — the Playwright storage state contains no session (global-setup only dismisses the welcome dialog). Manual check needed for the boxes above.

[GMW-1046]: https://vizzuality.atlassian.net/browse/GMW-1046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ