### PR TITLE
fix: PATCH /users for profile update (current_user is GET-only, was 404)

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -48,7 +48,9 @@ export async function PATCH(request: NextRequest) {
 
   const body = await request.json();
 
-  const upstream = await fetch(`${process.env.AUTH_API_URL}/users/current_user`, {
+  // Devise registrations#update — the BE update endpoint. current_user is GET-only,
+  // so PATCH must target /users (see mangrove-atlas-api config/routes.rb).
+  const upstream = await fetch(`${process.env.AUTH_API_URL}/users`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Context

Follow-up to #1623. That PR **squash-merged with the PATCH pointed at `/users/current_user`** — but the BE exposes `GET /users/current_user` (`current_user#show`) **only**, no PATCH there. So profile saves currently **404** on develop/staging.

The current-user update is Devise `registrations#update` at **`PATCH /users`** (`mangrove-atlas-api` `config/routes.rb`; custom `Users::RegistrationsController` supports update without password and returns `{ message, user }`).

## Change (FE only, one line)

- `src/app/api/auth/me/route.ts` — **PATCH** target `/users/current_user` → **`/users`**. GET read-back stays on `/users/current_user` (correct, GET-only).

No BE change. Outgoing payload unchanged (`user_roles`/`user_role_other`).

## Test plan

- [ ] Save profile → `PATCH /api/auth/me` returns **200** (no 404), values reflect without reload
- [ ] Reload → values persist (read-back from `/users/current_user`)
- [ ] Change email → Save → reload → persists
- [ ] Password change requires `current_password`
- [ ] Update → logout → login → changes visible