### PR TITLE
fix: net change y-axis double-converts km² to ha (GMW-1071)

### DIFF
--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -58,6 +58,15 @@ export const getFormat = (v) => {
   return formatByDecimals(v);
 };
 
+// Format a y-axis tick. `v` already reflects the selected unit — getWidgetData
+// converts km²→ha (×100) upstream, so this must NOT re-apply the factor or ha
+// labels gain 2 extra zeroes (GMW-1071). Keeps the sign for below-baseline loss.
+export const formatAxisTick = (v: number): string | number => {
+  const result = getFormat(Math.abs(v)); // comma-grouped string, e.g. "5,000"
+  if (Number(result.replace(/,/g, '')) === 0) return 0;
+  return v < 0 ? `-${result}` : result;
+};
+
 export const getWidgetData = (data: Data[], unit = '') => {
   if (!data?.length) return null;
   const firstYear = Math.min(...data.map((d) => d.year));
@@ -256,14 +265,7 @@ export function useMangroveNetChange(
       // same right-side space and align its plot box with this chart's.
       width: Y_AXIS_WIDTH,
       tick: { ...AXIS_TICK },
-      tickFormatter: (v) => {
-        // `v` already reflects the selected unit — getWidgetData converts km²→ha (×100)
-        // when unit === 'ha'. Do NOT re-apply it here or ha labels get 2 extra zeroes.
-        const result = getFormat(Math.abs(v)); // comma-grouped string, e.g. "5,000"
-        if (Number(result.replace(/,/g, '')) === 0) return 0;
-        // Loss sits below the zero baseline — keep the sign so negative levels read as "-N".
-        return v < 0 ? `-${result}` : result;
-      },
+      tickFormatter: formatAxisTick,
       tickMargin: 10,
       orientation: 'right',
       label: {

--- a/src/containers/datasets/net-change/hooks.tsx
+++ b/src/containers/datasets/net-change/hooks.tsx
@@ -257,8 +257,9 @@ export function useMangroveNetChange(
       width: Y_AXIS_WIDTH,
       tick: { ...AXIS_TICK },
       tickFormatter: (v) => {
-        const parsedNumber = unit === 'ha' ? v * 100 : v;
-        const result = getFormat(Math.abs(parsedNumber)); // comma-grouped string, e.g. "5,000"
+        // `v` already reflects the selected unit — getWidgetData converts km²→ha (×100)
+        // when unit === 'ha'. Do NOT re-apply it here or ha labels get 2 extra zeroes.
+        const result = getFormat(Math.abs(v)); // comma-grouped string, e.g. "5,000"
         if (Number(result.replace(/,/g, '')) === 0) return 0;
         // Loss sits below the zero baseline — keep the sign so negative levels read as "-N".
         return v < 0 ? `-${result}` : result;

--- a/tests/unit/containers/datasets/net-change/hooks.test.ts
+++ b/tests/unit/containers/datasets/net-change/hooks.test.ts
@@ -1,4 +1,5 @@
 import {
+  formatAxisTick,
   getEvenlySpacedTicks,
   getFormat,
   getNetChangeSources,
@@ -20,6 +21,30 @@ describe('getFormat', () => {
   it('formats with decimals derived from magnitude', () => {
     expect(getFormat(0.5)).toBe('0.5');
     expect(getFormat(0.123)).toBe('0.1');
+  });
+});
+
+describe('formatAxisTick', () => {
+  // Regression for GMW-1071: getWidgetData already converts km²→ha (×100), so the
+  // axis formatter must format the value as-is and never re-apply the factor.
+  it('formats the value as-is without re-scaling (no double km²→ha convert)', () => {
+    expect(formatAxisTick(5000)).toBe('5,000');
+    expect(formatAxisTick(5000)).not.toBe('500,000');
+  });
+
+  it('feeding it the ha-converted value yields 100× the km² label, not 10000×', () => {
+    const km2Value = 50;
+    const haValue = km2Value * 100; // what getWidgetData produces for unit 'ha'
+    expect(formatAxisTick(km2Value)).toBe('50');
+    expect(formatAxisTick(haValue)).toBe('5,000');
+  });
+
+  it('keeps the sign for below-baseline (loss) values', () => {
+    expect(formatAxisTick(-3000)).toBe('-3,000');
+  });
+
+  it('returns numeric 0 when the formatted value rounds to zero', () => {
+    expect(formatAxisTick(0)).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Context

[GMW-1071](https://vizzuality.atlassian.net/browse/GMW-1071) / [#1613](https://github.com/Vizzuality/mangrove-atlas/issues/1613) — in the **mangrove net change** widget, the y-axis showed 2 extra zeroes when the unit was set to **hectares**.

## Root cause

`getWidgetData` already converts values km²→ha (×100) when `unit === 'ha'` (`hooks.tsx:77-80`), so the data reaching the chart is already in the selected unit. The y-axis `tickFormatter` then multiplied by 100 **again** (`hooks.tsx:260`) → 10000× total → 2 extra zeroes on ha labels. km² was unaffected (it skipped the extra multiply), matching the report.

## Fix

Drop the re-conversion in the tick formatter; format the tick value directly (`getFormat(Math.abs(v))`). One-line change in `src/containers/datasets/net-change/hooks.tsx`.

Blast radius contained: net-change uses its own local formatter, not the shared `@/lib/format`. Sibling widgets (habitat-extent, mangroves-in-protected-areas, carbon-market-potential) apply the ×100 only once, to data — unaffected.

## Test plan

- [x] `pnpm check-types`
- [x] `pnpm lint`
- [ ] Open net change widget → toggle unit to **ha** → y-axis labels are 100× the km² values (not 10000×), tooltip + sentence values match
- [ ] Toggle back to **km²** → unchanged

[GMW-1071]: https://vizzuality.atlassian.net/browse/GMW-1071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ