### PR TITLE
perf: eager-load mobile header LCP image via priority (GMW-1075)

### DIFF
--- a/src/layouts/mobile/index.tsx
+++ b/src/layouts/mobile/index.tsx
@@ -41,6 +41,7 @@ const MobileLayout = () => {
           alt="Global Mangrove Watch"
           width={330}
           height={72}
+          priority
           className="h-[72px] w-[330px] -scale-x-100"
         />
         <LOGO_MOBILE_SVG


### PR DESCRIPTION
## Summary
The mobile header image (`/images/mobile-header.svg`) is the Largest Contentful Paint element and sits above the fold. Next.js logged a console warning recommending eager loading.

- Added the `priority` prop to the mobile header `next/image` in `src/layouts/mobile/index.tsx` (emits `loading="eager"` + a preload link).

## Test plan
- [ ] Mobile view: header logo renders, LCP console warning gone.

Jira: https://vizzuality.atlassian.net/browse/GMW-1075