### PR TITLE
fix: init Transifex Live after hydration to stop text mismatch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 
 import { MediaStylesTag } from './media-styles';
 import Providers from './providers';
+import TransifexLiveInit from './transifex-live-init';
 
 const OpenSansFont = Open_Sans({
   weight: ['300', '400', '600', '700'],
@@ -52,11 +53,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           verification crawler doesn't run JS, and afterInteractive injection is
           invisible to it, which blocks "Publish to production". Settings must be
           defined before live.js loads.
+
+          `manual_init: true` because Live translates by mutating the DOM: left to
+          auto-init it rewrites the server HTML while React is still hydrating,
+          which surfaces as a hydration text mismatch (React #418) and makes React
+          throw away and re-render the tree. <TransifexLiveInit /> calls
+          `Transifex.live.init()` from an effect instead, i.e. after hydration.
         */}
         <script
           id="transifex-live-settings"
           dangerouslySetInnerHTML={{
-            __html: `window.liveSettings = { api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}', detectlang: true, autocollect: true, dynamic: true, manual_init: false, translate_urls: false };`,
+            __html: `window.liveSettings = { api_key: '${process.env.NEXT_PUBLIC_TRANSIFEX_API_KEY}', detectlang: true, autocollect: true, dynamic: true, manual_init: true, translate_urls: false };`,
           }}
         />
         <script id="transifex-live" src="//cdn.transifex.com/live.js" async />
@@ -87,6 +94,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             `,
           }}
         />
+        <TransifexLiveInit />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/transifex-live-init.tsx
+++ b/src/app/transifex-live-init.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { initTransifexLive } from '@/lib/transifex-live';
+
+/**
+ * Starts Transifex Live after React has hydrated.
+ *
+ * The snippet in `layout.tsx` sets `manual_init: true`, so `live.js` loads (and
+ * stays visible to Transifex's non-JS verification crawler) without touching the
+ * DOM until this effect runs. Initialising pre-hydration made Live rewrite the
+ * server HTML mid-hydration, which React reported as a text mismatch and
+ * recovered from by regenerating the whole tree on the client.
+ *
+ * Rendered from the root layout so the app, embedded and print-report views all
+ * get translations.
+ */
+const TransifexLiveInit = () => {
+  useEffect(() => initTransifexLive(), []);
+
+  return null;
+};
+
+export default TransifexLiveInit;

--- a/src/containers/navigation/language-selector/index.tsx
+++ b/src/containers/navigation/language-selector/index.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useState, MouseEvent, useEffect } from 'react';
+import { useCallback, MouseEvent } from 'react';
 
 import cn from '@/lib/classnames';
+
+import { useTransifexLive } from 'hooks/use-transifex-live';
 
 import Helper from '@/containers/help/helper';
 
@@ -13,15 +15,6 @@ import {
 
 import LANGUAGES_ICON from '@/svgs/tools-bar/languages';
 import CHEVRON_ICON from '@/svgs/ui/chevron';
-
-interface Transifex {
-  live: {
-    detectLanguage: () => string;
-    getAllLanguages: () => { code: string; name: string }[];
-    translateTo: (string) => string;
-    init: () => void;
-  };
-}
 
 type LanguageSelectorProps = {
   theme?: 'light' | 'dark';
@@ -39,32 +32,12 @@ const LanguageSelector = ({
   hasArrow = false,
   className,
 }: LanguageSelectorProps) => {
-  const [languages, setLanguages] = useState([]);
-  const [currentLanguage, setCurrentLanguage] = useState('');
+  const { languages, currentLanguage, translateTo } = useTransifexLive();
 
-  const handleChange = useCallback((e: MouseEvent<HTMLButtonElement>) => {
-    const Transifex = window.Transifex as Transifex;
-    Transifex?.live.translateTo(e.currentTarget.value);
-    setCurrentLanguage(e.currentTarget.id);
-  }, []);
-
-  useEffect(() => {
-    const id = setTimeout(() => {
-      console.info('Transifex:', window.Transifex);
-      if (typeof window !== 'undefined' && window.Transifex) {
-        const tx = window.Transifex as Transifex;
-        if (tx?.live) {
-          tx.live?.init();
-          const locale = tx?.live.detectLanguage();
-          const langs = tx.live.getAllLanguages();
-          const defaultLanguage = langs?.find((lang) => lang.code === locale)?.name;
-          setCurrentLanguage(defaultLanguage);
-          setLanguages(langs);
-        }
-      }
-    }, 0);
-    return () => clearTimeout(id);
-  }, []);
+  const handleChange = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => translateTo(e.currentTarget.value),
+    [translateTo]
+  );
 
   return (
     <Helper
@@ -84,11 +57,11 @@ const LanguageSelector = ({
           )}
         >
           <LANGUAGES_ICON className="h-6 w-6 shrink-0" />
-          <span className="text-sm">{currentLanguage}</span>
+          <span className="text-sm">{currentLanguage?.name}</span>
           {hasArrow && <CHEVRON_ICON role="img" className="h-4 w-4" />}
         </DropdownMenuTrigger>
         <DropdownMenuContent className="bg-white">
-          {languages?.map((lang: { code: string; name: string }) => (
+          {languages.map((lang) => (
             <DropdownMenuItem key={lang.code} asChild className="rounded-lg">
               <button
                 data-testid={`${lang.code}-button`}
@@ -101,7 +74,7 @@ const LanguageSelector = ({
                 <span
                   className={cn({
                     'font-sans text-sm text-black/85': true,
-                    'text-brand-800 font-semibold': currentLanguage === lang.name,
+                    'text-brand-800 font-semibold': currentLanguage?.code === lang.code,
                   })}
                 >
                   {lang.name}

--- a/src/containers/navigation/mobile/language-selector/index.tsx
+++ b/src/containers/navigation/mobile/language-selector/index.tsx
@@ -1,4 +1,6 @@
-import { MouseEvent, useCallback, useEffect, useState } from 'react';
+import { MouseEvent, useCallback } from 'react';
+
+import { useTransifexLive } from 'hooks/use-transifex-live';
 
 import {
   DropdownMenu,
@@ -10,41 +12,13 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 
 import LANGUAGE_SVG from '@/svgs/sidebar/language';
 
-interface Transifex {
-  live: {
-    detectLanguage: () => string;
-    getAllLanguages: () => { code: string; name: string }[];
-    translateTo: (string) => string;
-    init: () => void;
-  };
-}
-
 const LanguageSelector = () => {
-  const [languages, setLanguages] = useState([]);
-  const [currentLanguage, setCurrentLanguage] = useState('');
+  const { languages, currentLanguage, translateTo } = useTransifexLive();
 
-  const handleChange = useCallback((e: MouseEvent<HTMLButtonElement>) => {
-    const Transifex = window.Transifex as Transifex;
-    Transifex?.live.translateTo(e.currentTarget.value);
-    setCurrentLanguage(e.currentTarget.id);
-  }, []);
-
-  useEffect(() => {
-    const id = setTimeout(() => {
-      if (typeof window !== 'undefined') {
-        const tx = window.Transifex as Transifex;
-        if (tx?.live) {
-          tx.live?.init();
-          const locale = tx?.live.detectLanguage();
-          const langs = tx.live.getAllLanguages();
-          const defaultLanguage = langs?.find((lang) => lang.code === locale)?.name;
-          setCurrentLanguage(defaultLanguage);
-          setLanguages(langs);
-        }
-      }
-    }, 0);
-    return () => clearTimeout(id);
-  }, []);
+  const handleChange = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => translateTo(e.currentTarget.value),
+    [translateTo]
+  );
 
   return (
     <DropdownMenu>
@@ -55,13 +29,15 @@ const LanguageSelector = () => {
             className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
           >
             <LANGUAGE_SVG className="h-8 w-8 fill-current text-white" role="img" title="Language" />
-            <span className="text-xxs font-sans leading-none text-white">{currentLanguage}</span>
+            <span className="text-xxs font-sans leading-none text-white">
+              {currentLanguage?.name}
+            </span>
           </DropdownMenuTrigger>
         </TooltipTrigger>
         <TooltipContent side="top">Change language</TooltipContent>
       </Tooltip>
       <DropdownMenuContent>
-        {languages?.map((lang: { code: string; name: string }) => (
+        {languages.map((lang) => (
           <DropdownMenuItem key={lang.code} asChild>
             <button
               data-testid={`${lang.code}-button`}

--- a/src/hooks/use-transifex-live/index.ts
+++ b/src/hooks/use-transifex-live/index.ts
@@ -1,0 +1,57 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  getTransifexLive,
+  onTransifexLiveReady,
+  type TransifexLanguage,
+  type TransifexLive,
+} from '@/lib/transifex-live';
+
+type UseTransifexLive = {
+  languages: TransifexLanguage[];
+  /** Currently applied language, `null` until Live is ready. */
+  currentLanguage: TransifexLanguage | null;
+  translateTo: (code: string) => void;
+};
+
+/**
+ * `getSelectedLanguageCode()` is an empty string until Live commits a language,
+ * so fall back to the one it detected — hence `||`, not `??`.
+ */
+function readCode(live: TransifexLive): string {
+  return live.getSelectedLanguageCode() || live.detectLanguage();
+}
+
+/**
+ * Read/write access to Transifex Live's language state for the language
+ * selectors. Initialisation is not done here — `TransifexLiveInit` in the root
+ * layout owns that, so Live starts exactly once and only after hydration.
+ */
+export function useTransifexLive(): UseTransifexLive {
+  const [languages, setLanguages] = useState<TransifexLanguage[]>([]);
+  const [currentCode, setCurrentCode] = useState<string | null>(null);
+
+  useEffect(() => {
+    return onTransifexLiveReady((live) => {
+      setLanguages(live.getAllLanguages() ?? []);
+      setCurrentCode(readCode(live));
+      // Keeps the desktop and mobile selectors in sync with each other, and with
+      // a language Live picked itself via `detectlang`. The event payload doesn't
+      // reliably carry the code, so re-read it from Live.
+      live.onTranslatePage(() => setCurrentCode(readCode(live)));
+    });
+  }, []);
+
+  const translateTo = useCallback((code: string) => {
+    getTransifexLive()?.translateTo(code);
+    setCurrentCode(code);
+  }, []);
+
+  return {
+    languages,
+    currentLanguage: languages.find((language) => language.code === currentCode) ?? null,
+    translateTo,
+  };
+}

--- a/src/lib/transifex-live.ts
+++ b/src/lib/transifex-live.ts
@@ -1,0 +1,93 @@
+/**
+ * Typed access to the Transifex Live vendor global (`window.Transifex.live`),
+ * injected by the `cdn.transifex.com/live.js` snippet in `src/app/layout.tsx`.
+ *
+ * Live translates by mutating the DOM, outside React's knowledge. The snippet is
+ * therefore configured with `manual_init: true` and initialised from here, once,
+ * *after* React has hydrated — otherwise the vendor script rewrites the server
+ * HTML while React is still hydrating it and every translated text node becomes a
+ * hydration mismatch (React #418 / "server rendered text didn't match the client").
+ *
+ * @see https://help.transifex.com/en/articles/6370718-javascript-api
+ */
+
+export type TransifexLanguage = { code: string; name: string };
+
+export interface TransifexLive {
+  init: () => void;
+  detectLanguage: () => string;
+  getAllLanguages: () => TransifexLanguage[] | undefined;
+  getSelectedLanguageCode: () => string;
+  translateTo: (code: string) => void;
+  /** Fires after Live applies a language. Its payload is unreliable — re-read the getters. */
+  onTranslatePage: (callback: () => void) => void;
+}
+
+export interface Transifex {
+  live: TransifexLive;
+}
+
+/** `live.js` is loaded `async`, so the global may not exist yet. */
+export function getTransifexLive(): TransifexLive | null {
+  if (typeof window === 'undefined') return null;
+  return window.Transifex?.live ?? null;
+}
+
+const POLL_INTERVAL_MS = 50;
+const POLL_TIMEOUT_MS = 15_000;
+
+/**
+ * Run `attempt` now and, while it reports "not yet", keep retrying until it
+ * succeeds or we give up (`live.js` blocked by an extension, offline, …).
+ *
+ * Polling rather than a load/ready callback because the script is `async`: the
+ * global can appear before or after any given component mounts, and Live exposes
+ * no way to observe "loaded" from outside itself.
+ *
+ * Returns a cancel function for the pending poll.
+ */
+function pollUntil(attempt: () => boolean): () => void {
+  if (typeof window === 'undefined' || attempt()) return () => undefined;
+
+  let elapsed = 0;
+  const intervalId = window.setInterval(() => {
+    elapsed += POLL_INTERVAL_MS;
+    if (attempt() || elapsed >= POLL_TIMEOUT_MS) {
+      window.clearInterval(intervalId);
+    }
+  }, POLL_INTERVAL_MS);
+
+  return () => window.clearInterval(intervalId);
+}
+
+let initialized = false;
+
+/**
+ * Initialise Transifex Live once per page load. Safe to call from several
+ * components — the first caller wins, the rest are no-ops.
+ */
+export function initTransifexLive(): () => void {
+  return pollUntil(() => {
+    const live = getTransifexLive();
+    if (!live) return false;
+    if (!initialized) {
+      initialized = true;
+      live.init();
+    }
+    return true;
+  });
+}
+
+/**
+ * Run `callback` once Live has loaded and knows its languages — i.e. once its
+ * getters are usable. Works whether the caller mounts before or after Live is
+ * ready, so late-mounting consumers (mobile nav, modals) aren't left blank.
+ */
+export function onTransifexLiveReady(callback: (live: TransifexLive) => void): () => void {
+  return pollUntil(() => {
+    const live = getTransifexLive();
+    if (!live?.getAllLanguages()?.length) return false;
+    callback(live);
+    return true;
+  });
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,8 +1,11 @@
+import type { Transifex } from '@/lib/transifex-live';
+
 declare global {
   interface Window {
     // ? As we are using explicitily window to access the `gtag` property we need to declare it before using it
     gtag: UniversalAnalytics.ga;
-    Transifex: Transifex;
+    /** Injected by the Transifex Live snippet in `src/app/layout.tsx`. Absent until `live.js` loads. */
+    Transifex?: Transifex;
   }
 }
 


### PR DESCRIPTION
## Why

The console was throwing on every load with a warm cache:

> Uncaught Error: Hydration failed because the server rendered text didn't match the client. As a result this tree will be regenerated on the client.
> `+ the world` / `- el mundo` — at `LocationWidget (src/containers/location-widget/index.tsx:101)`

Root cause is not the widget. `cdn.transifex.com/live.js` was loaded `async` with `manual_init: false`, so once it's in the HTTP cache it executes and rewrites the SSR text nodes *while* React is hydrating them. React rendered the English source (`the world`), found `el mundo` in the DOM, and recovered by discarding and re-rendering the whole tree. The `<h1>` was just the first node React tripped over — every translated text node was affected.

This is the mismatch that commit `e73a9a6` deliberately left visible ("keep hydration warnings visible so the underlying mismatch (likely Transifex Live mutating attributes before hydrate) can be traced and fixed at the source") rather than papering over with `suppressHydrationWarning`. Fixed at the source here.

## What

- **`src/app/layout.tsx`** — snippet stays a raw `<script>` in `<head>` (Transifex's verification crawler doesn't run JS, so `next/script` would break "Publish to production"), but now sets `manual_init: true`.
- **`src/app/transifex-live-init.tsx`** (new) — client component that calls `Transifex.live.init()` from an effect, i.e. after hydration. Rendered from the root layout, so the app, `/embedded` and `/print-report` views all still get translations.
- **`src/lib/transifex-live.ts`** (new) — typed access to the vendor global, one-shot init, and a ready-poll that works whether `live.js` lands before or after a component mounts (15s cap, so an ad-blocked `live.js` doesn't poll forever).
- **`src/hooks/use-transifex-live/index.ts`** (new) — replaces the duplicated `setTimeout(0)` + `tx.live.init()` + `console.info('Transifex:', …)` blocks in the desktop and mobile language selectors. Neither selector races init any more, and the two stay in sync with each other and with a language Live picked itself via `detectlang`.
- **`src/types/index.d.ts`** — `Window.Transifex` was declared as `Transifex: Transifex`, a type that doesn't exist; `skipLibCheck` hid it and made it `any`. Now properly typed and optional (the global is absent until `live.js` loads).

Two vendor quirks worth knowing, both hit while verifying:
- `getSelectedLanguageCode()` returns `''` (not `null`) until Live commits a language — needs `||`, not `??`, or the selector label renders empty.
- `onTranslatePage`'s payload does not carry `lang_code`; destructuring it wiped the good value. The code is re-read from Live in the callback instead.

## Test plan

Verified locally against the dev server with an `es-ES` browser locale. The mismatch only reproduces once `live.js` is cached, so each run warms the cache and then reloads three times:

| `liveSettings` | `<h1>` after load | hydration errors |
| --- | --- | --- |
| `manual_init: false` (before) | `el mundo` | **3 / 3 reloads failed** |
| `manual_init: true` (after) | `el mundo` | **0 / 3** |

- [x] SSR HTML still ships the English source (`<h1>the world</h1>`)
- [x] Post-hydration the page is translated (`el mundo`), no hydration error
- [x] Desktop and mobile selectors both label the active language (`Español`)
- [x] Switching to Français via the dropdown → `<h1>` becomes `le monde`, label becomes `Français`, `getSelectedLanguageCode()` is `fr_FR`
- [x] `pnpm check-types` and ESLint clean
- [ ] Preview deploy: confirm the Transifex verification / "Publish to production" flow still passes with `manual_init: true` (the snippet is unchanged in the raw HTML, but worth a look since that constraint drove #1578)
- [ ] Preview deploy: check `/embedded` and `/print-report` translate as before

Note there is a brief English-then-translated flash, since Live now starts a tick later. That flash existed before too — React was discarding the translated tree and re-rendering English before Live re-translated it.