### PR TITLE
fix(test): distinct testids for mobile Menu/Help triggers (GMW-1070)

### DIFF
--- a/src/containers/help/index.tsx
+++ b/src/containers/help/index.tsx
@@ -62,7 +62,7 @@ const HelpContainer = ({
       <Popover>
         {variant === 'mobile' ? (
           <PopoverTrigger
-            data-testid="guide-button"
+            data-testid="guide-button-mobile"
             aria-label="Help"
             className={cn(
               'flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none',

--- a/src/containers/navigation/menu/index.tsx
+++ b/src/containers/navigation/menu/index.tsx
@@ -28,7 +28,7 @@ const Menu = ({ variant = 'desktop' }: { variant?: 'desktop' | 'mobile' }) => {
       {variant === 'mobile' ? (
         <DialogTrigger asChild>
           <button
-            data-testid="menu-button"
+            data-testid="menu-button-mobile"
             type="button"
             onClick={() => setSection('main')}
             aria-label="Menu"


### PR DESCRIPTION
## Summary

Follow-up to #1627. Both the desktop and mobile layouts render in the DOM simultaneously (fresnel), so the mobile `Menu` / `Help` variants reused `data-testid="menu-button"` / `guide-button`, matching **2 elements** → Playwright strict-mode violations in `navigation.spec.ts` (`test menu links`, `test help guide`).

Mobile variants now use `menu-button-mobile` / `guide-button-mobile`; desktop testids stay unique.

## Test plan
- [ ] `tests/navigation.spec.ts` › `test menu links` passes
- [ ] `tests/navigation.spec.ts` › `test help guide` passes