### PR TITLE
fix: custom-area reset 400 + upload/save fixes (GMW-1067)

### DIFF
--- a/src/containers/datasets/biomass/hooks.tsx
+++ b/src/containers/datasets/biomass/hooks.tsx
@@ -103,6 +103,12 @@ export function useMangroveBiomass(
       },
     } as unknown as DataResponse,
     ...queryOptions,
+    // GMW-1067: skip fetching in the reset transition — analysis just disabled while the
+    // URL is still /custom-area (would GET ?location_id=custom-area → 400), or analysis
+    // enabled with no geometry yet (would POST a null geometry → 400).
+    enabled:
+      (isAnalysisEnabled ? !!geojson : location_id !== 'custom-area') &&
+      (queryOptions?.enabled ?? true),
   });
   const { data, isError, isFetching, refetch, isFetched } = query;
   const noData = isFetched && !data?.data?.length;

--- a/src/containers/datasets/blue-carbon/hooks.tsx
+++ b/src/containers/datasets/blue-carbon/hooks.tsx
@@ -89,6 +89,12 @@ export function useMangroveBlueCarbon(
       },
     },
     ...queryOptions,
+    // GMW-1067: skip fetching in the reset transition — analysis just disabled while the
+    // URL is still /custom-area (would GET ?location_id=custom-area → 400), or analysis
+    // enabled with no geometry yet (would POST a null geometry → 400).
+    enabled:
+      (isAnalysisEnabled ? !!geojson : location_id !== 'custom-area') &&
+      (queryOptions?.enabled ?? true),
   });
 }
 

--- a/src/containers/datasets/drawing-upload-tool/index.tsx
+++ b/src/containers/datasets/drawing-upload-tool/index.tsx
@@ -2,18 +2,18 @@ import { useEffect, useState } from 'react';
 
 import { useDropzone } from 'react-dropzone';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-
 import cn from '@/lib/classnames';
 
 import { analysisAtom } from '@/store/analysis';
 import { drawingToolAtom, drawingUploadToolAtom } from '@/store/drawing-tool';
 import { mapCursorAtom } from '@/store/map';
 
+import turfBbox from '@turf/bbox';
 import { useAtom, useSetAtom } from 'jotai';
 import { toast } from 'sonner';
 
 import { fetchUploadFile } from 'hooks/analysis';
+import { useLocationNavigation } from 'hooks/location-navigation';
 
 import Helper from '@/containers/help/helper';
 import DeleteDrawingButton from '@/containers/map/delete-drawing-button';
@@ -79,10 +79,7 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
   const setAnalysisState = useSetAtom(analysisAtom);
   const setMapCursor = useSetAtom(mapCursorAtom);
 
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const queryParams = searchParams.toString();
+  const { navigate } = useLocationNavigation();
 
   const { getRootProps, getInputProps } = useDropzone({
     multiple: false,
@@ -95,7 +92,6 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
         fetchUploadFile(files)
           .then((data) => {
             setFileUpload(false);
-            void router.push(`/custom-area${queryParams ? `?${queryParams}` : ''}`);
 
             setDrawingUploadToolState((drawingToolState) => ({
               ...drawingToolState,
@@ -113,6 +109,14 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
               ...prevAnalysisState,
               enabled: true,
             }));
+
+            // Change location to custom-area using the same client-side navigation the
+            // draw flow uses (history.replaceState — no RSC refetch/page remount) and fly
+            // the map to the uploaded geometry's bounds.
+            const uploadedBbox = data?.data
+              ? (turfBbox(data.data) as [number, number, number, number])
+              : null;
+            navigate({ type: 'custom-area' }, uploadedBbox);
 
             toast.success('File uploaded successfully');
           })

--- a/src/containers/datasets/habitat-extent/hooks.tsx
+++ b/src/containers/datasets/habitat-extent/hooks.tsx
@@ -87,6 +87,12 @@ export function useMangroveHabitatExtent(
       },
     },
     ...queryOptions,
+    // GMW-1067: skip fetching in the reset transition — analysis just disabled while the
+    // URL is still /custom-area (would GET ?location_id=custom-area → 400), or analysis
+    // enabled with no geometry yet (would POST a null geometry → 400).
+    enabled:
+      (isAnalysisEnabled ? !!geojson : location_id !== 'custom-area') &&
+      (queryOptions?.enabled ?? true),
   });
 
   const { data, isFetched, isFetching, isError, refetch } = query;

--- a/src/containers/datasets/height/hooks.tsx
+++ b/src/containers/datasets/height/hooks.tsx
@@ -129,6 +129,12 @@ export function useMangroveHeight(
       },
     },
     ...queryOptions,
+    // GMW-1067: skip fetching in the reset transition — analysis just disabled while the
+    // URL is still /custom-area (would GET ?location_id=custom-area → 400), or analysis
+    // enabled with no geometry yet (would POST a null geometry → 400).
+    enabled:
+      (isAnalysisEnabled ? !!geojson : location_id !== 'custom-area') &&
+      (queryOptions?.enabled ?? true),
   });
 
   const { data, isFetched } = query;

--- a/src/containers/datasets/locations/user-locations.tsx
+++ b/src/containers/datasets/locations/user-locations.tsx
@@ -75,6 +75,8 @@ type Bounds = {
 
 export type CustomGeometry = {
   description: string;
+  // The backend only accepts Polygon geometry on create; uploaded MultiPolygons are
+  // reduced to a single Polygon before saving (see buildCustomGeometry).
   type: 'Polygon';
   coordinates: GeoJSON.Polygon['coordinates'];
 };

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -158,6 +158,12 @@ export function useMangroveNetChange(
       metadata: null,
     },
     ...queryOptions,
+    // GMW-1067: skip fetching in the reset transition — analysis just disabled while the
+    // URL is still /custom-area (would GET ?location_id=custom-area → 400), or analysis
+    // enabled with no geometry yet (would POST a null geometry → 400).
+    enabled:
+      (isAnalysisEnabled ? !!geojson : location_id !== 'custom-area') &&
+      (queryOptions?.enabled ?? true),
   });
 
   const { data, isFetched } = query;

--- a/src/containers/navigation/menu/profile/saved-areas/item-new.tsx
+++ b/src/containers/navigation/menu/profile/saved-areas/item-new.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import cn from '@/lib/classnames';
 
@@ -19,6 +19,34 @@ import { Input } from '@/components/ui/input';
 
 const LuPlusIcon = LuPlus as unknown as (p: React.SVGProps<SVGSVGElement>) => JSX.Element;
 
+// Planar shoelace area of a linear ring — only used to compare relative polygon sizes,
+// so an unprojected approximation is fine.
+const ringArea = (ring: GeoJSON.Position[]): number => {
+  let area = 0;
+  for (let i = 0, n = ring.length - 1; i < n; i++) {
+    area += ring[i][0] * ring[i + 1][1] - ring[i + 1][0] * ring[i][1];
+  }
+  return Math.abs(area / 2);
+};
+
+// Reduce a geometry to Polygon coordinates the backend accepts. Polygon passes through;
+// MultiPolygon is unwrapped when single-part, otherwise the largest part is kept.
+const toPolygonCoordinates = (
+  geom: GeoJSON.Geometry | undefined
+): GeoJSON.Polygon['coordinates'] | null => {
+  if (!geom) return null;
+  if (geom.type === 'Polygon') return geom.coordinates?.length ? geom.coordinates : null;
+  if (geom.type === 'MultiPolygon') {
+    const polygons = geom.coordinates;
+    if (!polygons?.length) return null;
+    if (polygons.length === 1) return polygons[0];
+    return polygons.reduce((largest, polygon) =>
+      ringArea(polygon[0]) > ringArea(largest[0]) ? polygon : largest
+    );
+  }
+  return null;
+};
+
 type Props = {
   name: string;
   systemLocationId?: number; // only for system routes
@@ -29,10 +57,13 @@ type Props = {
 const LocationItemNew = ({ name, systemLocationId, locationType, disabled }: Props) => {
   const [newName, setNewName] = useState(name);
 
-  // If route changes name, resync
-  useEffect(() => {
+  // Resync the input when the route-provided name changes, without an effect
+  // (adjust state during render — see https://react.dev/learn/you-might-not-need-an-effect).
+  const [prevName, setPrevName] = useState(name);
+  if (name !== prevName) {
+    setPrevName(name);
     setNewName(name);
-  }, [name]);
+  }
 
   const createUserLocationMutation = useCreateUserLocation();
 
@@ -44,13 +75,17 @@ const LocationItemNew = ({ name, systemLocationId, locationType, disabled }: Pro
     const uploaded = uploadedGeojson?.features?.[0]?.geometry;
 
     const geom = drawn ?? uploaded;
-    if (!geom || geom.type !== 'Polygon' || !('coordinates' in geom) || !geom.coordinates)
-      return null;
+    // Drawn areas are always a single Polygon. Uploaded shapefiles/geopackages commonly
+    // convert to MultiPolygon, which the create endpoint rejects (500). Reduce those to a
+    // single Polygon (unwrap when there is one part; otherwise keep the largest part) so
+    // uploaded areas can be saved.
+    const coordinates = toPolygonCoordinates(geom);
+    if (!coordinates) return null;
 
     return {
       description: drawn ? 'Custom drawn area' : 'Uploaded area',
       type: 'Polygon',
-      coordinates: (geom as GeoJSON.Polygon).coordinates,
+      coordinates,
     };
   }, [customGeojson, uploadedGeojson]);
 

--- a/tests/drawing-tool.spec.ts
+++ b/tests/drawing-tool.spec.ts
@@ -132,4 +132,23 @@ test.describe('Custom area has a polygon', () => {
     await expect(page.getByTestId('delete-custom-area-button').first()).not.toBeVisible();
     await expect(page.getByTestId('drawing-tool-button')).toContainText('Draw area');
   });
+
+  // GMW-1067: resetting a custom area used to fire a transient widgets request with the
+  // stale location_id=custom-area (and/or an analysis POST with a null geometry) that
+  // returned 400 in the network tab. The analysis widget hooks now guard `enabled`.
+  test('reset does not trigger a 400 request (GMW-1067)', async ({ page }) => {
+    const badRequests: string[] = [];
+    page.on('response', (res) => {
+      if (res.status() >= 400 && res.status() < 500 && /\/widgets\/|\/analysis/.test(res.url())) {
+        badRequests.push(`${res.status()} ${res.url()}`);
+      }
+    });
+
+    await page.getByTestId('delete-custom-area-button').first().click();
+    await expect(page.getByTestId('drawing-tool-button')).toContainText('Draw area');
+    // Let any transient refetch triggered by the reset settle.
+    await page.waitForTimeout(1500);
+
+    expect(badRequests).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes [GMW-1067](https://vizzuality.atlassian.net/browse/GMW-1067) plus two related custom-area/upload bugs found while working on it.

## 1. Reset returns 400 (GMW-1067)
Resetting a custom area clears the analysis atoms synchronously, but the URL only settles to worldwide on a later tick. In that transient render the analysis widget hooks refetched with the stale `location_id=custom-area` against the main widgets API → **400** (a null-geometry analysis POST could also 400).

- Guard each analysis widget query's `enabled`: require geometry when analysis is on, and a non-custom-area location when it is off.
- Applied to `height`, `biomass`, `blue-carbon`, `habitat-extent`, `net-change`.
- Playwright regression asserting no 4xx on reset (`tests/drawing-tool.spec.ts`).

## 2. Upload didn't switch location to custom-area
Upload used `router.push('/custom-area')` — a full App Router navigation through the `[[...params]]` catch-all (RSC refetch + page re-render) that didn't reliably switch the location and never moved the map.

- Use the same client-side `navigate()` the draw flow uses (`history.replaceState`, no RSC refetch) and fly the map to the uploaded geometry's bounds.

## 3. Uploaded areas couldn't be saved
`buildCustomGeometry` only accepted `Polygon`; uploaded shapefiles/geopackages commonly convert to `MultiPolygon`, so save silently no-opped. The create endpoint only accepts Polygon (sending MultiPolygon **500s**).

- Reduce the geometry to a Polygon before saving: unwrap a single-part MultiPolygon (lossless), else keep the largest part (planar shoelace compare — no new deps).
- Replaced a `setState`-in-effect name resync with a render-time adjustment.
- Caveat: a true multi-part upload saves only its largest part — a backend Polygon-only limit.

## Test plan
- [x] `pnpm check-types`, `pnpm lint`
- [ ] Reset a custom area (drawn + uploaded) — no 400 in the network tab
- [ ] Upload a shapefile/geojson — location switches to custom-area, map flies to the area
- [ ] Save an uploaded area (Polygon and MultiPolygon shapefiles) — persists, no 500
- [ ] `npx playwright test tests/drawing-tool.spec.ts`

[GMW-1067]: https://vizzuality.atlassian.net/browse/GMW-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ