### PR TITLE
fix: correct species widget no-data behaviour (GMW-1062)

### DIFF
--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -95,7 +95,7 @@ const SpeciesLocation = () => {
     updateFade();
   }, [updateFade, specieOptions]);
 
-  if (isFetched && !species.length) return <NoData />;
+  if (isFetched && !species?.length) return <NoData />;
 
   return (
     <div className={WIDGET_CARD_WRAPPER_STYLE}>

--- a/src/containers/datasets/species-threatened/hooks.tsx
+++ b/src/containers/datasets/species-threatened/hooks.tsx
@@ -100,19 +100,22 @@ export function useMangroveSpeciesThreatened(
   const { data, isLoading, isFetched, isPlaceholderData } = query;
 
   const DATA = useMemo(() => {
-    const { data: speciesData } = data;
+    const speciesData = data?.data;
     if (!speciesData) return null;
     const { categories, total, species, threatened } = speciesData;
 
     const threatenedLegend: number | string = getThreatened(threatened, total);
     const speciesByGroup = groupBy(species, (s) => s?.red_list_cat);
 
-    const chartData = Object.entries(categories)?.map((item) => ({
-      value: item[1],
-      color: COLORS[item[0]],
-      label: `${RED_LIST_CATEGORIES[item[0]]}`,
-      species: speciesByGroup[item[0]].sort(),
-    }));
+    const categoryEntries = Object.entries(categories ?? {});
+    const chartData = categoryEntries.length
+      ? categoryEntries.map((item) => ({
+          value: item[1],
+          color: COLORS[item[0]],
+          label: `${RED_LIST_CATEGORIES[item[0]]}`,
+          species: speciesByGroup[item[0]] ?? [],
+        }))
+      : null;
 
     return {
       threatenedLegend,


### PR DESCRIPTION
## Summary

Fixes the no-data path across the three species widgets (`species-location`, `species-distribution`, `species-threatened`). Two of the three were buggy: one skipped the `<NoData/>` card entirely, one crashed.

- **species-threatened** (`hooks.tsx`):
  - Guard the `data` destructure (`data?.data`) — no crash when the query result is undefined.
  - Empty `categories` now yields `chartData = null` instead of a truthy `[]`, so `<NoData/>` renders instead of an empty pie chart.
  - Default a missing species group to `[]` — removes a latent `.sort()` crash on categories that have a count but no matching species.
- **species-location** (`widget.tsx`): optional-chain the length check (`!species?.length`) — shows `<NoData/>` instead of crashing when data is undefined.
- **species-distribution**: unchanged, already correct (`noData` derived in its hook). All three now share the same empty-detection shape.

Out of scope (see GMW-1062): the API cannot yet distinguish "no data" from "data with no threatened species", so both still show the generic NoData card. This PR fixes the FE crashes/detection; accurate per-case messaging depends on the API change tracked in GMW-1062.

## Test plan

- [ ] `pnpm check-types` — clean (verified locally)
- [ ] `pnpm lint` — clean (verified locally)
- [ ] Country with mangrove species → all three widgets render normally (regression)
- [ ] Sparse/empty location → each widget shows the NoData card; **no empty pie** in threatened, **no console crash** in location
- [ ] Expand a threatened category with a count but no species entries → no crash

Relates to GMW-1062.