### PR TITLE
fix: prevent empty toast on dark-mode OS (GMW-1043)

### DIFF
--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -7,30 +7,33 @@ import {
   Cross1Icon,
   ReloadIcon,
 } from '@radix-ui/react-icons';
-import { useTheme } from 'next-themes';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 
 const Toaster = ({ icon = false, ...props }: ToasterProps & { icon?: boolean }) => {
-  const { theme = 'system' } = useTheme();
-
   return (
+    // App has no dark mode: force light so sonner's text color matches the
+    // hardcoded white --normal-bg below. Passing "system" here let dark-OS
+    // users get near-white text on white → an apparently empty toast (GMW-1043).
     <Sonner
-      theme={theme as ToasterProps['theme']}
+      theme="light"
       className="toaster group font-inter text-sm font-bold shadow-[0px_4px_12px_0px_#00000014]"
       icons={
         !icon
           ? undefined
           : {
-              success: <CheckCircledIcon className="size-4 fill-current text-brand-800" />,
-              info: <InfoCircledIcon className="size-4 bg-brand-800" />,
-              warning: <ExclamationTriangleIcon className="size-4 bg-brand-800" />,
-              error: <Cross1Icon className="size-4 bg-brand-800" />,
-              loading: <ReloadIcon className="size-4 animate-spin bg-brand-800" />,
+              success: <CheckCircledIcon className="text-brand-800 size-4 fill-current" />,
+              info: <InfoCircledIcon className="bg-brand-800 size-4" />,
+              warning: <ExclamationTriangleIcon className="bg-brand-800 size-4" />,
+              error: <Cross1Icon className="bg-brand-800 size-4" />,
+              loading: <ReloadIcon className="bg-brand-800 size-4 animate-spin" />,
             }
       }
       style={
         {
           '--normal-bg': '#fff',
+          // Pin the text color so it can never end up light-on-white, regardless
+          // of the resolved theme (brand-900). Defensive alongside theme="light".
+          '--normal-text': '#003C39',
           '--normal-border': 'var(--border)',
           '--border-radius': 'var(--radius)',
         } as React.CSSProperties


### PR DESCRIPTION
## What

Fixes the "empty pop-up in the top-right corner" reported during GMW-1043 QA when saving a change in **My profile**.

## Root cause

`src/components/ui/toast.tsx` mounted sonner with `theme={theme}` from `useTheme()` (next-themes). There is **no `ThemeProvider` anywhere in the app**, so `useTheme()` fell back to its default `'system'` → `<Sonner theme="system">`, which honours the OS `prefers-color-scheme`.

The inline `style` hardcodes `--normal-bg: '#fff'` but never set `--normal-text`. On a **dark-mode OS**, sonner applies its dark-theme near-white `--normal-text` over the hardcoded white background → **white text on white = an apparently empty toast**.

That's why it reproduced for a reviewer on dark mode but not for the assignee on light mode. Only one toast fires on save (`toast.success('User details have been updated successfully.')`, `hooks.ts:89`); the message was present but invisible.

## Fix

- Force `theme="light"` on the `<Sonner>` toaster (the app has no dark mode; the brand toast is intentionally white). Drops the now-unused `useTheme`/`next-themes` dependency.
- Pin `--normal-text` to brand-900 (`#003C39`) as defence-in-depth so toast text can never end up light-on-white again.

Global fix — applies to every app toast (profile, signup, password reset, drawing-upload), not just profile save.

## Test plan

- [ ] DevTools → Rendering → *Emulate prefers-color-scheme: dark*, save a My profile change → success toast text is now visible (was empty before).
- [ ] Light mode → still correct.
- [ ] Spot-check another toast (signup / password reset) in dark mode → visible.
- [ ] `pnpm lint` / `pnpm check-types` green.
