### PR TITLE
fix: add thousands separators to net change widget Y-axis (GMW-1054)

### DIFF
--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -54,7 +54,7 @@ const AXIS_TICK = {
 
 export const getFormat = (v) => {
   const decimalCount = -Math.floor(Math.log10(v) + 1) + 1;
-  const formatByDecimals = format(`.${decimalCount === Infinity ? 1 : Math.abs(decimalCount)}~f`);
+  const formatByDecimals = format(`,.${decimalCount === Infinity ? 1 : Math.abs(decimalCount)}~f`);
   return formatByDecimals(v);
 };
 
@@ -252,8 +252,8 @@ export function useMangroveNetChange(
       tick: { ...AXIS_TICK },
       tickFormatter: (v) => {
         const parsedNumber = unit === 'ha' ? v * 100 : v;
-        const result = Number(getFormat(Math.abs(parsedNumber)));
-        if (result === 0) return 0;
+        const result = getFormat(Math.abs(parsedNumber)); // comma-grouped string, e.g. "5,000"
+        if (Number(result.replace(/,/g, '')) === 0) return 0;
         // Loss sits below the zero baseline — keep the sign so negative levels read as "-N".
         return v < 0 ? `-${result}` : result;
       },


### PR DESCRIPTION
## Summary
Net Change widget Y-axis numbers rendered without thousands separators (e.g. `5000`). This adds comma grouping so they read `5,000`, `-2,000`, etc. Unit label (km²/ha) unchanged.

## Change
`src/containers/datasets/net-change/hooks.tsx`
- `getFormat`: add group flag to the d3 spec (`.N~f` → `,.N~f`).
- `tickFormatter`: stop wrapping the formatted value in `Number(...)` (re-parsing stripped the commas); keep sign and zero handling.

Applies to both units. Only consumer of `getFormat` is this widget's axis (grep-verified).

## Test plan
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [ ] Open a location with the Net Change widget; toggle km² ⇄ ha; confirm axis ticks show commas (`4,000`) and negatives keep the leading `-`

## Flag (out of scope)
`tickFormatter` multiplies by 100 for `ha` (line 254) but chart data is already ha-converted in `getWidgetData` — possible double-conversion, not addressed here.

Jira: GMW-1054
Closes #1596