### PR TITLE
fix: share the current view, not the one the dialog mounted with

### DIFF
--- a/src/components/map/controls/share/index.tsx
+++ b/src/components/map/controls/share/index.tsx
@@ -1,6 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
-
-import { usePathname, useSearchParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
 
 import cn from '@/lib/classnames';
 
@@ -15,33 +13,44 @@ import { Tooltip, TooltipContent, TooltipPortal, TooltipTrigger } from '@/compon
 
 import SHARE_SVG from '@/svgs/map/share';
 
+type ShareTargets = {
+  url: string;
+  embedCode: string;
+};
+
+/**
+ * Built from `window.location` rather than from `usePathname` / `useSearchParams`: what gets
+ * copied has to be exactly the view the user is looking at, and `window.location` is the one
+ * source that is always current, whatever a router hook last re-rendered with.
+ */
+function readShareTargets(): ShareTargets {
+  const { origin, pathname, search, href } = window.location;
+
+  // `/` would otherwise produce `/embedded/`, and every other path needs its leading slash kept —
+  // dropping it built `/embeddedcountry/IDN` instead of `/embedded/country/IDN`.
+  const path = pathname === '/' ? '' : pathname;
+
+  return {
+    url: href,
+    embedCode: `<iframe src="${origin}/embedded${path}${search}" title="Global Mangrove Watch"></iframe>`,
+  };
+}
+
 const Share = ({ className, disabled = false }: { className?: string; disabled: boolean }) => {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const [shareTargets, setShareTargets] = useState<ShareTargets | null>(null);
 
-  const asPath = useMemo(() => {
-    const search = searchParams?.toString();
-    return search ? `${pathname}?${search}` : pathname;
-  }, [pathname, searchParams]);
-
-  const currentUrl = useMemo(
-    () => (typeof window !== 'undefined' ? window.location.href : null),
-    []
-  );
-  const embeddedLink = useMemo(
-    () =>
-      typeof window !== 'undefined'
-        ? `<iframe src="${window.location.origin}/embedded${asPath.slice(1, asPath.length)}" title="Global Mangrove Watch"></iframe>`
-        : null,
-    [asPath]
-  );
+  // Snapshot as the dialog opens. It's modal, so the view can't change while it's up — one read
+  // guarantees the displayed URL and the copied one are the same thing.
+  const handleOpenChange = useCallback((open: boolean) => {
+    setShareTargets(open ? readShareTargets() : null);
+  }, []);
 
   const [shareLinkBtnText, setShareLinkBtnText] = useState('Copy link');
   const [shareEmbedCodeBtnText, setShareEmbedCodeBtnText] = useState('Copy code');
 
   const copyShareLink = useCallback(() => {
     navigator.clipboard
-      .writeText(currentUrl || '')
+      .writeText(shareTargets?.url || '')
       .then(() => {
         setShareLinkBtnText('Copied');
         setTimeout(function () {
@@ -51,12 +60,12 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
       .catch((err: ErrorEvent) => {
         console.info(err.message);
       });
-  }, [currentUrl]);
+  }, [shareTargets]);
 
   const copyEmbeddedCode = useCallback(
     () =>
       navigator.clipboard
-        .writeText(embeddedLink || '')
+        .writeText(shareTargets?.embedCode || '')
         .then(() => {
           setShareEmbedCodeBtnText('Copied');
           setTimeout(function () {
@@ -66,13 +75,13 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
         .catch((err: ErrorEvent) => {
           console.info(err.message);
         }),
-    [embeddedLink]
+    [shareTargets]
   );
 
   return (
     <>
       {!disabled && (
-        <Dialog>
+        <Dialog onOpenChange={handleOpenChange}>
           <Tooltip>
             <TooltipTrigger asChild>
               <DialogTrigger asChild>
@@ -80,8 +89,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
                   type="button"
                   aria-label="Share"
                   className={cn({
-                    'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white text-black hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none':
-                      true,
+                    'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white text-black hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
                   })}
                 >
                   <SHARE_SVG className="h-4 w-4 group-hover:bg-gray-100" aria-hidden="true" />
@@ -97,7 +105,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
               <div className="flex flex-col space-y-1">
                 <h4 className="ml-4 text-[13px] font-semibold">Public url to share</h4>
                 <div className="bg-brand-600/10 flex h-12 items-center justify-between space-x-4 rounded-3xl p-4 text-sm">
-                  <p className="truncate">{currentUrl}</p>
+                  <p className="truncate">{shareTargets?.url}</p>
                   <button
                     onClick={copyShareLink}
                     className="border-brand-800/20 text-brand-800 hover:bg-brand-800/20 rounded-3xl border px-5 py-1 font-semibold whitespace-nowrap"
@@ -109,7 +117,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
               <div>
                 <h4 className="ml-4 text-[13px] font-semibold">Code to embed map</h4>
                 <div className="bg-brand-600/10 flex h-12 items-center space-x-4 rounded-3xl p-4 text-sm">
-                  <p className="truncate">{embeddedLink}</p>
+                  <p className="truncate">{shareTargets?.embedCode}</p>
                   <button
                     onClick={copyEmbeddedCode}
                     className="border-brand-800/20 text-brand-800 hover:bg-brand-800/20 rounded-3xl border px-5 py-1 font-semibold whitespace-nowrap"
@@ -131,8 +139,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
               disabled
               aria-label="Share (unavailable for custom areas)"
               className={cn(className, {
-                'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none':
-                  true,
+                'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
               })}
             >
               <SHARE_SVG

--- a/tests/component/components/map/controls/share.test.tsx
+++ b/tests/component/components/map/controls/share.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+
+import Share from '@/components/map/controls/share';
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+/**
+ * These assert on the URL the dialog *copies*, not on how it renders — the field is
+ * `truncate`d by design, so visual clipping is expected and irrelevant. What matters is that
+ * the clipboard receives the full current view.
+ *
+ * The clipboard is `userEvent.setup()`'s own stub, read back with `readText()`. Don't replace
+ * `navigator.clipboard` with a spy here: setup() overwrites it, so the spy never sees the write.
+ */
+
+const ORIGIN = 'http://localhost:3000';
+
+afterEach(() => {
+  window.history.replaceState({}, '', '/');
+});
+
+/** Navigate the way nuqs does — history only, no Next router involvement. */
+function goTo(path: string) {
+  window.history.replaceState({}, '', path);
+}
+
+/** The tooltip on the trigger needs the provider the root layout supplies in the real app. */
+function renderShare() {
+  return render(
+    <TooltipProvider>
+      <Share disabled={false} />
+    </TooltipProvider>
+  );
+}
+
+/**
+ * `pointerEventsCheck: 0` because Radix's modal sets `pointer-events: none` on the body while a
+ * dialog is up and clears it asynchronously on close; user-event would otherwise refuse the next
+ * click. findByRole rather than getByRole for the same reason — the content mounts and unmounts.
+ */
+function setupUser() {
+  return userEvent.setup({ pointerEventsCheck: 0 });
+}
+
+async function openShareDialog(user: UserEvent) {
+  await user.click(await screen.findByRole('button', { name: 'Share' }));
+  await screen.findByRole('dialog');
+}
+
+async function closeShareDialog(user: UserEvent) {
+  await user.keyboard('{Escape}');
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+}
+
+async function copy(user: UserEvent, button: 'Copy link' | 'Copy code') {
+  await user.click(await screen.findByRole('button', { name: button }));
+  return navigator.clipboard.readText();
+}
+
+describe('Share dialog', () => {
+  it('copies the current location, not the one the control mounted with', async () => {
+    const user = setupUser();
+    renderShare();
+
+    // Mounted at `/`, then navigated — this is the case that was broken: the copied link kept
+    // pointing at the root, so a recipient never landed on the country the sharer was viewing.
+    goTo('/country/IDN?active-widgets=mangrove_habitat_extent');
+    await openShareDialog(user);
+
+    expect(await copy(user, 'Copy link')).toBe(
+      `${ORIGIN}/country/IDN?active-widgets=mangrove_habitat_extent`
+    );
+  });
+
+  it('builds an embed URL that keeps the path separator', async () => {
+    const user = setupUser();
+    renderShare();
+
+    goTo('/country/IDN?active-widgets=mangrove_habitat_extent');
+    await openShareDialog(user);
+
+    // Regression guard: this used to drop the leading slash and produce
+    // `/embeddedcountry/IDN`, which is not a route.
+    expect(await copy(user, 'Copy code')).toBe(
+      `<iframe src="${ORIGIN}/embedded/country/IDN?active-widgets=mangrove_habitat_extent" title="Global Mangrove Watch"></iframe>`
+    );
+  });
+
+  it('embeds the bare route at the root, without a trailing slash', async () => {
+    const user = setupUser();
+    renderShare();
+
+    goTo('/');
+    await openShareDialog(user);
+
+    expect(await copy(user, 'Copy code')).toBe(
+      `<iframe src="${ORIGIN}/embedded" title="Global Mangrove Watch"></iframe>`
+    );
+  });
+
+  it('re-reads the location each time it opens', async () => {
+    const user = setupUser();
+    renderShare();
+
+    goTo('/country/IDN');
+    await openShareDialog(user);
+    expect(await copy(user, 'Copy link')).toBe(`${ORIGIN}/country/IDN`);
+
+    await closeShareDialog(user);
+
+    goTo('/country/BRA');
+    await openShareDialog(user);
+
+    // Asserted on the displayed value rather than by copying again: the button is still labelled
+    // "Copied" from the first copy (a 5s timeout that outlives the dialog). Display and clipboard
+    // read the same snapshot, and the tests above already cover the clipboard path.
+    expect(await screen.findByText(`${ORIGIN}/country/BRA`)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes [GMW-1077](https://vizzuality.atlassian.net/browse/GMW-1077) · reported as #1644

## What

The Share dialog handed out URLs that didn't reach the sharer's view. Turned out to be **two independent defects** — the copy link and the embed code were broken for different reasons, which is why fixing only the dependency array wouldn't have been enough.

| | Before | After |
|---|---|---|
| Copy link | frozen at mount → the root, wrong country | live `window.location.href` |
| Embed code | `/embeddedcountry/IDN` — not a route | `/embedded/country/IDN` |

**The link.** `currentUrl` was memoised with an empty dependency array, so `window.location.href` was read once when the control mounted and never again. Every view change after that was invisible to it — including the country, which lives in the path — so the copied link pointed at whichever page loaded first, usually the root. This is the "not even taking the right country" part of the report.

**The embed code.** Separately, `${origin}/embedded${asPath.slice(1)}` stripped the leading slash and concatenated the path straight onto `embedded`:

```
/                  ->  /embedded                     ok
/country/IDN       ->  /embeddedcountry/IDN           broken
```

It only ever looked right at the root, where the slice returns an empty string.

## Approach

Both values now come from a single `readShareTargets()` read of `window.location`, snapshotted when the dialog opens.

The dialog is modal, so the view can't change while it's up — one read per open means the URL on screen and the URL on the clipboard are the same value by construction, and nothing depends on `usePathname` / `useSearchParams` any more. A value that has to be exact shouldn't depend on when the router hooks last re-rendered, particularly with nuqs writing this app's view state under its default `shallow: true`.

Note the field's visual truncation is unchanged and intended — only the copied value was wrong.

## Tests

Four component tests in `tests/component/components/map/controls/share.test.tsx`, asserting on clipboard contents rather than rendered text. I checked they actually bite by reintroducing each defect:

- restore the `.slice(1)` → 1 test fails
- snapshot at mount instead of on open → 3 tests fail

They navigate with `history.replaceState`, i.e. the way nuqs does, so they cover the case the router hooks may not observe.

## Test plan

- [x] `pnpm test:unit` — 107/107 across 24 files
- [x] `pnpm check-types` clean
- [x] `pnpm lint` / `pnpm lint:a11y` clean on the changed files
- [ ] Manual: open Share on a country view, copy the link, open it in a new tab, confirm it lands on the same country with the same widgets
- [ ] Manual: paste the embed code into a scratch HTML file and confirm the iframe renders that same view

The two manual checks are the ones jsdom can't cover — it verifies the strings, not the actual clipboard write or that `/embedded/country/IDN` really renders in an iframe.

## Also in here

Auto-fixed the 2 pre-existing `prettier/prettier` errors in this file, since the formatter touches it on commit anyway.

## Noticed, not fixed

The **"Copied" button label persists across close and reopen** — a 5s `setTimeout` that isn't cleared when the dialog unmounts, so reopening within that window shows a stale "Copied". Cosmetic and unrelated to this ticket; happy to take it here or separately.

[GMW-1077]: https://vizzuality.atlassian.net/browse/GMW-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ