### PR TITLE
fix: keep small widget values visible in number formatting

### DIFF
--- a/src/lib/format/index.ts
+++ b/src/lib/format/index.ts
@@ -1,7 +1,31 @@
 import { format, formatPrefix } from 'd3-format';
 
-export const formatNumberNearestInteger = format(',.0f');
-export const numberFormat = format(',.2f');
+// Max decimals to prevent absurd precision on extreme tiny values.
+const MAX_ADAPTIVE_DECIMALS = 8;
+
+/**
+ * Format `value` with at least `minDecimals` decimals. When the value is small enough
+ * that fixed `minDecimals` precision would hide or distort it (e.g. 0.006 → "0.01",
+ * 0.003 → "0.00"), add just enough decimals to surface ~2 significant figures so the
+ * real value stays visible: 0.006 → "0.006", 0.003 → "0.003". Works for positive and
+ * negative values alike (sign preserved by d3). Normal-range values keep their exact
+ * current look — trailing zeros are only trimmed on the expanded (small-value) branch.
+ */
+export const adaptiveFormat = (value: number, minDecimals = 2): string => {
+  if (!Number.isFinite(value) || value === 0) return format(`,.${minDecimals}f`)(value);
+  const abs = Math.abs(value);
+  // Decimals needed to surface ~2 significant figures for sub-unit magnitudes.
+  const sigFigDecimals = Math.floor(-Math.log10(abs)) + 2;
+  const decimals = Math.min(Math.max(minDecimals, sigFigDecimals), MAX_ADAPTIVE_DECIMALS);
+  // Only expand (and trim) when the value needs more precision than the fixed baseline;
+  // otherwise keep the exact fixed format so normal values render identically to before.
+  return decimals > minDecimals
+    ? format(`,.${decimals}~f`)(value)
+    : format(`,.${minDecimals}f`)(value);
+};
+
+export const formatNumberNearestInteger = (value: number) => adaptiveFormat(value, 0);
+export const numberFormat = (value: number) => adaptiveFormat(value, 2);
 export const formatAxis = format(',.0d');
 export const formatMillion = formatPrefix(',.0', 1e6);
 export const significantDigitsFormat = format('.3s');

--- a/tests/unit/lib/format/index.test.ts
+++ b/tests/unit/lib/format/index.test.ts
@@ -1,4 +1,5 @@
 import {
+  adaptiveFormat,
   formatAxis,
   formatMillion,
   formatNumberNearestInteger,
@@ -6,10 +7,24 @@ import {
   significantDigitsFormat,
 } from '@/lib/format';
 
+// d3-format uses the Unicode minus sign (U+2212), not the ASCII hyphen, for negatives.
+const MINUS = '−';
+
 describe('formatNumberNearestInteger', () => {
   it('rounds to the nearest integer with thousands separators', () => {
     expect(formatNumberNearestInteger(1234.6)).toBe('1,235');
     expect(formatNumberNearestInteger(1000000)).toBe('1,000,000');
+  });
+
+  it('keeps small sub-integer values visible instead of rounding them to "0"', () => {
+    expect(formatNumberNearestInteger(0.3)).toBe('0.3');
+    expect(formatNumberNearestInteger(0.006)).toBe('0.006');
+    expect(formatNumberNearestInteger(0)).toBe('0');
+  });
+
+  it('keeps small negative sub-integer values visible with their sign', () => {
+    expect(formatNumberNearestInteger(-0.3)).toBe(`${MINUS}0.3`);
+    expect(formatNumberNearestInteger(-0.006)).toBe(`${MINUS}0.006`);
   });
 });
 
@@ -17,10 +32,53 @@ describe('numberFormat', () => {
   it('formats with two decimals and thousands separators', () => {
     expect(numberFormat(1000)).toBe('1,000.00');
     expect(numberFormat(1.5)).toBe('1.50');
+    expect(numberFormat(1.234)).toBe('1.23');
+    expect(numberFormat(0)).toBe('0.00');
+  });
+
+  it('adds decimals so small values stay visible instead of rounding to "0.00"', () => {
+    // 0.003 keeps three decimals, 0.006 is not rounded up to "0.01", etc.
+    expect(numberFormat(0.003)).toBe('0.003');
+    expect(numberFormat(0.006)).toBe('0.006');
+    expect(numberFormat(0.00004)).toBe('0.00004');
+  });
+
+  it('applies the same rules to negative values, preserving the sign', () => {
+    // Normal-range negatives keep two decimals; small negatives expand just like positives.
+    expect(numberFormat(-1000)).toBe(`${MINUS}1,000.00`);
+    expect(numberFormat(-1.234)).toBe(`${MINUS}1.23`);
+    expect(numberFormat(-0.003)).toBe(`${MINUS}0.003`);
+    expect(numberFormat(-0.006)).toBe(`${MINUS}0.006`);
+    expect(numberFormat(-0.00004)).toBe(`${MINUS}0.00004`);
+  });
+
+  it('leaves non-finite input to d3 (no crash)', () => {
+    expect(numberFormat(Number.NaN)).toBe('NaN');
+  });
+});
+
+describe('adaptiveFormat', () => {
+  it('respects the minDecimals baseline for normal-range values', () => {
+    expect(adaptiveFormat(1234.5, 2)).toBe('1,234.50');
+    expect(adaptiveFormat(0.5, 2)).toBe('0.50');
+    expect(adaptiveFormat(1234.5, 0)).toBe('1,235');
+  });
+
+  it('expands to ~2 significant figures for small magnitudes (both signs)', () => {
+    expect(adaptiveFormat(0.003, 2)).toBe('0.003');
+    expect(adaptiveFormat(0.006, 0)).toBe('0.006');
+    expect(adaptiveFormat(-0.003, 2)).toBe(`${MINUS}0.003`);
+    expect(adaptiveFormat(-0.006, 0)).toBe(`${MINUS}0.006`);
+  });
+
+  it('caps expansion at 8 decimals for extreme values', () => {
+    expect(adaptiveFormat(0.000000006, 2)).toBe('0.00000001');
   });
 });
 
 describe('formatAxis', () => {
+  // Axes carry dates (years) — no adaptive small-value logic here, just the thousands
+  // separator, exactly as before.
   it('formats integers (e.g. years) with thousands separators', () => {
     expect(formatAxis(2024)).toBe('2,024');
   });


### PR DESCRIPTION
## Context

Widget numbers are formatted through shared `d3-format` helpers in `src/lib/format/index.ts` that use **fixed precision**:

- `numberFormat = format(',.2f')` — any value `< 0.005` rendered as `"0.00"`, and `0.006` was rounded up to `"0.01"`, hiding the real value.
- `formatNumberNearestInteger = format(',.0f')` — any value `< 0.5` rendered as `"0"`.
- Negatives near zero collapsed to `"−0.00"`.

Genuinely non-zero small quantities (tiny coverage %, small CO₂e slices, small net change) looked like nothing.

## Change

Introduce an `adaptiveFormat` core and redefine `numberFormat` / `formatNumberNearestInteger` on top of it (same call signature — all 26 consumer widgets untouched):

- Small sub-unit magnitudes expand to **~2 significant figures** so the real value stays visible: `0.003 → "0.003"`, `0.006 → "0.006"`, `0.00004 → "0.00004"`.
- **Normal-range values are byte-identical to before**: `12.5 → "12.50"`, `1,234.5 → "1,234.50"`, `0 → "0.00"`.
- Works for positive and negative alike; sign preserved (`−0.003`).
- Capped at 8 decimals; `0`/`NaN`/`Infinity` safe.
- `formatAxis` (dates/years) **unchanged** — thousands separator only, no adaptive decimals.

**Scope:** central lib only. Per-widget bespoke formatters (`net-change`, `flood-protection`, `restoration` popup, `drivers-change`) are out of scope. Follow-up: `getFormat` in `net-change/hooks.tsx` returns `NaN` on negatives (`Math.log10`).

## Test plan

- [x] `pnpm test:unit tests/unit/lib/format/index.test.ts` — 13 passing (small +/- values, normal values, zero/NaN, 8-decimal cap, axis unchanged)
- [x] `pnpm check-types`
- [x] `pnpm lint`
- [ ] Eyeball a low-coverage widget (`habitat-extent` / `blue-carbon` small slice) in dev to confirm tiny values now render with decimals and normal widgets look unchanged