### PR TITLE
feat: draw and analyse saved custom areas on map click

### DIFF
--- a/src/containers/navigation/menu/profile/saved-areas/item.tsx
+++ b/src/containers/navigation/menu/profile/saved-areas/item.tsx
@@ -4,9 +4,14 @@ import { useCallback, useMemo, useState } from 'react';
 
 import cn from '@/lib/classnames';
 
+import { analysisAtom } from '@/store/analysis';
+import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
+
 import turfBbox from '@turf/bbox';
 import bbox from '@turf/bbox';
-import type { Feature, Polygon, MultiPolygon, Geometry } from 'geojson';
+import type { Feature, FeatureCollection, Polygon, MultiPolygon, Geometry } from 'geojson';
+import { useSetAtom } from 'jotai';
+import { useResetAtom } from 'jotai/utils';
 import { LuPencil, LuCheck } from 'react-icons/lu';
 
 import { useLocationNavigation, locationToNavTarget } from 'hooks/location-navigation';
@@ -30,7 +35,7 @@ import CLOSE_SVG from '@/svgs/ui/close';
 
 type BBox = [number, number, number, number];
 
-function customGeometryToBBox(custom_geometry: { coordinates: any }): BBox | null {
+function customGeometryToFeature(custom_geometry: { coordinates: any }): Feature | null {
   const coords = custom_geometry?.coordinates;
   if (!coords) return null;
 
@@ -47,13 +52,25 @@ function customGeometryToBBox(custom_geometry: { coordinates: any }): BBox | nul
     ? ({ type: 'MultiPolygon', coordinates: coords } as MultiPolygon)
     : ({ type: 'Polygon', coordinates: coords } as Polygon);
 
-  const feature: Feature = {
+  return {
     type: 'Feature',
     properties: {},
     geometry,
   };
+}
 
+function customGeometryToBBox(custom_geometry: { coordinates: any }): BBox | null {
+  const feature = customGeometryToFeature(custom_geometry);
+  if (!feature) return null;
   return bbox(feature) as BBox;
+}
+
+function customGeometryToFeatureCollection(custom_geometry: {
+  coordinates: any;
+}): FeatureCollection | null {
+  const feature = customGeometryToFeature(custom_geometry);
+  if (!feature) return null;
+  return { type: 'FeatureCollection', features: [feature] };
 }
 
 const LuPencilIcon = LuPencil as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
@@ -71,6 +88,12 @@ const LocationItem = ({ userLocationId, name, locationType, location, geometry }
   const [isEditMode, setEditMode] = useState(false);
   const [newName, setNewName] = useState(name);
   const { navigate } = useLocationNavigation();
+
+  const setDrawingUploadToolState = useSetAtom(drawingUploadToolAtom);
+  const resetDrawingUploadToolState = useResetAtom(drawingUploadToolAtom);
+  const resetDrawingToolState = useResetAtom(drawingToolAtom);
+  const setAnalysisState = useSetAtom(analysisAtom);
+  const resetAnalysisState = useResetAtom(analysisAtom);
 
   const deleteUserLocationArea = useDeleteUserLocation();
   const updateUserLocationMutation = useUpdateUserLocation();
@@ -146,18 +169,49 @@ const LocationItem = ({ userLocationId, name, locationType, location, geometry }
     return customGeometryToBBox(geometry);
   }, [geometry]);
 
+  const customFeatureCollection = useMemo(() => {
+    if (!geometry) return null;
+    return customGeometryToFeatureCollection(geometry);
+  }, [geometry]);
+
   const handleLocationClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
       e.preventDefault();
       e.stopPropagation();
 
       if (locationType === 'system' && location) {
+        // Leaving any active custom-area analysis when jumping to a system area.
+        resetDrawingToolState();
+        resetDrawingUploadToolState();
+        resetAnalysisState();
         navigate(locationToNavTarget(location), bounds);
-      } else if (locationType === 'custom') {
+      } else if (locationType === 'custom' && customFeatureCollection) {
+        // Feed the saved geometry into the drawing-tool pipeline so it renders
+        // via mapbox-gl-draw and reroutes the widgets/data hooks to the
+        // analysis API — same state as a freshly drawn/uploaded area.
+        resetDrawingToolState();
+        setDrawingUploadToolState((prev) => ({
+          ...prev,
+          uploadedGeojson: customFeatureCollection,
+          customGeojson: null,
+        }));
+        setAnalysisState((prev) => ({ ...prev, enabled: true }));
         navigate({ type: 'custom-area' }, customBounds);
       }
     },
-    [navigate, bounds, customBounds, location, locationType]
+    [
+      navigate,
+      bounds,
+      customBounds,
+      customFeatureCollection,
+      location,
+      locationType,
+      resetDrawingToolState,
+      resetDrawingUploadToolState,
+      resetAnalysisState,
+      setDrawingUploadToolState,
+      setAnalysisState,
+    ]
   );
 
   return (


### PR DESCRIPTION
## What

When a saved **custom** area is clicked in the Saved Areas panel, the map now:
1. Flies to the area (already worked)
2. **Draws the stored geometry** on the map, and
3. **Runs the analysis** for it

## How

Clicking a saved custom location converts its stored `custom_geometry` (bare `Polygon`) into a `FeatureCollection` and feeds it into the existing drawing-tool pipeline:

- Sets `drawingUploadToolAtom.uploadedGeojson` → mounts `DrawControl` and renders the polygon via `mapbox-gl-draw` (same render path as a drawn/uploaded area).
- Enables `analysisAtom` → widgets switch to the analysis set and data hooks reroute to `AnalysisAPI`.
- Resets the sibling `drawingToolAtom` so there's a single active geometry.

Selecting a **system** saved area now resets the drawing/analysis state, so jumping from a custom-area analysis back to a system area cleanly exits analysis mode.

The geometry→bbox conversion was refactored into a shared `customGeometryToFeature` helper (reused by both the bbox and the new FeatureCollection builders), preserving the existing Polygon/MultiPolygon heuristic.

## Test plan

- [ ] Save a custom (drawn/uploaded) area, then click it in Saved Areas → map flies to it, polygon is drawn, analysis widgets load with data.
- [ ] Click a saved system area → flies there, no leftover custom polygon, analysis mode exits.
- [ ] Switch custom → system → custom and confirm no stale geometry/analysis state.

> Note: this branch also carries the unrelated commit `f9568d63` (password-fix in the account form), which is not yet on `develop`.
