### PR TITLE
fix: correct user_role_other API key + revive signup role fields

### DIFF
--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -25,11 +25,11 @@ const formSchema = z
     username: z.string().min(1, { message: 'Please enter your name' }),
     email: z.string().email({ message: 'Please enter a valid email address' }),
     organization: z.string().optional(),
-    roles: z
+    user_roles: z
       .array(z.string().refine((v) => ROLE_VALUES.includes(v)))
       .optional()
       .default([]),
-    'other-role': z.string().optional(),
+    user_role_other: z.string().optional(),
     password: z.string().nonempty({ message: 'Please enter your password' }).min(6, {
       message: 'Please enter a password with at least 6 characters',
     }),
@@ -46,11 +46,11 @@ const formSchema = z
         path: ['confirm-password'],
       });
     }
-    if (data.roles?.includes(OTHER_ROLE_VALUE) && !data['other-role']?.trim()) {
+    if (data.user_roles?.includes(OTHER_ROLE_VALUE) && !data.user_role_other?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Please describe your role',
-        path: ['other-role'],
+        path: ['user_role_other'],
       });
     }
   });
@@ -67,16 +67,16 @@ export default function SignupPage() {
       password: '',
       'confirm-password': '',
       organization: '',
-      roles: [],
-      'other-role': '',
+      user_roles: [],
+      user_role_other: '',
     },
   });
 
-  const showOtherRole = form.watch('roles')?.includes(OTHER_ROLE_VALUE);
+  const showOtherRole = form.watch('user_roles')?.includes(OTHER_ROLE_VALUE);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const { email, password, username, organization, roles } = values;
-    const otherRole = values['other-role']?.trim();
+    const { email, password, username, organization, user_roles } = values;
+    const otherRole = values.user_role_other?.trim();
 
     form.clearErrors();
 
@@ -87,8 +87,10 @@ export default function SignupPage() {
           password,
           name: username,
           ...(organization?.trim() ? { organization: organization.trim() } : {}),
-          ...(roles?.length ? { user_roles: roles } : {}),
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_other_role: otherRole } : {}),
+          ...(user_roles?.length ? { user_roles } : {}),
+          ...(user_roles?.includes(OTHER_ROLE_VALUE) && otherRole
+            ? { user_role_other: otherRole }
+            : {}),
         },
       },
       {
@@ -195,7 +197,7 @@ export default function SignupPage() {
 
                   <FormField
                     control={form.control}
-                    name="roles"
+                    name="user_roles"
                     render={({ field }) => (
                       <FormItem className="space-y-1.5">
                         <FormLabel className="text-xs font-semibold">What is your role?</FormLabel>
@@ -209,8 +211,8 @@ export default function SignupPage() {
                           onChange={(selection) => {
                             field.onChange(selection);
                             if (!selection.includes(OTHER_ROLE_VALUE)) {
-                              form.setValue('other-role', '');
-                              form.clearErrors('other-role');
+                              form.setValue('user_role_other', '');
+                              form.clearErrors('user_role_other');
                             }
                           }}
                         />
@@ -222,7 +224,7 @@ export default function SignupPage() {
                   {showOtherRole && (
                     <FormField
                       control={form.control}
-                      name="other-role"
+                      name="user_role_other"
                       render={({ field }) => (
                         <FormItem className="space-y-1.5">
                           <FormLabel className="text-xs font-semibold" required>

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -33,11 +33,11 @@ const formSchema = z
     username: z.string().min(1, { message: 'Please enter your name' }).optional(),
     email: z.string().email({ message: 'Please enter a valid email address' }).optional(),
     organization: z.string().optional(),
-    roles: z
+    user_roles: z
       .array(z.string().refine((v) => ROLE_VALUES.includes(v)))
       .optional()
       .default([]),
-    'other-role': z.string().optional(),
+    user_role_other: z.string().optional(),
     // Empty string means "not changing the password".
     password: z
       .string()
@@ -50,11 +50,11 @@ const formSchema = z
     delete_account: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.roles?.includes(OTHER_ROLE_VALUE) && !data['other-role']?.trim()) {
+    if (data.user_roles?.includes(OTHER_ROLE_VALUE) && !data.user_role_other?.trim()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Please describe your role',
-        path: ['other-role'],
+        path: ['user_role_other'],
       });
     }
     // Current password is only needed to change the password.
@@ -85,14 +85,14 @@ const AccountContent = () => {
       username: user?.name || '',
       organization: user?.organization || '',
       email: user?.email || '',
-      roles: user?.roles ?? [],
-      'other-role': user?.other_role || '',
+      user_roles: user?.roles ?? [],
+      user_role_other: user?.other_role || '',
       password: '',
       current_password: '',
     },
   });
 
-  const showOtherRole = form.watch('roles')?.includes(OTHER_ROLE_VALUE);
+  const showOtherRole = form.watch('user_roles')?.includes(OTHER_ROLE_VALUE);
   const changingPassword = !!form.watch('password');
 
   // current_password is a confirmation, not a profile change — typing it alone
@@ -102,8 +102,8 @@ const AccountContent = () => {
   );
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    const { email, password, username, organization, roles, current_password } = values;
-    const otherRole = values['other-role']?.trim();
+    const { email, password, username, organization, user_roles, current_password } = values;
+    const otherRole = values['user_role_other']?.trim();
 
     form.clearErrors();
 
@@ -113,19 +113,23 @@ const AccountContent = () => {
           email,
           name: username,
           organization,
-          user_roles: roles ?? [],
+          user_roles: user_roles ?? [],
           // Only send password fields when the user is actually changing it.
           ...(password ? { password, current_password } : {}),
-          ...(roles?.includes(OTHER_ROLE_VALUE) && otherRole ? { user_other_role: otherRole } : {}),
+          ...(user_roles?.includes(OTHER_ROLE_VALUE) && otherRole
+            ? { user_role_other: otherRole }
+            : {}),
         },
       },
       {
         onSuccess: () => {
+          // NextAuth local-session contract uses `roles`/`other_role` (read by the
+          // jwt callback in auth.ts) — not the API's `user_roles`/`user_role_other`.
           void updateSession({
             name: username,
             organization,
-            roles: roles ?? [],
-            other_role: roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
+            roles: user_roles ?? [],
+            other_role: user_roles?.includes(OTHER_ROLE_VALUE) && otherRole ? otherRole : null,
           });
         },
         onError: (error: any) => {
@@ -211,7 +215,7 @@ const AccountContent = () => {
 
           <FormField
             control={form.control}
-            name="roles"
+            name="user_roles"
             render={({ field }) => (
               <FormItem className="gap-0">
                 <FormLabel className="text-xs font-semibold">What is your role?</FormLabel>
@@ -226,8 +230,8 @@ const AccountContent = () => {
                   onChange={(selection) => {
                     field.onChange(selection);
                     if (!selection.includes(OTHER_ROLE_VALUE)) {
-                      form.setValue('other-role', '');
-                      form.clearErrors('other-role');
+                      form.setValue('user_role_other', '');
+                      form.clearErrors('user_role_other');
                     }
                   }}
                 />
@@ -239,7 +243,7 @@ const AccountContent = () => {
           {showOtherRole && (
             <FormField
               control={form.control}
-              name="other-role"
+              name="user_role_other"
               render={({ field }) => (
                 <FormItem className="gap-0">
                   <FormLabel className="text-xs font-semibold" required>

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -78,7 +78,7 @@ export const authOptions: NextAuthOptions = {
           name: data?.username || credentials.email,
           organization: data?.organization || null,
           roles: data?.user_roles ?? [],
-          other_role: data?.user_other_role || null,
+          other_role: data?.user_role_other || null,
           accessToken: token,
         };
       },
@@ -110,7 +110,7 @@ export const authOptions: NextAuthOptions = {
           name: data.name || data.username,
           organization: data.organization || null,
           roles: data.user_roles ?? [],
-          other_role: data.user_other_role || null,
+          other_role: data.user_role_other || null,
           accessToken: credentials.token,
         };
       },

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -13,7 +13,7 @@ export type SignupPayload = {
     name: string;
     organization?: string;
     user_roles?: string[];
-    user_other_role?: string;
+    user_role_other?: string;
   };
 };
 export type SignupResponse =
@@ -26,7 +26,7 @@ export type UpdateUserPayload = {
     name?: string;
     organization?: string;
     user_roles?: string[];
-    user_other_role?: string;
+    user_role_other?: string;
     // Only required by the API when changing the password.
     current_password?: string;
   };

--- a/tests/component/containers/navigation/menu/profile/account.test.tsx
+++ b/tests/component/containers/navigation/menu/profile/account.test.tsx
@@ -108,7 +108,7 @@ describe('AccountContent — profile update', () => {
     expect(payload.user.user_roles).toEqual(expect.arrayContaining(['scientist', 'ngo']));
   });
 
-  it('sends the free-text role under user_other_role (the key the backend expects)', async () => {
+  it('sends the free-text role under user_role_other (the key the backend expects)', async () => {
     const user = userEvent.setup();
     renderAccount();
 
@@ -122,8 +122,8 @@ describe('AccountContent — profile update', () => {
     await waitFor(() => expect(updateUserMock).toHaveBeenCalledTimes(1));
 
     const payload = updateUserMock.mock.calls[0][0] as { user: Record<string, unknown> };
-    expect(payload.user.user_other_role).toBe('Park Ranger');
+    expect(payload.user.user_role_other).toBe('Park Ranger');
     // Regression guard: the old (wrong) key must never be sent.
-    expect(payload.user).not.toHaveProperty('user_role_other');
+    expect(payload.user).not.toHaveProperty('user_other_role');
   });
 });


### PR DESCRIPTION
## Why

The backend expects the free-text "Other" role under **`user_role_other`** (alongside `user_roles`):

```json
{ "user_roles": ["scientist", "other"], "user_role_other": "none" }
```

A prior fix (`a20ad59c`) renamed the key the wrong way — to `user_other_role` — so the free-text role was still dropped by the API. This corrects the key and cleans up two related issues in the same area.

## What changed

**1. API key `user_other_role` → `user_role_other`**
- Profile + signup payload builds (`account.tsx`, `signup/page.tsx`)
- `UpdateUserPayload` / `SignupPayload` types (`services/auth.ts`)
- Both `authorize` reads from the backend (`auth.ts` — `sign_in` + `current_user`)

**2. Signup role fields were dead**
Schema/defaults used `user_role` / `user_roles` / `user_role_other`, but validation, `watch`, submit and the `FormField` names all used `roles` / `other-role`. The mismatch meant role selection never validated and never submitted. All consumers now agree on `user_roles` / `user_role_other` (account form aligned to the same names).

**3. Profile `updateSession` bug**
`updateSession` sent `user_roles`, but the NextAuth jwt callback reads `session.roles` (`auth.ts`), so saved roles never reflected into the local session after save. Now sends `roles` / `other_role` — the local-session contract, mapped from the backend `user_*` keys in `authorize`.

### Resulting layers
- **Form fields:** `user_roles` / `user_role_other`
- **API payload:** `user_roles` / `user_role_other` ✓
- **NextAuth session:** `roles` / `other_role` (internal, mapped in `authorize`)

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm test:unit` — account test 3/3 (locks `user_role_other`, guards old `user_other_role`)
- [x] `eslint` changed files — 0 errors
- [ ] Save profile with "Other" role → confirm PATCH body has `user_roles` + `user_role_other`; reload → persists
- [ ] Sign up selecting roles incl. "Other" → confirm roles submit and free-text validates
