### PR TITLE
chore: switch country boundaries to countries_12miles_location_v4

### DIFF
--- a/src/containers/datasets/contextual-layers/country/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/country/hooks.tsx
@@ -4,9 +4,9 @@ import type { LayerProps, SourceProps } from 'react-map-gl';
 
 export function useSource(): SourceProps {
   return {
-    id: 'country-boundaries',
+    id: 'countries_12miles_location_v4',
     type: 'vector',
-    url: 'mapbox://globalmangrovewatch.3v0yd8n1',
+    url: 'mapbox://globalmangrovewatch.j84w2y',
   };
 }
 
@@ -16,8 +16,8 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
       {
         id: `${id}-line`,
         type: 'line',
-        source: 'country-boundaries',
-        'source-layer': 'gadm_eez_location_v3',
+        source: 'countries_12miles_location_v4',
+        'source-layer': 'countries_12miles_location_v4',
         paint: {
           'line-color': 'hsl(58, 66%, 47%)',
           'line-opacity': 0.7,
@@ -26,8 +26,8 @@ export function useLayers({ id }: { id: LayerProps['id'] }): LayerProps[] {
       {
         id,
         type: 'fill',
-        source: 'country-boundaries',
-        'source-layer': 'gadm_eez_location_v3',
+        source: 'countries_12miles_location_v4',
+        'source-layer': 'countries_12miles_location_v4',
         paint: {
           'fill-color': 'hsla(58, 78%, 58%, 0.08)',
           'fill-opacity': ['interpolate', ['linear'], ['zoom'], 0, 1, 5, 0],


### PR DESCRIPTION
## What & why

Switch the country-boundaries layer source to the `countries_12miles_location_v4` Mapbox tileset.

- source id: `country-boundaries` → `countries_12miles_location_v4`
- url: `mapbox://globalmangrovewatch.3v0yd8n1` → `mapbox://globalmangrovewatch.j84w2y`
- source-layer: `gadm_eez_location_v3` → `countries_12miles_location_v4`

File: `src/containers/datasets/contextual-layers/country/hooks.tsx`

## Test plan

- [ ] Country view renders boundary line + fill from the new tileset
- [ ] `pnpm check-types` / `pnpm lint`
