### PR TITLE
fix: persist free-text 'Other' role (user_other_role key)

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -88,7 +88,7 @@ export default function SignupPage() {
           name: username,
           ...(organization?.trim() ? { organization: organization.trim() } : {}),
           ...(roles?.length ? { user_roles: roles } : {}),
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_role_other: otherRole } : {}),
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_other_role: otherRole } : {}),
         },
       },
       {

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -120,13 +120,28 @@ const AccountContent = () => {
         },
       },
       {
-        onSuccess: () => {
-          void updateSession({
+        onSuccess: async (data) => {
+          // DEBUG(profile-update): what the API returned vs what we push into the
+          // next-auth session. Remove before merge.
+          // eslint-disable-next-line no-console
+          console.debug(
+            '[profile-update] mutation success. api data =',
+            data,
+            '| session update =',
+            {
+              organization,
+              roles: roles ?? [],
+              other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
+            }
+          );
+          const updated = await updateSession({
             name: username,
             organization,
             roles: roles ?? [],
             other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
           });
+          // eslint-disable-next-line no-console
+          console.debug('[profile-update] session after updateSession =', updated?.user);
         },
         onError: (error: any) => {
           const apiErrors = error?.response?.data?.errors;

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -120,28 +120,13 @@ const AccountContent = () => {
         },
       },
       {
-        onSuccess: async (data) => {
-          // DEBUG(profile-update): what the API returned vs what we push into the
-          // next-auth session. Remove before merge.
-          // eslint-disable-next-line no-console
-          console.debug(
-            '[profile-update] mutation success. api data =',
-            data,
-            '| session update =',
-            {
-              organization,
-              roles: roles ?? [],
-              other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
-            }
-          );
-          const updated = await updateSession({
+        onSuccess: () => {
+          void updateSession({
             name: username,
             organization,
             roles: roles ?? [],
             other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
           });
-          // eslint-disable-next-line no-console
-          console.debug('[profile-update] session after updateSession =', updated?.user);
         },
         onError: (error: any) => {
           const apiErrors = error?.response?.data?.errors;

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -116,7 +116,7 @@ const AccountContent = () => {
           user_roles: roles ?? [],
           // Only send password fields when the user is actually changing it.
           ...(password ? { password, current_password } : {}),
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_role_other: otherRole } : {}),
+          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_other_role: otherRole } : {}),
         },
       },
       {

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -78,7 +78,7 @@ export const authOptions: NextAuthOptions = {
           name: data?.username || credentials.email,
           organization: data?.organization || null,
           roles: data?.user_roles ?? [],
-          other_role: data?.user_role_other || null,
+          other_role: data?.user_other_role || null,
           accessToken: token,
         };
       },
@@ -110,7 +110,7 @@ export const authOptions: NextAuthOptions = {
           name: data.name || data.username,
           organization: data.organization || null,
           roles: data.user_roles ?? [],
-          other_role: data.user_role_other || null,
+          other_role: data.user_other_role || null,
           accessToken: credentials.token,
         };
       },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -13,7 +13,7 @@ export type SignupPayload = {
     name: string;
     organization?: string;
     user_roles?: string[];
-    user_role_other?: string;
+    user_other_role?: string;
   };
 };
 export type SignupResponse =
@@ -26,7 +26,7 @@ export type UpdateUserPayload = {
     name?: string;
     organization?: string;
     user_roles?: string[];
-    user_role_other?: string;
+    user_other_role?: string;
     // Only required by the API when changing the password.
     current_password?: string;
   };

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -49,5 +49,14 @@ export function signupUser(payload: SignupPayload) {
 }
 
 export function updateUser(payload: UpdateUserPayload, _token: string) {
-  return AuthAPI.patch<UpdateUserResponse>('/users', payload, {}).then((r) => r.data);
+  // DEBUG(profile-update): trace outgoing PATCH + backend echo to see whether
+  // organization / user_roles are persisted. Remove before merge.
+  const { password: _pw, current_password: _cpw, ...safeUser } = payload.user;
+  // eslint-disable-next-line no-console
+  console.debug('[profile-update] PATCH /users payload.user =', safeUser);
+  return AuthAPI.patch<UpdateUserResponse>('/users', payload, {}).then((r) => {
+    // eslint-disable-next-line no-console
+    console.debug('[profile-update] PATCH /users response =', r.status, r.data);
+    return r.data;
+  });
 }

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -49,14 +49,5 @@ export function signupUser(payload: SignupPayload) {
 }
 
 export function updateUser(payload: UpdateUserPayload, _token: string) {
-  // DEBUG(profile-update): trace outgoing PATCH + backend echo to see whether
-  // organization / user_roles are persisted. Remove before merge.
-  const { password: _pw, current_password: _cpw, ...safeUser } = payload.user;
-  // eslint-disable-next-line no-console
-  console.debug('[profile-update] PATCH /users payload.user =', safeUser);
-  return AuthAPI.patch<UpdateUserResponse>('/users', payload, {}).then((r) => {
-    // eslint-disable-next-line no-console
-    console.debug('[profile-update] PATCH /users response =', r.status, r.data);
-    return r.data;
-  });
+  return AuthAPI.patch<UpdateUserResponse>('/users', payload, {}).then((r) => r.data);
 }

--- a/tests/component/containers/navigation/menu/profile/account.test.tsx
+++ b/tests/component/containers/navigation/menu/profile/account.test.tsx
@@ -107,4 +107,23 @@ describe('AccountContent — profile update', () => {
     const payload = updateUserMock.mock.calls[0][0] as { user: { user_roles?: string[] } };
     expect(payload.user.user_roles).toEqual(expect.arrayContaining(['scientist', 'ngo']));
   });
+
+  it('sends the free-text role under user_other_role (the key the backend expects)', async () => {
+    const user = userEvent.setup();
+    renderAccount();
+
+    await user.click(screen.getByRole('button', { name: /scientist/i }));
+    await user.click(await screen.findByRole('option', { name: 'Other' }));
+    await user.keyboard('{Escape}');
+
+    await user.type(screen.getByPlaceholderText('Tell us your role'), 'Park Ranger');
+    await user.click(await screen.findByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateUserMock).toHaveBeenCalledTimes(1));
+
+    const payload = updateUserMock.mock.calls[0][0] as { user: Record<string, unknown> };
+    expect(payload.user.user_other_role).toBe('Park Ranger');
+    // Regression guard: the old (wrong) key must never be sent.
+    expect(payload.user).not.toHaveProperty('user_role_other');
+  });
 });

--- a/tests/component/containers/navigation/menu/profile/account.test.tsx
+++ b/tests/component/containers/navigation/menu/profile/account.test.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// next-auth session: an authenticated user with an organization and one role.
+// `update` is what the account form calls to reflect saved edits back into the
+// client session, so we assert against it.
+const updateSessionMock = vi.fn().mockResolvedValue(undefined);
+const sessionData = {
+  user: {
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    organization: 'Old Org',
+    roles: ['scientist'],
+    other_role: null,
+    accessToken: 'test-token',
+  },
+};
+
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: sessionData, update: updateSessionMock, status: 'authenticated' }),
+  signOut: vi.fn(),
+}));
+
+// Mock only the network call; the real react-query hook + onSuccess/updateSession
+// path runs so we exercise the actual mapping from form values to API payload.
+const updateUserMock = vi.fn().mockResolvedValue({ ok: true });
+vi.mock('services/auth', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import('services/auth');
+  return { ...actual, updateUser: (...args: unknown[]) => updateUserMock(...args) };
+});
+
+import AccountContent from '@/containers/navigation/menu/profile/account';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  // Radix popover (RolesSelect) touches these in jsdom.
+  if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+  if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+  if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {};
+});
+
+beforeEach(() => {
+  updateUserMock.mockClear();
+  updateSessionMock.mockClear();
+});
+
+function renderAccount() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <AccountContent />
+    </QueryClientProvider>
+  );
+}
+
+describe('AccountContent — profile update', () => {
+  it('saves a new organization and preserves the existing roles', async () => {
+    const user = userEvent.setup();
+    renderAccount();
+
+    const org = screen.getByPlaceholderText('Organization');
+    await user.clear(org);
+    await user.type(org, 'New Org');
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateUserMock).toHaveBeenCalledTimes(1));
+
+    const payload = updateUserMock.mock.calls[0][0] as {
+      user: { organization?: string; user_roles?: string[] };
+    };
+    expect(payload.user.organization).toBe('New Org');
+    expect(payload.user.user_roles).toEqual(['scientist']);
+    // No password change → credentials must not be sent.
+    expect(payload.user).not.toHaveProperty('password');
+
+    await waitFor(() =>
+      expect(updateSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({ organization: 'New Org', roles: ['scientist'] })
+      )
+    );
+  });
+
+  it('adds a newly selected role to the saved user_roles', async () => {
+    const user = userEvent.setup();
+    renderAccount();
+
+    // Open the roles dropdown (trigger shows the current selection label).
+    await user.click(screen.getByRole('button', { name: /scientist/i }));
+    await user.click(await screen.findByRole('option', { name: 'NGO' }));
+    // The RolesSelect popover is modal (aria-hides the rest of the tree); close
+    // it so the Save button is back in the accessibility tree and enabled.
+    await user.keyboard('{Escape}');
+
+    await user.click(await screen.findByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => expect(updateUserMock).toHaveBeenCalledTimes(1));
+
+    const payload = updateUserMock.mock.calls[0][0] as { user: { user_roles?: string[] } };
+    expect(payload.user.user_roles).toEqual(expect.arrayContaining(['scientist', 'ngo']));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes profile & signup silently dropping the free-text **"Other" role**. The backend expects the key `user_other_role`, but the client sent `user_role_other` on both write payloads and also parsed that wrong key back from `current_user` — so the value never round-tripped.

Renamed `user_role_other` → `user_other_role` in all 6 spots:
- **Writes:** `account.tsx` (profile update), `auth/signup/page.tsx` (signup).
- **Types:** `UpdateUserPayload`, `SignupPayload` in `services/auth.ts`.
- **Reads:** both `authorize` callbacks in `lib/auth/auth.ts` (credentials + shared-token/SSO).

`user_roles` and `organization` were already correct.

## Tests
Adds the first vitest **component** test for the account form (`tests/component/.../profile/account.test.tsx`):
- saves a new organization + preserves existing roles → correct API payload + session update
- adds a newly selected role to `user_roles`
- sends free-text role under `user_other_role` (**regression guard**: asserts the old `user_role_other` key is never sent)

All 3 pass; `tsc` clean.

## Test plan
- [ ] CI green
- [ ] Log in → profile → change Organization → save → reload → persists
- [ ] Add/remove roles + set "Other" free-text → save → reload → persists
- [ ] Signup with an "Other" role → value stored server-side

## Note
Squash-merge recommended — the branch contains a temporary debug commit and its revert (net-zero) used while locating the bug.
