### PR TITLE
fix: stop widget cards vanishing while their data loads

### DIFF
--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -5,8 +5,6 @@ import cn from '@/lib/classnames';
 
 import { useSyncActiveLayers } from '@/store/layers';
 
-import { isEmpty } from 'lodash-es';
-
 import type {
   FloodProtectionIndicatorId,
   FloodProtectionPeriodId,
@@ -107,26 +105,28 @@ const FloodProtection = ({
     }
   }, [ref]);
 
-  if (!data && isEmpty(data)) return null;
-
+  // Destructured defensively rather than bailing out with `return null` while the request is in
+  // flight: the card below already renders `<Loading>` and gates its content on `isFetched && data`,
+  // and returning nothing here meant the whole widget — card and all — disappeared until the
+  // response landed.
   const {
     periods,
     max,
     selectedValue,
     location,
     getFormattedValue,
-  }: {
+  }: Partial<{
     periods: FloodProtectionPeriodId[];
     max: number;
     selectedValue: number;
     location: string;
     getFormattedValue: (value: number, indicator: FloodProtectionIndicatorId) => string;
-  } = data;
+  }> = data ?? {};
 
   const isWorldwide = location === 'Worldwide';
   const trianglePositionPerc = (selectedValue * 100) / max;
   const trianglePosition = (lineChartWidth * trianglePositionPerc) / 100 - 11; // substract icon size;
-  const value = getFormattedValue(selectedValue, indicator);
+  const value = getFormattedValue?.(selectedValue, indicator);
 
   const getBackground = (indicator: FloodProtectionIndicatorId): string => {
     let background: string;

--- a/src/containers/datasets/restoration-sites/widget.tsx
+++ b/src/containers/datasets/restoration-sites/widget.tsx
@@ -60,12 +60,16 @@ const RestorationSitesWidget = () => {
     setFilters(filterKeys);
   }, [setMapFilters, filterKeys]);
 
-  if (!filtersData) return null;
-
   return (
     <div className={WIDGET_CARD_WRAPPER_STYLE}>
-      <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-20" />
-      {isFetched && data && (
+      {/* Covers the filters request too. This used to be `if (!filtersData) return null`, which
+          removed the entire widget from the page until `/widgets/sites_filters` answered — on a slow
+          response the card never appeared at all rather than showing a spinner. */}
+      <Loading
+        visible={isFetching || isFetchingFilters}
+        iconClassName="flex w-10 h-10 m-auto my-20"
+      />
+      {isFetched && data && filtersData && (
         <div className="relative space-y-8">
           {data.data?.length > 0 && (
             <p className={WIDGET_SENTENCE_STYLE}>

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -17,12 +17,10 @@ import WidgetApplicability from './applicability';
 import WidgetHeader from './header';
 import { useIsLayerActive } from './selector';
 
-type ChildrenType = ReactElement & { type?: () => null };
-
 type WidgetLayoutProps = {
   id: WidgetSlugType;
   title: string;
-  children: ChildrenType | null;
+  children: ReactElement | null;
   className?: string;
   contextualLayersIds?: string[];
   contextualLayers?: {
@@ -57,8 +55,6 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
   // Keep content overflow visible while expanded so Popovers / chart tooltips aren't clipped;
   // hide it during the collapse animation so the card shrinks cleanly.
   const [isContentOverflowVisible, setIsContentOverflowVisible] = useState(!isCollapsed);
-
-  if (Boolean(children?.type() === null)) return null;
 
   return (
     <AnimatePresence>

--- a/tests/fixtures/drawing-tool.ts
+++ b/tests/fixtures/drawing-tool.ts
@@ -71,7 +71,12 @@ export const useDrawingTool = (page: Page) => ({
 
   uploadGeojson: async (file: string) => {
     const responsePromise = page.waitForResponse(
-      (res) => res.url().includes('/spatial_file/converter') && res.request().method() === 'POST'
+      (res) => res.url().includes('/spatial_file/converter') && res.request().method() === 'POST',
+      // Not the 10s `actionTimeout` this would otherwise inherit: the file is converted by the
+      // shared staging API, and a round trip there regularly costs more than that. Every test in
+      // `Upload shapefile` and `Custom area has a polygon` goes through here, so an under-budgeted
+      // wait fails eight tests at once for no reason but backend latency.
+      { timeout: 60000 }
     );
     await page.getByTestId('shapefile-upload').setInputFiles(file);
     const res = await responsePromise;


### PR DESCRIPTION
Investigating the 12 Playwright failures in [run 30616744677](https://github.com/Vizzuality/mangrove-atlas/actions/runs/30616744677/job/91111578683) turned up a real production bug, not flake.

## First, what it wasn't

The run was on #1646, which changed only eslint's ignore list — it can't affect the build or runtime. Every other Playwright run that day passed on the same `develop` base. And a blanket staging outage doesn't fit either: API-dependent tests pass *between* the failures (`climate_and_policy` ✓ at 08:41:02, 20+ layer tests ✓ 08:47–08:53). The failures were specific tests failing all three retries while their neighbours passed.

## The production bug

`WidgetWrapper` decided whether to render by calling its child as a plain function:

```js
if (Boolean(children?.type() === null)) return null;
```

Two things wrong with that:

1. It invokes a component **outside React**, so the child's hooks — `useState`, `useQuery`, `useAtomValue` — register against `WidgetWrapper`'s hook list instead of their own.
2. It made the entire card, `data-testid` included, conditional on the child's data **already being in the query cache**. But a widget's fetch only starts when it mounts, and the wrapper refused to mount it until the fetch had finished.

So on a slow response the restoration sites widget didn't show a spinner — it disappeared from the page. Users see this, not just CI.

Introduced 2025-08-27 in `ebf2a9a7`; long-standing and latent, surfacing whenever staging is slow enough.

## Why it could just be deleted

Both widgets that returned null early were guarding a **load**, not expressing "this widget has nothing to show":

| widget | was | now |
|---|---|---|
| restoration-sites | `if (!filtersData) return null` | `<Loading>` covers the filters request too |
| flood-protection | `if (!data && isEmpty(data)) return null` | destructure defensively; markup was already gated on `isFetched && data` |

restoration-sites already had a `<Loading>` spinner in its card — the early return just short-circuited past it. flood-protection's return existed only to avoid destructuring `undefined` on the very next line. 18 of the 20 widgets already render `<Loading>` inside the card; these two now match.

With neither widget returning null, the wrapper has nothing left to predict, and `ChildrenType` goes with it.

## Test fixture: a 10s budget for a file conversion

`tests/fixtures/drawing-tool.ts` waited for `POST /spatial_file/converter` while inheriting `actionTimeout: 10000` (`playwright.config.ts:85`). That is not a realistic budget for a conversion round trip to shared staging, and every test in `Upload shapefile` and `Custom area has a polygon` goes through that fixture — so one slow response failed eight tests at once. Now an explicit 60s.

## Verification

All four affected specs, locally: **47 passed, 1 skipped, 0 failed**. Every one of the 12 CI failures passes.

- [x] `tests/categories.spec.ts` + `tests/drawing-tool.spec.ts` — 17 passed, 1 skipped
- [x] `tests/layers.spec.ts` + `tests/national-dashboard.spec.ts` — 30 passed
- [x] `pnpm test:unit` — 107/107
- [x] `pnpm check-types`, `pnpm lint`, `pnpm lint:a11y` clean

## Two notes for the reviewer

**`national-dashboard:50` also passes now**, and I didn't target it — I'd flagged its cause as unconfirmed. Plausible shared root cause: the `children.type()` call throws a hooks-order error, React recovers by regenerating the tree, and the legend loses state. That would make several apparently unrelated failures one bug. **Unproven** — worth a second opinion rather than taking my word for it.

**Branch is named `chore/…`** from when this was scoped as an investigation. The commit is `fix:`, which is what release-please reads, so the version bump is correct regardless.

## Not fixed

A nested-button warning surfaced in the test output for `DeleteDrawingButton` — `<button>` inside `<button>`, the same invalid-HTML pattern #1645 fixed in the map popup controls. Out of scope here; happy to take it separately.