### PR TITLE
fix: profile update goes direct to BE /users; align getToken cookie for /auth/me GET

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,12 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { SESSION_COOKIE_NAME, useSecureCookies } from '@/lib/auth/auth';
 import { clearSSOCookie } from '@/lib/auth/sso-cookie';
 
 import { getToken } from 'next-auth/jwt';
 
 export async function POST(request: NextRequest) {
   try {
-    const token = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+    const token = await getToken({
+      req: request,
+      secret: process.env.NEXTAUTH_SECRET,
+      cookieName: SESSION_COOKIE_NAME,
+      secureCookie: useSecureCookies,
+    });
     const accessToken = (token as any)?.accessToken;
 
     if (accessToken) {

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { SESSION_COOKIE_NAME, useSecureCookies } from '@/lib/auth/auth';
+
 import { getToken } from 'next-auth/jwt';
 
 // Fetch the canonical current user from the auth service and normalize the
@@ -26,7 +28,12 @@ async function fetchCurrentUser(accessToken: string) {
 // Read the current user. Proxies to the auth service server-side so the bearer
 // token stays off the client and the session can be re-hydrated from BE truth.
 export async function GET(request: NextRequest) {
-  const jwt = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+  const jwt = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+    cookieName: SESSION_COOKIE_NAME,
+    secureCookie: useSecureCookies,
+  });
   const accessToken = (jwt as any)?.accessToken;
 
   if (!accessToken) return NextResponse.json({ ok: false }, { status: 401 });
@@ -41,7 +48,12 @@ export async function GET(request: NextRequest) {
 // Update the current user. Proxies to the auth service server-side so the browser
 // never makes a cross-origin call and the bearer token stays off the client.
 export async function PATCH(request: NextRequest) {
-  const jwt = await getToken({ req: request, secret: process.env.NEXTAUTH_SECRET });
+  const jwt = await getToken({
+    req: request,
+    secret: process.env.NEXTAUTH_SECRET,
+    cookieName: SESSION_COOKIE_NAME,
+    secureCookie: useSecureCookies,
+  });
   const accessToken = (jwt as any)?.accessToken;
 
   if (!accessToken) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/src/app/api/auth/sso/set-from-session/route.ts
+++ b/src/app/api/auth/sso/set-from-session/route.ts
@@ -1,11 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { SESSION_COOKIE_NAME, useSecureCookies } from '@/lib/auth/auth';
 import { setSSOCookie } from '@/lib/auth/sso-cookie';
 
 import { getToken } from 'next-auth/jwt';
 
 export async function POST(request: NextRequest) {
-  const jwt = await getToken({ req: request as any, secret: process.env.NEXTAUTH_SECRET });
+  const jwt = await getToken({
+    req: request as any,
+    secret: process.env.NEXTAUTH_SECRET,
+    cookieName: SESSION_COOKIE_NAME,
+    secureCookie: useSecureCookies,
+  });
 
   if (!jwt?.accessToken) {
     return NextResponse.json({ ok: false }, { status: 401 });

--- a/src/containers/navigation/menu/profile/subscriptions.tsx
+++ b/src/containers/navigation/menu/profile/subscriptions.tsx
@@ -25,8 +25,7 @@ const SubscriptionsContent = () => {
 
   const serverPrefs =
     (dataUserNotificationsPreferences?.data as
-      | DataUserNotificationPreferencesToggleLocationAlerts
-      | undefined) ?? undefined;
+      DataUserNotificationPreferencesToggleLocationAlerts | undefined) ?? undefined;
 
   const [basePrefs, setBasePrefs] = useState<
     DataUserNotificationPreferencesToggleLocationAlerts | undefined
@@ -114,7 +113,7 @@ const SubscriptionsContent = () => {
             {!hasLocations && (
               <TooltipContent
                 side="right"
-                className="shadow-soft max-w-[190px] rounded-3xl bg-white p-4 text-black/85 first-letter:uppercase"
+                className="shadow-soft max-w-47.5 rounded-3xl bg-white p-4 text-black/85 first-letter:uppercase"
               >
                 Save at least one area to activate notifications.
                 <TooltipArrow className="fill-white" width={10} height={5} />
@@ -126,7 +125,8 @@ const SubscriptionsContent = () => {
             <div className="flex max-w-sm flex-col justify-between gap-2">
               <span className="text-lg font-light">What&apos;s new</span>
               <p className="text-sm text-[#939393]">
-                Weekly updates on mangrove conservation news and the latest platform enhancements.
+                Occasional updates on mangrove conservation news and the latest platform
+                enhancements.
               </p>
             </div>
 

--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -29,6 +29,15 @@ declare module 'next-auth' {
 const isProd = process.env.NEXT_PUBLIC_ENVIRONMENT === 'production';
 const cookieDomain = isProd ? '.globalmangrovewatch.org' : undefined;
 
+// Single source of truth for the session cookie so writers (authOptions.cookies)
+// and readers (getToken in the /api/auth/* route handlers) never drift. getToken
+// otherwise auto-detects the name from the request scheme, which mismatches on
+// https-but-not-production envs (staging/preview) and yields a spurious 401.
+export const useSecureCookies = isProd;
+export const SESSION_COOKIE_NAME = isProd
+  ? '__Secure-next-auth.session-token'
+  : 'next-auth.session-token';
+
 export const authOptions: NextAuthOptions = {
   secret: process.env.NEXTAUTH_SECRET,
   debug: process.env.NEXT_PUBLIC_ENVIRONMENT !== 'production',
@@ -158,7 +167,7 @@ export const authOptions: NextAuthOptions = {
 
   cookies: {
     sessionToken: {
-      name: isProd ? '__Secure-next-auth.session-token' : 'next-auth.session-token',
+      name: SESSION_COOKIE_NAME,
       options: {
         httpOnly: true,
         sameSite: 'lax',

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -49,7 +49,9 @@ export function signupUser(payload: SignupPayload) {
 }
 
 export function updateUser(payload: UpdateUserPayload) {
-  // Same-origin proxy → auth service (see src/app/api/auth/me/route.ts), so the browser
-  // never makes a cross-origin PATCH and the bearer token stays server-side.
-  return NextAPI.patch<UpdateUserResponse>('/auth/me', payload).then((r) => r.data);
+  // Update goes straight to the auth service (Devise registrations#update on /users).
+  // The same-origin /auth/me proxy 401s in some envs, so we call the BE directly; the
+  // bearer token is attached client-side by the AuthAPI interceptor from the (SSO-kept)
+  // session. current_user is GET-only, so the PATCH target is /users.
+  return AuthAPI.patch<UpdateUserResponse>('/users', payload).then((r) => r.data);
 }


### PR DESCRIPTION
## Context

Pressing **Save changes** in the profile Account form (e.g. editing `user_roles`) 401'd. Two separate things:

1. The same-origin `/api/auth/me` **PATCH** proxy returned 401 in some envs (`getToken` couldn't read the JWT).
2. The `/api/auth/me` **GET** proxy (used by `session-sync`) shared the same `getToken` weakness.

## Changes

### 1. Profile update → direct to BE `/users` (`src/services/auth.ts`)
`updateUser` now calls `AuthAPI.patch('/users')` (Devise `registrations#update`, per API spec `PATCH /users` = Update user profile) instead of the `/auth/me` proxy. SSO login and the session are unchanged; the bearer token is attached client-side by the `AuthAPI` interceptor from the kept session. Payload shape (`{ user: {...} }`) is unchanged.

### 2. `getToken` cookie-name alignment (auth route handlers)
`getToken` auto-detected the session-cookie name from request scheme, but NextAuth writes it from `NEXT_PUBLIC_ENVIRONMENT`. On https-but-not-`production` envs the names diverged, so the JWT was unreadable → 401.

- `src/lib/auth/auth.ts` — export `SESSION_COOKIE_NAME` + `useSecureCookies` as a single source of truth; `cookies.sessionToken.name` reuses the constant.
- `me/route.ts` (GET), `logout/route.ts`, `sso/set-from-session/route.ts` — pass `cookieName` + `secureCookie` to every `getToken`. Still relevant: `/auth/me` **GET** powers `session-sync`, and logout/sso read the JWT. (The PATCH proxy handler is now unused by the app but left in place.)

### 3. Minor
`subscriptions.tsx` copy + tailwind tweak (separate commit).

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint` (changed files)
- [ ] Deploy preview: log in (incl. SSO) → edit roles → **Save changes** → expect `200` from `PATCH /users`, success toast, values persist on reopen
- [ ] Confirm no CORS error on the cross-origin `PATCH /users` (auth backend already allows `PATCH /users/password` from the app origin)
- [ ] `session-sync` GET `/api/auth/me` returns `200` on staging (getToken fix)
- [ ] Logout still 200s and calls upstream `sign_out`