### PR TITLE
fix: point alerts layer at automated deforestation-alerts tileset

### DIFF
--- a/src/containers/datasets/alerts/hooks.tsx
+++ b/src/containers/datasets/alerts/hooks.tsx
@@ -472,7 +472,7 @@ export function useSources(): SourceProps[] {
     {
       id: 'alerts-dots',
       type: 'vector',
-      url: 'mapbox://globalmangrovewatch.shglec',
+      url: 'mapbox://globalmangrovewatch.deforestation-alerts',
     },
     {
       id: 'monitored-alerts',


### PR DESCRIPTION
## Why

PR #1639 added an automated pipeline (`data/pipelines/update_alerts_tileset.py` + `.github/workflows/update-alerts-tileset.yml`) that builds and uploads the deforestation alerts data to the named Mapbox tileset `globalmangrovewatch.deforestation-alerts`.

The frontend was still reading the old, manually-uploaded tileset hash `mapbox://globalmangrovewatch.shglec`, so the map never picked up any of the automated updates — alerts data on the map stayed frozen at the last manual upload.

## What

One-line change in `useSources()` (`src/containers/datasets/alerts/hooks.tsx`): repoint the `alerts-dots` vector source at `mapbox://globalmangrovewatch.deforestation-alerts`.

The layer's `source-layer: 'alerts'` already matches the pipeline's `SOURCE_LAYER = "alerts"`, so nothing else needed changing.

## Test plan

- [ ] Deforestation alerts widget renders dots on the preview deploy
- [ ] Latest alert dates extend past the previous stale cutoff (data was ending 2026-01)
- [ ] `< 3 months` / `3-24 months` / `> 24 months` colour buckets still work — filters rely on `scr5_obs_date`, `agree` and `count`; confirm those attributes exist in the new tileset
- [ ] Monitored-alerts outline layer (`alert_region_tiles` source-layer) unaffected