### PR TITLE
docs: standardize Node.js version to 24 (GMW-1055)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 ### Requirements
 
-- Node.js 22 (see `.nvmrc`)
+- Node.js 24 (see `.nvmrc`)
 - [pnpm](https://pnpm.io/) 10.x
 
 ### Setup


### PR DESCRIPTION
## Summary

Resolves the `pnpm install` unsupported-engine warning by standardizing on Node.js 24.

```
WARN  Unsupported engine: wanted: {"node":"24.x"} (current: {"node":"v22.20.0"})
```

Repo config already targets Node 24 (`.nvmrc` = 24.18.0, `package.json` `engines.node` = `24.x`); app CI resolves via `node-version-file: .nvmrc`. The only stale reference was the README, now corrected.

## Changes

- README: Node.js 22 → Node.js 24 in requirements

## Out of scope

- `nodejs22` runtimes in `deploy-*.yml` are Google Cloud Functions runtimes (separate deployables; no `nodejs24` GCF runtime available) — left as-is.

## Test plan

- [x] `pnpm install` on Node 24 — no engine warning
- [x] `pnpm check-types` passes on Node 24
- [ ] Confirm CI (playwright, unit-tests) green on preview