### PR TITLE
chore: exclude build output from eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,11 @@ export default defineConfig([
   prettierRecommended,
   globalIgnores([
     '.next/**',
+    // Build and tool output. Linting `.vercel` in particular took `eslint .` from 11s to over
+    // 55 minutes: it holds ~3.8MB of minified bundle chunks on single lines, which is worst-case
+    // input for the type-aware rules and for prettier.
+    '.vercel/**',
+    'coverage/**',
     'out/**',
     'build/**',
     'next-env.d.ts',


### PR DESCRIPTION
## What

`eslint .` was traversing `.vercel/`. Once a local `vercel build` or `vercel pull` has populated it, `pnpm lint` goes from an 11 second run to one that had not finished after **55 minutes** of CPU time — it looks like a hang, but it's just grinding.

`globalIgnores` covered `.next`, `out`, `build`, `public`, `storybook-static` and `cloud-functions`, but not `.vercel` or `coverage`.

## Why it's so slow

`.vercel/output/static/_next/static/chunks/` holds 22 minified JS files, ~3.8MB total, the largest 968KB on a single line. For scale, all 567 files in `src/` come to 1.15MB — so the build output is roughly 3× the byte volume of the entire source tree, concentrated in files with no line breaks. That's worst-case input for the type-aware `typescript-eslint` rules and for `eslint-plugin-prettier`, which reformats every file it checks.

## Why CI never caught it

Both `.vercel` and `coverage` are gitignored, so they don't exist on a fresh CI checkout. This only reproduces on a working copy where Vercel or a coverage run has left output behind.

## Measured

| | `eslint .` |
|---|---|
| before | >55 min, killed unfinished |
| after | **11.9s** |

## Scope

Ignore list only — no rule changes, so no behaviour change for any file that was actually meant to be linted.

Worth flagging separately: the now-usable run surfaces **40 pre-existing errors and 47 warnings**, almost all `prettier/prettier` formatting in `src/components/ui/*`. They predate this PR and are untouched by it — they were simply unobservable while the command couldn't complete. Happy to take the `--fix` sweep as a follow-up if you want it.

## Test plan

- [x] `pnpm lint` completes in ~12s on a working copy with `.vercel/` populated
- [x] `pnpm check-types` clean
- [ ] Confirm CI lint timing is unchanged (expected — CI never had these directories)