### PR TITLE
feat(data): add countries v4 vector tile pipeline notebook

### DIFF
--- a/data/notebooks/Lab/data_processing/layers/countries-v4-creation.ipynb
+++ b/data/notebooks/Lab/data_processing/layers/countries-v4-creation.ipynb
@@ -1,0 +1,196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": "# Pipeline to convert GMW OpenStreetMap country boundaries into vector tiles\n\nSource: `Lab/data/raw/gmw_openstreetmap_country_boundaries_20260624.gpkg`\n\n**Outputs:**\n- `countries_12miles_location_v4.json` / `.mbtiles` — all countries layer for Mapbox\n- `new_territories_bo.csv` — 6 new territories for backoffice import (BLM, CCK, KWT, MNP, IOT, NRU)"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1c2d3e4",
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\nimport csv\nimport json\nimport uuid\nfrom pathlib import Path\n\nimport geopandas\nimport pandas as pd\nimport pyproj\nimport subprocess\nimport logging\nfrom typing import Union\n\nfrom shapely.geometry import mapping, box\nfrom shapely.ops import transform"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f282f4f",
+   "source": "### Setup",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1d2e3f4",
+   "metadata": {},
+   "outputs": [],
+   "source": "WORK_DIR = Path(os.getcwd())\n# Navigate to Lab/ from notebook directory (layers -> data_processing -> Lab)\nLAB_DIR = WORK_DIR.parents[1] if \"data_processing\" in str(WORK_DIR) else WORK_DIR\nBASE_DIR = LAB_DIR / \"data\"\nlogging.basicConfig(level=logging.INFO)\nlogging.info(f\"Base dir: {BASE_DIR}\")\n\ninput_dir = BASE_DIR / \"raw\"\noutput_dir = BASE_DIR / \"processed\"\noutput_dir.mkdir(parents=True, exist_ok=True)\n\n## Path setup\nin_file = input_dir / \"gmw_openstreetmap_country_boundaries_20260624.gpkg\"\nlocations_csv = input_dir / \"locations_merged.csv\"\nlayer_name = \"gmw_openstreetmap_country_boundaries_20260624\"\n\nassert in_file.exists(), f\"Input file not found: {in_file}\"\nassert locations_csv.exists(), f\"Locations CSV not found: {locations_csv}\""
+  },
+  {
+   "cell_type": "markdown",
+   "id": "312f752b",
+   "source": "### Helper functions",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1f2a3b4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mbtilesGeneration(\n",
+    "    data_path: Path, output_path: Union[Path, None] = None, update: bool = False\n",
+    ") -> Path:\n",
+    "    \"\"\"\n",
+    "    Generate mbtiles from a vector data file using mapshaper + tippecanoe.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_path : Path - The path to the vector data file.\n",
+    "    output_path : Path - The path to the output mbtiles file.\n",
+    "    update : bool, optional - If True, the output will be overwritten.\n",
+    "    \n",
+    "    Returns\n",
+    "    -------\n",
+    "    Path - The path to the generated mbtiles file.\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        assert data_path.exists(), \"Data path does not exist.\"\n",
+    "\n",
+    "        if not output_path:\n",
+    "            output_path = data_path.with_suffix(\".mbtiles\")\n",
+    "\n",
+    "        if update or not output_path.exists():\n",
+    "\n",
+    "            if data_path.suffix != \".json\":\n",
+    "                CMD = f'mapshaper {data_path} -clean allow-overlaps rewind -o format=geojson {data_path.with_suffix(\".json\")} force'\n",
+    "                subprocess.run(CMD, shell=True, check=True)\n",
+    "                data_path = data_path.with_suffix(\".json\")\n",
+    "\n",
+    "            assert data_path.suffix == \".json\", \"Data path must be a json file.\"\n",
+    "\n",
+    "            logging.info(\"Creating mbtiles file...\")\n",
+    "\n",
+    "            subprocess.run(\n",
+    "                f\"tippecanoe -zg -f -P -o {output_path} --extend-zooms-if-still-dropping {data_path}\",\n",
+    "                shell=True,\n",
+    "                check=True,\n",
+    "            )\n",
+    "\n",
+    "        return output_path\n",
+    "\n",
+    "    except Exception as e:\n",
+    "        logging.error(e)\n",
+    "        return 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "ae56c9e3",
+   "source": "def generate_location_idn(iso: str) -> str:\n    \"\"\"Generate a location_idn from an ISO code using UUID5 with NAMESPACE_OID.\n    \n    This is the same scheme used for all existing location_idn values in the CSV.\n    The result is deterministic: the same ISO always produces the same UUID.\n    \"\"\"\n    return str(uuid.uuid5(uuid.NAMESPACE_OID, iso))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1a2b3c4",
+   "metadata": {},
+   "source": "### Load and inspect source data"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2b3c4d5",
+   "metadata": {},
+   "outputs": [],
+   "source": "gdf = geopandas.read_file(in_file, driver=\"GPKG\", layer=layer_name)\nprint(f\"Features: {len(gdf)}\")\nprint(f\"CRS: {gdf.crs}\")\nprint(f\"Columns: {list(gdf.columns)}\")\ngdf.head(3)"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e73d51cd",
+   "source": "### Dissolve features with the same ISO code\n\nSome ISO codes have multiple features (e.g. ATF has 5 islands, BES has 3).\nMerge them into single MultiPolygon features so each ISO appears once.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b123387b",
+   "source": "# Dissolve by ISO code, joining names for merged features\ngdf_dissolved = gdf.dissolve(\n    by=\"iso_code_3char\",\n    aggfunc={\"name_en\": \", \".join},\n).reset_index()\n\n# Deduplicate repeated names (e.g. \"Sudan, Sudan\" → \"Sudan\")\ngdf_dissolved[\"name_en\"] = gdf_dissolved[\"name_en\"].apply(\n    lambda x: \", \".join(dict.fromkeys(x.split(\", \")))\n)\n\nprint(f\"Before dissolve: {len(gdf)} features\")\nprint(f\"After dissolve: {len(gdf_dissolved)} features ({len(gdf) - len(gdf_dissolved)} merged)\")\n\n# Show merged names\nmerged = gdf_dissolved[gdf_dissolved[\"name_en\"].str.contains(\", \")]\nif len(merged):\n    print(f\"\\n=== Merged names ===\")\n    print(merged[[\"iso_code_3char\", \"name_en\"]].to_string(index=False))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2c3d4e5",
+   "metadata": {},
+   "source": "### Match with locations_merged.csv and generate ids for unmatched"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2d3e4f5",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Load location_idn and id mapping from locations_merged.csv (country rows only)\niso_to_location = {}\nmax_id = 4688  # 4688 is assigned to worldwide in the backoffice\nwith open(locations_csv) as f:\n    reader = csv.DictReader(f)\n    for row in reader:\n        rid = int(row[\"id\"])\n        if rid > max_id:\n            max_id = rid\n        if row[\"type\"] == \"country\":\n            iso_to_location[row[\"iso\"]] = {\n                \"location_idn\": row[\"location_idn\"],\n                \"id\": row[\"id\"],\n                \"name\": row[\"name\"],\n            }\n\nlogging.info(f\"Found {len(iso_to_location)} countries in locations_merged.csv\")\nlogging.info(f\"New ids will start from: {max_id + 1}\")\n\n# ISOs that were merged during dissolve — use CSV name for these\nmerged_isos = set(gdf[\"iso_code_3char\"].value_counts()[lambda x: x > 1].index)\n\n# Names for unmatched countries with merged geometries\nUNMATCHED_NAMES = {\n    \"UMI\": \"United States Minor Outlying Islands\",\n}\n\n# Build result: match with CSV where possible, generate new ids for unmatched\nrows = []\nnext_id = max_id + 1\nfor _, row in gdf_dissolved.iterrows():\n    iso = row[\"iso_code_3char\"]\n    match = iso_to_location.get(iso)\n    if match:\n        location_idn = match[\"location_idn\"]\n        loc_id = match[\"id\"]\n        # Use CSV name only for merged ISOs, otherwise keep GPKG name_en\n        name = match[\"name\"] if iso in merged_isos else row[\"name_en\"]\n    else:\n        location_idn = generate_location_idn(iso)\n        loc_id = next_id\n        next_id += 1\n        name = UNMATCHED_NAMES.get(iso, row[\"name_en\"])\n    rows.append({\n        \"iso\": iso,\n        \"name\": name,\n        \"type\": \"country\",\n        \"location_idn\": location_idn,\n        \"id\": loc_id,\n        \"geometry\": row[\"geometry\"],\n    })\n\nresult = geopandas.GeoDataFrame(rows, crs=gdf.crs)\n\nmatched = result[\"iso\"].isin(iso_to_location.keys()).sum()\nunmatched_df = result[~result[\"iso\"].isin(iso_to_location.keys())]\nlogging.info(f\"Matched: {matched}, Unmatched: {len(unmatched_df)}\")\n\nprint(f\"\\n=== Unmatched countries ({len(unmatched_df)}) — new ids generated ===\")\nprint(unmatched_df[[\"iso\", \"name\", \"id\", \"location_idn\"]].sort_values(\"iso\").to_string(index=False))"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2e3f4a5",
+   "metadata": {},
+   "source": "### Export to GeoJSON"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2f3a4b5",
+   "metadata": {},
+   "outputs": [],
+   "source": "json_path = output_dir / \"countries_12miles_location_v4.json\"\nresult.to_file(json_path, driver=\"GeoJSON\")\nlogging.info(f\"GeoJSON saved to {json_path}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2a3b4c5",
+   "metadata": {},
+   "source": "### Generate mbtiles"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3b4c5d6",
+   "metadata": {},
+   "outputs": [],
+   "source": "output_mbtiles = output_dir / \"countries_12miles_location_v4.mbtiles\"\nmbtiles_result = mbtilesGeneration(json_path, output_path=output_mbtiles, update=True)\nlogging.info(f\"mbtiles generated at: {mbtiles_result}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ef0ce3b7",
+   "source": "### Generate backoffice CSV for new territories\n\nExport only the 6 new countries using the IDs assigned by the backoffice database.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "5f014e66",
+   "source": "def geom_to_json(geom):\n    \"\"\"Convert shapely geometry to JSON string matching backoffice format.\"\"\"\n    geojson = mapping(geom)\n    return json.dumps(geojson, separators=(\", \", \":\"))\n\ndef compute_metrics(geom):\n    \"\"\"Project geometry to UTM and compute area_m2, perimeter_m, coast_length_m.\"\"\"\n    centroid = geom.centroid\n    zone = int((centroid.x + 180) / 6) + 1\n    hemisphere = \"south\" if centroid.y < 0 else \"north\"\n    utm_crs = pyproj.CRS(f\"+proj=utm +zone={zone} +{hemisphere} +datum=WGS84\")\n    project = pyproj.Transformer.from_crs(\"EPSG:4326\", utm_crs, always_xy=True).transform\n    geom_projected = transform(project, geom)\n    return geom_projected.area, geom_projected.length, geom_projected.length\n\n# Only these 6 territories, with their backoffice-assigned IDs\nTARGET_ISOS_IDS = {\n    \"BLM\": 4690,\n    \"CCK\": 4722,\n    \"KWT\": 4723,\n    \"MNP\": 4724,\n    \"IOT\": 4725,\n    \"NRU\": 4726,\n}\nTARGET_ISOS = list(TARGET_ISOS_IDS.keys())\n\n# Filter to target countries only\nunmatched = result[result[\"iso\"].isin(TARGET_ISOS)].copy()\n# Reorder to match TARGET_ISOS\nunmatched = unmatched.set_index(\"iso\").loc[TARGET_ISOS].reset_index()\nlogging.info(f\"Generating backoffice CSV for {len(unmatched)} new territories\")\n\n# Build CSV rows\nbo_rows = []\nfor _, row in unmatched.iterrows():\n    geom = row[\"geometry\"]\n    minx, miny, maxx, maxy = geom.bounds\n    bbox_geom = box(minx, miny, maxx, maxy)\n    area_m2, perimeter_m, coast_length_m = compute_metrics(geom)\n\n    bo_rows.append({\n        \"id\": TARGET_ISOS_IDS[row[\"iso\"]],\n        \"name\": row[\"name\"],\n        \"location_type\": \"country\",\n        \"iso\": row[\"iso\"],\n        \"bounds\": geom_to_json(bbox_geom),\n        \"geometry\": geom_to_json(geom),\n        \"area_m2\": area_m2,\n        \"perimeter_m\": perimeter_m,\n        \"coast_length_m\": coast_length_m,\n        \"location_id\": row[\"location_idn\"],\n    })\n\n# Write CSV\nbo_csv_path = output_dir / \"new_territories_bo.csv\"\nbo_df = pd.DataFrame(bo_rows)\nbo_df.to_csv(bo_csv_path, index=False)\nlogging.info(f\"Backoffice CSV saved to {bo_csv_path}\")\nprint(f\"\\n{len(bo_rows)} new territories written\")\nprint(bo_df[[\"id\", \"name\", \"iso\", \"area_m2\", \"perimeter_m\", \"coast_length_m\"]].to_string(index=False))",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
 ## Summary
  - Notebook to convert GMW OpenStreetMap country boundaries (GPKG) into vector tiles (GeoJSON + mbtiles)
  - Generates backoffice CSV for the 6 new territories (BLM, CCK, KWT, MNP, IOT, NRU) with projected area_m2, perimeter_m, and   coast_length_m metrics
  - Dissolves multi-feature ISOs into single MultiPolygon geometries and matches against locations_merged.csv