### PR TITLE
fix: use PATCH for user updates + stop logging password payloads

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -43,7 +43,7 @@ export function requestPasswordReset(payload: ResetPasswordPayload) {
 
 export function updatePassword(payload: ResetPasswordUpdatePayload) {
   console.info('Updating password for:', payload, AuthAPI.defaults.baseURL);
-  return AuthAPI.put<ResetPasswordResponse>('/users/password', payload).then((r) => r.data);
+  return AuthAPI.patch<ResetPasswordResponse>('/users/password', payload).then((r) => r.data);
 }
 
 export function signupUser(payload: SignupPayload) {
@@ -51,5 +51,5 @@ export function signupUser(payload: SignupPayload) {
 }
 
 export function updateUser(payload: UpdateUserPayload, _token: string) {
-  return AuthAPI.put<UpdateUserResponse>('/users', payload, {}).then((r) => r.data);
+  return AuthAPI.patch<UpdateUserResponse>('/users', payload, {}).then((r) => r.data);
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -37,12 +37,10 @@ export type UpdateUserResponse =
 
 // Functions
 export function requestPasswordReset(payload: ResetPasswordPayload) {
-  console.info('Requesting password reset for:', payload, AuthAPI.defaults.baseURL);
   return AuthAPI.post<ResetPasswordResponse>('/users/password', payload).then((r) => r.data);
 }
 
 export function updatePassword(payload: ResetPasswordUpdatePayload) {
-  console.info('Updating password for:', payload, AuthAPI.defaults.baseURL);
   return AuthAPI.patch<ResetPasswordResponse>('/users/password', payload).then((r) => r.data);
 }
 


### PR DESCRIPTION
## Summary

Two fixes in the auth service (`src/services/auth.ts`):

1. **PUT → PATCH** for user updates — `updatePassword` (`/users/password`) and `updateUser` (`/users`) now use `AuthAPI.patch` instead of `put`, matching the auth service's partial-update semantics.
2. **Stop logging password payloads** — removed `console.info` calls in `requestPasswordReset` and `updatePassword` that logged the full request payload (password / reset token) to the console.

## Test plan
- [x] `tsc` + eslint clean (pre-commit hook)
- [ ] CI green
- [ ] Password reset flow works end-to-end (request reset + set new password)
- [ ] Profile update (`updateUser`) persists via PATCH
- [ ] Confirm auth backend accepts PATCH on `/users` and `/users/password`
