### PR TITLE
fix(a11y): WCAG 2.2 AA remediation with axe-core regression harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@axe-core/playwright": "4.12.1",
     "@playwright/test": "1.61.1",
     "@tailwindcss/forms": "0.5.11",
     "@tailwindcss/postcss": "4.3.2",
@@ -110,6 +111,7 @@
     "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "6.0.3",
     "@vitest/coverage-v8": "4.1.9",
+    "axe-core": "4.13.0",
     "eslint": "9.39.2",
     "eslint-config-next": "16.2.10",
     "eslint-config-prettier": "10.1.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -84,6 +84,11 @@ export default defineConfig({
      * instead of the 2-minute test-timeout that tells us nothing. */
     actionTimeout: 10000,
     storageState: STORAGE_STATE,
+    /* Motion/AnimatePresence cards sit at `opacity: 0` mid-animation. axe
+     * samples whatever is on screen, so animating cards produce flaky
+     * colour-contrast results. Reduced motion settles them immediately and
+     * also matches how a `prefers-reduced-motion` user sees the app. */
+    contextOptions: { reducedMotion: 'reduce' },
   },
 
   /* Configure projects for major browsers */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@axe-core/playwright':
+        specifier: 4.12.1
+        version: 4.12.1(playwright-core@1.61.1)
       '@playwright/test':
         specifier: 1.61.1
         version: 1.61.1
@@ -281,6 +284,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)
+      axe-core:
+        specifier: 4.13.0
+        version: 4.13.0
       eslint:
         specifier: 9.39.2
         version: 9.39.2(jiti@2.7.0)
@@ -368,6 +374,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.12.1':
+    resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -2996,6 +3007,10 @@ packages:
 
   axe-core@4.12.1:
     resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
+    engines: {node: '>=4'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
     engines: {node: '>=4'}
 
   axios@1.18.1:
@@ -5785,6 +5800,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
+    dependencies:
+      axe-core: 4.12.1
+      playwright-core: 1.61.1
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -8193,6 +8213,8 @@ snapshots:
 
   axe-core@4.12.1: {}
 
+  axe-core@4.13.0: {}
+
   axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -8835,7 +8857,7 @@ snapshots:
       array-includes: 3.1.9
       array.prototype.flatmap: 1.3.3
       ast-types-flow: 0.0.8
-      axe-core: 4.12.1
+      axe-core: 4.13.0
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2

--- a/src/app/[[...params]]/layout.tsx
+++ b/src/app/[[...params]]/layout.tsx
@@ -5,10 +5,16 @@ import Providers from './providers';
 export default function ParamsLayout({ children }: { children: React.ReactNode }) {
   return (
     <Providers>
-      <div className="relative h-screen w-screen overflow-hidden">
+      {/*
+        The map is this app's main content, so the main landmark belongs here,
+        around the map and the widgets that annotate it. It previously wrapped
+        only the widgets column, which left the skip link jumping *past* the map
+        into the widget list. id="main-content" is the root layout's skip target.
+      */}
+      <main id="main-content" className="relative h-screen w-screen overflow-hidden">
         <MapContainer mapId="default" />
         {children}
-      </div>
+      </main>
     </Providers>
   );
 }

--- a/src/app/[[...params]]/page.tsx
+++ b/src/app/[[...params]]/page.tsx
@@ -9,17 +9,49 @@ import MainApp from '@/containers/main-app';
 
 const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
 
-export const metadata: Metadata = {
-  title: 'Global Mangrove Watch',
-  description:
-    'Global Mangrove Watch (GMW) is an online platform that provides the remote sensing data and tools for monitoring mangroves necessary for this. It gives universal access to near real-time information on where and what changes there are to mangroves across the world, and highlights why they are valuable.',
-  openGraph: {
-    title: 'Global Mangrove Watch',
-    description:
-      'Global Mangrove Watch (GMW) is an online platform that provides the remote sensing data and tools for monitoring mangroves necessary for this. It gives universal access to near real-time information on where and what changes there are to mangroves across the world, and highlights why they are valuable.',
-    type: 'website',
-  },
-};
+const DESCRIPTION =
+  'Global Mangrove Watch (GMW) is an online platform that provides the remote sensing data and tools for monitoring mangroves necessary for this. It gives universal access to near real-time information on where and what changes there are to mangroves across the world, and highlights why they are valuable.';
+
+/**
+ * Resolve the page title from the location in the URL.
+ *
+ * Every route under this catch-all previously shipped the same static title,
+ * so `/country/IDN` and the worldwide view were indistinguishable in the
+ * browser tab, in history, and to a screen reader announcing the page. This
+ * reuses the same prefetch the page itself performs — React Query dedupes the
+ * request, so it costs nothing extra.
+ */
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ params?: string[] }>;
+}): Promise<Metadata> {
+  const { params: urlParams } = await params;
+  const locationType = urlParams?.[0];
+  const locationId = urlParams?.[1];
+
+  let title = 'Worldwide';
+
+  if (locationType && ALLOWED_LOCATION_TYPES.includes(locationType) && locationId) {
+    const queryClient = new QueryClient();
+    try {
+      const { data } = await queryClient.fetchQuery(locationQueryOptions(locationType, locationId));
+      if (data?.name) title = data.name;
+    } catch {
+      // Leave the default; the page itself decides whether this is a 404.
+    }
+  }
+
+  return {
+    title,
+    description: DESCRIPTION,
+    openGraph: {
+      title: `${title} | Global Mangrove Watch`,
+      description: DESCRIPTION,
+      type: 'website',
+    },
+  };
+}
 
 export default async function Page({ params }: { params: Promise<{ params?: string[] }> }) {
   const { params: urlParams } = await params;

--- a/src/app/auth/forgot-password/layout.tsx
+++ b/src/app/auth/forgot-password/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Reset your password',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -44,15 +44,17 @@ export default function ForgotPasswordPage() {
   return (
     <div className="relative flex min-h-screen bg-white">
       <Logo position="top-left" width={360} />
-      <section
+      {/* Empty decorative panel — see the signup page. */}
+      <div
+        aria-hidden="true"
         className="flex w-[50%] flex-col justify-center bg-cover bg-right px-4 py-8"
-        aria-labelledby="mrt-hero-title"
         style={{ backgroundImage: 'url(/images/login/image.webp)' }}
       />
 
-      <section className="mx-auto w-full max-w-md px-4 pb-20">
+      <div className="mx-auto w-full max-w-md px-4 pb-20">
         <LandingNavigation />
-        <div className="flex h-full w-full flex-col justify-center space-y-10">
+        {/* See login-container: main is the form column, not the whole screen. */}
+        <main id="main-content" className="flex h-full w-full flex-col justify-center space-y-10">
           <h1 className="text-brand-800 font-sans text-[40px] font-light">Forgot Password</h1>
           {resetPassword.isSuccess && (
             <SuccessAlert message="Please check your inbox for instructions to reset your password" />
@@ -94,8 +96,8 @@ export default function ForgotPasswordPage() {
               </form>
             </Form>
           </div>
-        </div>
-      </section>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -74,8 +74,9 @@ export default function ForgotPasswordPage() {
                           <Input
                             type="email"
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Email"
+                            autoComplete="email"
                           />
                         </FormControl>
                         <FormMessage />

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Account',
+};
+
+/**
+ * The auth pages are all `'use client'`, so they cannot export `metadata`
+ * themselves — this layout (and the per-route layouts beside each page)
+ * supplies it.
+ *
+ * It also provides the `<main id="main-content">` landmark. The root layout
+ * renders a "Skip to main content" link on every route, and without this the
+ * link pointed at nothing here: the auth pages wrap their content in
+ * `<section>`, so there was no main landmark to skip to.
+ */
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return <main id="main-content">{children}</main>;
+}

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -7,13 +7,14 @@ export const metadata: Metadata = {
 /**
  * The auth pages are all `'use client'`, so they cannot export `metadata`
  * themselves — this layout (and the per-route layouts beside each page)
- * supplies it.
+ * supplies it. Metadata only: no wrapper element.
  *
- * It also provides the `<main id="main-content">` landmark. The root layout
- * renders a "Skip to main content" link on every route, and without this the
- * link pointed at nothing here: the auth pages wrap their content in
- * `<section>`, so there was no main landmark to skip to.
+ * The main landmark is deliberately *not* here. Wrapping `children` in one made
+ * main cover the whole screen — the logo, the decorative hero and the landing
+ * nav included — when the main content of these routes is just the form column.
+ * Each auth page marks its own form column as `<main id="main-content">`, which
+ * is what the root layout's skip link targets.
  */
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
-  return <main id="main-content">{children}</main>;
+  return children;
 }

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -5,10 +5,6 @@ export const metadata: Metadata = {
 };
 
 /**
- * The auth pages are all `'use client'`, so they cannot export `metadata`
- * themselves — this layout (and the per-route layouts beside each page)
- * supplies it. Metadata only: no wrapper element.
- *
  * The main landmark is deliberately *not* here. Wrapping `children` in one made
  * main cover the whole screen — the logo, the decorative hero and the landing
  * nav included — when the main content of these routes is just the form column.

--- a/src/app/auth/password/reset/layout.tsx
+++ b/src/app/auth/password/reset/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Set a new password',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/password/reset/page.tsx
+++ b/src/app/auth/password/reset/page.tsx
@@ -86,17 +86,19 @@ function ResetPasswordForm() {
   return (
     <div className="relative flex min-h-screen bg-white">
       <Logo position="top-left" width={360} />
-      <section
+      {/* Empty decorative panel — see the signup page. */}
+      <div
+        aria-hidden="true"
         className="flex w-[50%] flex-col justify-center bg-cover bg-right px-4 py-8"
-        aria-labelledby="mrt-hero-title"
         style={{
           backgroundImage: 'url(/images/login/image.webp)',
         }}
       />
 
-      <section className="mx-auto w-full max-w-md px-4 pb-20">
+      <div className="mx-auto w-full max-w-md px-4 pb-20">
         <LandingNavigation />
-        <div className="flex h-full w-full flex-col justify-center space-y-10">
+        {/* See login-container: main is the form column, not the whole screen. */}
+        <main id="main-content" className="flex h-full w-full flex-col justify-center space-y-10">
           <h1 className="text-brand-800 font-sans text-[40px] font-light">Reset Password</h1>
           <div className="space-y-6">
             <Form {...form}>
@@ -151,8 +153,8 @@ function ResetPasswordForm() {
               </form>
             </Form>
           </div>
-        </div>
-      </section>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/auth/password/reset/page.tsx
+++ b/src/app/auth/password/reset/page.tsx
@@ -113,8 +113,9 @@ function ResetPasswordForm() {
                         <FormControl>
                           <Input
                             type="password"
+                            autoComplete="new-password"
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Password"
                           />
                         </FormControl>
@@ -133,8 +134,9 @@ function ResetPasswordForm() {
                         <FormControl>
                           <Input
                             type="password"
+                            autoComplete="new-password"
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Password"
                           />
                         </FormControl>

--- a/src/app/auth/signin/layout.tsx
+++ b/src/app/auth/signin/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign in',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/signup/layout.tsx
+++ b/src/app/auth/signup/layout.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign up',
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -148,8 +148,9 @@ export default function SignupPage() {
                         <FormControl>
                           <Input
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Name"
+                            autoComplete="name"
                           />
                         </FormControl>
                         <FormMessage />
@@ -168,8 +169,9 @@ export default function SignupPage() {
                         <FormControl>
                           <Input
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Email"
+                            autoComplete="email"
                           />
                         </FormControl>
                         <FormMessage />
@@ -186,8 +188,9 @@ export default function SignupPage() {
                         <FormControl>
                           <Input
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Organization"
+                            autoComplete="organization"
                           />
                         </FormControl>
                         <FormMessage />
@@ -233,8 +236,9 @@ export default function SignupPage() {
                           <FormControl>
                             <Input
                               {...field}
-                              className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                              className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                               placeholder="Tell us your role"
+                              autoComplete="organization-title"
                             />
                           </FormControl>
                           <FormMessage />
@@ -254,8 +258,9 @@ export default function SignupPage() {
                         <FormControl>
                           <Input
                             type="password"
+                            autoComplete="new-password"
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Password"
                           />
                         </FormControl>
@@ -274,8 +279,9 @@ export default function SignupPage() {
                         <FormControl>
                           <Input
                             type="password"
+                            autoComplete="new-password"
                             {...field}
-                            className="focus:border-brand-800 block w-full rounded-[100px] px-3 py-2 text-sm placeholder:text-zinc-400"
+                            className="focus:border-brand-800 block w-full rounded-[100px] px-3 py-2 text-sm placeholder:text-black/60"
                             placeholder="Password"
                           />
                         </FormControl>

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -121,17 +121,20 @@ export default function SignupPage() {
   return (
     <div className="relative flex min-h-screen bg-white">
       <Logo position="top-left" width={360} />
-      <section
+      {/* Empty decorative panel: no content, and `mrt-hero-title` only exists on
+          the signin page, so the section/aria-labelledby pair named nothing here. */}
+      <div
+        aria-hidden="true"
         className="flex w-[50%] flex-col justify-center bg-cover bg-right px-4 py-8"
-        aria-labelledby="mrt-hero-title"
         style={{
           backgroundImage: 'url(/images/login/image.webp)',
         }}
       />
 
-      <section className="mx-auto w-full max-w-md px-4 pb-20">
+      <div className="mx-auto w-full max-w-md px-4 pb-20">
         <LandingNavigation />
-        <div className="flex h-full w-full flex-col justify-center space-y-10">
+        {/* See login-container: main is the form column, not the whole screen. */}
+        <main id="main-content" className="flex h-full w-full flex-col justify-center space-y-10">
           <h1 className="text-brand-800 font-sans text-[40px] font-light">Sign up</h1>
           <div className="space-y-6">
             <Form {...form}>
@@ -307,8 +310,8 @@ export default function SignupPage() {
 
             <FooterSignin />
           </div>
-        </div>
-      </section>
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/embedded/[[...params]]/page.tsx
+++ b/src/app/embedded/[[...params]]/page.tsx
@@ -2,11 +2,36 @@ import { notFound } from 'next/navigation';
 
 import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
+import type { Metadata } from 'next';
 
 import { locationQueryOptions, type DataResponse } from '@/containers/datasets/locations/hooks';
 import EmbeddedWrapper from '@/containers/embedded/wrapper';
 
 const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ params?: string[] }>;
+}): Promise<Metadata> {
+  const { params: urlParams } = await params;
+  const locationType = urlParams?.[0];
+  const locationId = urlParams?.[1];
+
+  let name = 'Worldwide';
+
+  if (locationType && ALLOWED_LOCATION_TYPES.includes(locationType) && locationId) {
+    const queryClient = new QueryClient();
+    try {
+      const { data } = await queryClient.fetchQuery(locationQueryOptions(locationType, locationId));
+      if (data?.name) name = data.name;
+    } catch {
+      // Leave the default; the page itself decides whether this is a 404.
+    }
+  }
+
+  return { title: `${name} (embedded)` };
+}
 
 export default async function EmbeddedPage({ params }: { params: Promise<{ params?: string[] }> }) {
   const { params: urlParams } = await params;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,13 @@ const InterFont = Inter({
 });
 
 export const metadata: Metadata = {
-  title: 'Global Mangrove Watch',
+  // `template` lets each route name itself while keeping the site name in the
+  // browser tab, history and screen-reader page title. Without it, every route
+  // — signup, password reset, 404, each country — announced the same string.
+  title: {
+    default: 'Global Mangrove Watch',
+    template: '%s | Global Mangrove Watch',
+  },
 };
 
 export const viewport: Viewport = {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,7 +1,13 @@
 import Link from 'next/link';
 
+import type { Metadata } from 'next';
+
 import { Button } from '@/components/ui/button';
 import ErrorPage from 'components/error-page';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+};
 
 export default function NotFound() {
   return (

--- a/src/app/print-report/[[...params]]/layout.tsx
+++ b/src/app/print-report/[[...params]]/layout.tsx
@@ -6,7 +6,8 @@ import PrintLegend from '@/containers/print-report/print-legend';
 
 export default function PrintReportLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="print-report relative min-h-screen w-full bg-white p-4">
+    // id="main-content" is the target of the root layout's skip link.
+    <main id="main-content" className="print-report relative min-h-screen w-full bg-white p-4">
       <Image
         src="/images/logo-bg.png"
         alt="Global Mangrove Watch"
@@ -20,6 +21,6 @@ export default function PrintReportLayout({ children }: { children: React.ReactN
         <PrintLegend />
       </div>
       {children}
-    </div>
+    </main>
   );
 }

--- a/src/app/print-report/[[...params]]/page.tsx
+++ b/src/app/print-report/[[...params]]/page.tsx
@@ -2,11 +2,39 @@ import { notFound } from 'next/navigation';
 
 import { QueryClient, dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import turfBbox from '@turf/bbox';
+import type { Metadata } from 'next';
 
 import type { DataResponse } from '@/containers/datasets/locations/hooks';
 import PrintReportPage from '@/containers/print-report';
 
 const ALLOWED_LOCATION_TYPES = ['custom-area', 'country', 'wdpa'];
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ params?: string[] }>;
+}): Promise<Metadata> {
+  const { params: urlParams } = await params;
+  const locationId = urlParams?.[1];
+
+  let name = 'Worldwide';
+
+  if (locationId) {
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/locations/${locationId}`, {
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (res.ok) {
+        const json = (await res.json()) as { data?: DataResponse['data'][0] };
+        if (json.data?.name) name = json.data.name;
+      }
+    } catch {
+      // Leave the default; the page itself decides whether this is a 404.
+    }
+  }
+
+  return { title: `${name} report` };
+}
 
 export default async function Page({ params }: { params: Promise<{ params?: string[] }> }) {
   const { params: urlParams } = await params;

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { MapProvider } from 'react-map-gl';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MotionConfig } from 'motion/react';
 import { SessionProvider } from 'next-auth/react';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
 
@@ -29,20 +30,30 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   );
 
   return (
-    <NuqsAdapter>
-      <QueryClientProvider client={queryClient}>
-        <MediaContextProvider disableDynamicMediaQueries>
-          <MapProvider>
-            <TooltipProvider delayDuration={200}>
-              <SessionProvider>
-                <SessionSync />
-                {children}
-              </SessionProvider>
-            </TooltipProvider>
-          </MapProvider>
-          <Toaster position="top-right" />
-        </MediaContextProvider>
-      </QueryClientProvider>
-    </NuqsAdapter>
+    /*
+     * `reducedMotion="user"` makes every motion/react component honour the
+     * OS-level prefers-reduced-motion setting: transform and layout animations
+     * are disabled while opacity animations are kept, which is the behaviour
+     * WCAG 2.3.3 asks for. Applying it here covers the widget collapse, the
+     * widgets column, the legend and the deck in one place, instead of a
+     * motion-safe: variant on each of them.
+     */
+    <MotionConfig reducedMotion="user">
+      <NuqsAdapter>
+        <QueryClientProvider client={queryClient}>
+          <MediaContextProvider disableDynamicMediaQueries>
+            <MapProvider>
+              <TooltipProvider delayDuration={200}>
+                <SessionProvider>
+                  <SessionSync />
+                  {children}
+                </SessionProvider>
+              </TooltipProvider>
+            </MapProvider>
+            <Toaster position="top-right" />
+          </MediaContextProvider>
+        </QueryClientProvider>
+      </NuqsAdapter>
+    </MotionConfig>
   );
 }

--- a/src/components/auth/email-alert.tsx
+++ b/src/components/auth/email-alert.tsx
@@ -18,7 +18,7 @@ export default function SuccessAlert({
       ].join(' ')}
     >
       <div className="text-brand-800 mt-0.5 shrink-0">
-        <CheckCircledIcon strokeWidth={2} className="h-5 w-5" />
+        <CheckCircledIcon strokeWidth={2} className="h-5 w-5" aria-hidden="true" />
       </div>
 
       <div className="text-sm leading-5">{message}</div>

--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -55,7 +55,7 @@ const RolesSelect = ({
           type="button"
           className="focus:border-brand-800 flex w-full cursor-pointer items-center justify-between space-x-4 rounded-[100px] border border-black/10 py-2 pr-2 pl-3 text-left text-sm"
         >
-          <span className={cn('truncate', { 'text-zinc-400': !selectedLabels.length })}>
+          <span className={cn('truncate', { 'text-black/60': !selectedLabels.length })}>
             {selectedLabels.length ? selectedLabels.join(', ') : placeholder}
           </span>
           <ARROW_SVG

--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -95,7 +95,12 @@ const RolesSelect = ({
                     { 'border-4': checked }
                   )}
                 >
-                  {checked && <CHECK_SVG className="fill-brand-800/70 h-2.5 w-2.5 fill-current" />}
+                  {checked && (
+                    <CHECK_SVG
+                      className="fill-brand-800/70 h-2.5 w-2.5 fill-current"
+                      aria-hidden="true"
+                    />
+                  )}
                 </span>
                 <span>{option.label}</span>
               </button>

--- a/src/components/auth/roles-select.tsx
+++ b/src/components/auth/roles-select.tsx
@@ -53,7 +53,7 @@ const RolesSelect = ({
         <button
           id={id}
           type="button"
-          className="focus:border-brand-800 flex w-full cursor-pointer items-center justify-between space-x-4 rounded-[100px] border border-black/10 py-2 pr-2 pl-3 text-left text-sm focus:outline-none"
+          className="focus:border-brand-800 flex w-full cursor-pointer items-center justify-between space-x-4 rounded-[100px] border border-black/10 py-2 pr-2 pl-3 text-left text-sm"
         >
           <span className={cn('truncate', { 'text-zinc-400': !selectedLabels.length })}>
             {selectedLabels.length ? selectedLabels.join(', ') : placeholder}

--- a/src/components/chart/brush/component.tsx
+++ b/src/components/chart/brush/component.tsx
@@ -289,6 +289,7 @@ function SVGBrushComponent({
           height={16}
           filter={`url(#${shadowFilterId})`}
           pointerEvents="none"
+          aria-hidden="true"
         />
       </g>
 
@@ -359,6 +360,7 @@ function SVGBrushComponent({
           height={16}
           filter={`url(#${shadowFilterId})`}
           pointerEvents="none"
+          aria-hidden="true"
         />
       </g>
     </g>

--- a/src/components/chart/data-table.tsx
+++ b/src/components/chart/data-table.tsx
@@ -1,0 +1,71 @@
+/**
+ * Screen-reader alternative for a chart.
+ *
+ * Recharts draws an SVG whose meaning is carried entirely by shape, position
+ * and colour — none of which reach assistive technology, and colour alone also
+ * fails WCAG 1.4.1 for anyone who cannot distinguish the series. Rather than
+ * trying to narrate the graphic, this exposes the same numbers as a real table
+ * and lets the SVG be decorative.
+ */
+type ChartDataTableProps = {
+  /** The rows the chart is drawn from. */
+  data: Record<string, unknown>[];
+  /** Key holding each row's category/label (falls back to `label`/`name`). */
+  xKey?: string;
+  /** Series keys, in the order they appear in the chart. */
+  seriesKeys: string[];
+  /** Accessible name for the table. */
+  caption: string;
+  /** Id of an existing element to name the table (e.g. the widget's <h2>). */
+  labelledBy?: string | null;
+};
+
+const cellValue = (value: unknown): string => {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number' || typeof value === 'string') return String(value);
+  return '';
+};
+
+const rowLabel = (
+  row: Record<string, unknown>,
+  xKey: string | undefined,
+  index: number
+): string => {
+  const candidates = [xKey ? row[xKey] : undefined, row.label, row.name];
+  const found = candidates.find((c) => typeof c === 'string' || typeof c === 'number');
+  return found === undefined ? `Row ${index + 1}` : String(found);
+};
+
+const ChartDataTable = ({ data, xKey, seriesKeys, caption, labelledBy }: ChartDataTableProps) => {
+  if (!data?.length || !seriesKeys.length) return null;
+
+  return (
+    <table className="sr-only" aria-labelledby={labelledBy ?? undefined}>
+      {/* When the table is named by the widget heading, the caption would
+          repeat it, so it is only rendered as the fallback name. */}
+      {!labelledBy && <caption>{caption}</caption>}
+      <thead>
+        <tr>
+          <th scope="col">{xKey ?? 'Category'}</th>
+          {seriesKeys.map((key) => (
+            <th key={key} scope="col">
+              {key}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, index) => (
+          <tr key={rowLabel(row, xKey, index)}>
+            <th scope="row">{rowLabel(row, xKey, index)}</th>
+            {seriesKeys.map((key) => (
+              <td key={key}>{cellValue(row[key])}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default ChartDataTable;

--- a/src/components/chart/data-table.tsx
+++ b/src/components/chart/data-table.tsx
@@ -55,14 +55,21 @@ const ChartDataTable = ({ data, xKey, seriesKeys, caption, labelledBy }: ChartDa
         </tr>
       </thead>
       <tbody>
-        {data.map((row, index) => (
-          <tr key={rowLabel(row, xKey, index)}>
-            <th scope="row">{rowLabel(row, xKey, index)}</th>
-            {seriesKeys.map((key) => (
-              <td key={key}>{cellValue(row[key])}</td>
-            ))}
-          </tr>
-        ))}
+        {data.map((row, index) => {
+          const label = rowLabel(row, xKey, index);
+
+          return (
+            // Rows are positional and never reorder, and labels repeat by design
+            // (a monthly series charted against `year` shares one label per year),
+            // so the index is part of the key.
+            <tr key={`${label}-${index}`}>
+              <th scope="row">{label}</th>
+              {seriesKeys.map((key) => (
+                <td key={key}>{cellValue(row[key])}</td>
+              ))}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -21,7 +21,10 @@ import {
   ReferenceLine,
 } from 'recharts';
 
+import { useWidgetTitleId } from '@/containers/widget/context';
+
 import Brush from './brush';
+import ChartDataTable from './data-table';
 
 const DEFAULTVALUES = {
   pie: {
@@ -39,6 +42,7 @@ const ChartsMap = new Map([
 ]);
 
 const Chart = ({ config, className }: { config: any; className?: string }) => {
+  const widgetTitleId = useWidgetTitleId();
   const {
     data,
     margin = {
@@ -74,8 +78,30 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
   const { pies, bars, lines, bar } = chartBase;
   const ChartComponent = ChartsMap.get(type) as React.ElementType;
 
+  // Series in draw order, used to build the screen-reader table below.
+  const seriesKeys: string[] = [
+    ...(bar && dataKey ? [dataKey as string] : []),
+    ...(bars ? Object.keys(bars) : []),
+    ...(lines ? Object.keys(lines) : []),
+    ...(pies ? Object.keys(pies) : []),
+  ];
+
+  const label: string = config.a11y?.label ?? 'Chart';
+
   return (
-    <div
+    /*
+     * The SVG is decorative and the numbers are exposed as a table.
+     *
+     * Recharts conveys series identity through stroke/fill alone, so the plot
+     * is unusable both to a screen reader and to anyone who cannot tell the
+     * colours apart. Marking the drawing aria-hidden and shipping the same
+     * data as a real <table> is more useful than any amount of labelling on
+     * the individual marks.
+     *
+     * Pass `config.a11y.label` to name the chart; without it the table is
+     * still exposed, just generically named.
+     */
+    <figure
       className={cn({
         // `chart-overflow-visible` lets axis labels that overflow the plot stay
         // visible (edge tick labels would otherwise be clipped by the svg surface).
@@ -83,7 +109,15 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
         className,
       })}
     >
+      <ChartDataTable
+        data={data}
+        xKey={xKey}
+        seriesKeys={seriesKeys}
+        caption={label}
+        labelledBy={config.a11y?.label ? null : widgetTitleId}
+      />
       <ResponsiveContainer
+        aria-hidden="true"
         width={width || '100%'}
         height={height || 250}
         className="relative w-full flex-1"
@@ -226,7 +260,7 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
           endIndex={endIndex}
         />
       )}
-    </div>
+    </figure>
   );
 };
 

--- a/src/components/chart/index.tsx
+++ b/src/components/chart/index.tsx
@@ -200,7 +200,7 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
                 <Bar key={key} dataKey={key} dot={false} {...bars[key]}>
                   {!!bars[key].label && <Label {...bars[key].label} />}
                   {bars[key].itemColor &&
-                    data.map((item) => <Cell key={`c_${item.color}`} fill={item.color} />)}
+                    data.map((item, i) => <Cell key={`c_${i}`} fill={item.color} />)}
                 </Bar>
               );
             })}
@@ -235,7 +235,8 @@ const Chart = ({ config, className }: { config: any; className?: string }) => {
                 </Pie>
               );
             })}
-          {referenceLines && referenceLines.map((line) => <ReferenceLine key={line} {...line} />)}
+          {referenceLines &&
+            referenceLines.map((line, i) => <ReferenceLine key={`rl_${i}`} {...line} />)}
           {tooltip && <Tooltip {...tooltip} />}
           {/* {brush && (
             <BrushRecharts

--- a/src/components/contact/index.tsx
+++ b/src/components/contact/index.tsx
@@ -146,7 +146,7 @@ function ContactForm() {
                   open={isOpen}
                 >
                   <FormControl>
-                    <SelectTrigger className="focus-visible:ring-ring focus:ring-brand-800 flex h-9 w-full rounded-3xl border border-black/15 px-3 py-0 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50">
+                    <SelectTrigger className="focus-visible:ring-brand-800 focus:ring-brand-800 flex h-9 w-full rounded-3xl border border-black/15 px-3 py-0 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50">
                       <SelectValue placeholder="Select" />
                       {/* <LuChevronDown
                         className={cn({

--- a/src/components/contact/index.tsx
+++ b/src/components/contact/index.tsx
@@ -230,12 +230,6 @@ function ContactForm() {
               name="privacyPolicy"
               render={({ field }) => (
                 <FormItem className="space-y-1.5">
-                  {/* The checkbox was previously wrapped in a <button> that also
-                      contained the Radix Checkbox (itself a <button role="checkbox">)
-                      and a <Link> — nested interactive content, invalid HTML, and a
-                      keyboard trap for the link. The <Label htmlFor> bound to nothing
-                      either, because Radix renders a button, so the checkbox had no
-                      accessible name. The name now comes from aria-labelledby. */}
                   <div className="flex items-center space-x-2.5 text-black/85">
                     <FormControl>
                       <Checkbox

--- a/src/components/contact/index.tsx
+++ b/src/components/contact/index.tsx
@@ -23,7 +23,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -231,13 +230,19 @@ function ContactForm() {
               name="privacyPolicy"
               render={({ field }) => (
                 <FormItem className="space-y-1.5">
-                  <FormControl>
-                    <button type="button" className="flex items-center space-x-2.5 text-black/85">
+                  {/* The checkbox was previously wrapped in a <button> that also
+                      contained the Radix Checkbox (itself a <button role="checkbox">)
+                      and a <Link> — nested interactive content, invalid HTML, and a
+                      keyboard trap for the link. The <Label htmlFor> bound to nothing
+                      either, because Radix renders a button, so the checkbox had no
+                      accessible name. The name now comes from aria-labelledby. */}
+                  <div className="flex items-center space-x-2.5 text-black/85">
+                    <FormControl>
                       <Checkbox
-                        id="privacyPolicy"
+                        aria-labelledby="privacyPolicy-label"
                         onCheckedChange={(checked) => field.onChange(checked)}
                         className={cn({
-                          '[data=] h-5 w-5 cursor-pointer border border-black/15': true,
+                          'h-5 w-5 shrink-0 cursor-pointer border border-black/15': true,
                         })}
                         checked={field.value}
                       >
@@ -252,6 +257,7 @@ function ContactForm() {
                             strokeWidth="2"
                             strokeLinecap="round"
                             strokeLinejoin="round"
+                            aria-hidden="true"
                             className="lucide lucide-circle-check-icon lucide-circle-check stroke-2 text-white"
                           >
                             <circle cx="12" cy="12" r="10" />
@@ -259,14 +265,14 @@ function ContactForm() {
                           </svg>
                         </CheckboxIndicator>
                       </Checkbox>
-                      <Label htmlFor="privacyPolicy" className="cursor-pointer">
-                        I agree with the 
-                        <Link href="/" className="underline">
-                          Privacy Policy.
-                        </Link>
-                      </Label>
-                    </button>
-                  </FormControl>
+                    </FormControl>
+                    <span id="privacyPolicy-label">
+                      I agree with the{' '}
+                      <Link href="/" className="underline">
+                        Privacy Policy.
+                      </Link>
+                    </span>
+                  </div>
                   <FormMessage />
                 </FormItem>
               )}

--- a/src/components/contextual/card.tsx
+++ b/src/components/contextual/card.tsx
@@ -8,7 +8,6 @@ import { useSyncBasemapContextual } from '@/store/map-settings';
 import type { BasemapId } from '@/containers/datasets/contextual-layers/basemaps';
 import { INFO } from '@/containers/datasets/registries';
 
-import { Checkbox, CheckboxIndicator } from '@/components/ui/checkbox';
 import Info from '@/components/widget-controls/info';
 import { WIDGET_CARD_WRAPPER_STYLE } from 'styles/widgets';
 import type { ContextualBasemapsId, MosaicId, WidgetSlugType } from 'types/widget';
@@ -79,20 +78,25 @@ const CardBasemapContextual = ({ id, type, name, description }: CardBasemapConte
         >
           <Image src={THUMBS[id]} alt={name} fill className="shadow-soft rounded-lg" />
 
-          <Checkbox
+          {/* A presentational tick, not a control: it has no change handler,
+              and a Radix Checkbox renders a <button>, which cannot legally
+              nest inside the button that wraps this card. */}
+          <span
+            aria-hidden="true"
             className={cn({
-              'absolute right-2 bottom-2 h-6 w-6 rounded-full border-none': true,
+              'absolute right-2 bottom-2 flex h-6 w-6 items-center justify-center rounded-full': true,
+              'bg-brand-800': isActive,
             })}
-            checked={isActive}
           >
-            <CheckboxIndicator className="text-white">
-              <CHECK_SVG className="h-full w-full fill-current text-white" aria-hidden="true" />
-            </CheckboxIndicator>
-          </Checkbox>
+            {isActive && <CHECK_SVG className="h-full w-full fill-current text-white" />}
+          </span>
         </button>
 
         <div>
-          <h4>{name}</h4>
+          {/* Was an <h4> under the <h2> above — a skipped level, and a repeat
+              of text the h2 already carries. Preflight renders headings at
+              inherited size, so this is visually identical. */}
+          <p>{name}</p>
           {description && <p>{description}</p>}
         </div>
       </div>

--- a/src/components/contextual/card.tsx
+++ b/src/components/contextual/card.tsx
@@ -73,8 +73,7 @@ const CardBasemapContextual = ({ id, type, name, description }: CardBasemapConte
           onClick={handleClick}
           data-testid={id}
           className={cn({
-            [`relative mr-10 h-24 w-24 shrink-0 rounded-xl border-4 border-transparent bg-cover bg-center`]:
-              true,
+            [`relative mr-10 h-24 w-24 shrink-0 rounded-xl border-4 border-transparent bg-cover bg-center`]: true,
             'border-brand-800': isActive,
           })}
         >
@@ -87,11 +86,7 @@ const CardBasemapContextual = ({ id, type, name, description }: CardBasemapConte
             checked={isActive}
           >
             <CheckboxIndicator className="text-white">
-              <CHECK_SVG
-                className="h-full w-full fill-current text-white"
-                role="img"
-                title="Checkmark"
-              />
+              <CHECK_SVG className="h-full w-full fill-current text-white" aria-hidden="true" />
             </CheckboxIndicator>
           </Checkbox>
         </button>

--- a/src/components/contextual/contextual-basemaps.tsx
+++ b/src/components/contextual/contextual-basemaps.tsx
@@ -52,42 +52,28 @@ const ContextualBasemapsMapSettings = () => {
   return (
     <div className="relative flex flex-col text-sm leading-none text-black/85">
       <RadioGroup onValueChange={handleClick} defaultValue={defaultActive} className="space-y-2">
-        <div className="flex items-center space-x-4">
-          <RadioGroupItem
-            option={{ value: 'no-layer', label: 'No layer' }}
-            data-testid="no-layer"
-            label={false}
-          />
-          <label
-            className={cn({
-              'cursor-pointer': true,
-              'text-brand-800 font-semibold': isActive === 'no-layer',
-            })}
-            htmlFor="no-layer"
-          >
-            No layer
-          </label>
-        </div>
+        {/* The option text is rendered by RadioGroupItem, inside the radio
+            button itself — see hi-res-extent-basemap.tsx for the reasoning. */}
+        <RadioGroupItem
+          option={{ value: 'no-layer', label: 'No layer' }}
+          data-testid="no-layer"
+          labelClassName={cn({
+            'cursor-pointer': true,
+            'text-brand-800 font-semibold': isActive === 'no-layer',
+          })}
+        />
 
         {CONTEXTUAL_LAYERS_PLANET_SERIES_ATTRIBUTES.map(({ id, name, mosaic_id }) => {
           return (
             <div key={id} className="space-y-2">
-              <div className="flex items-center space-x-4">
-                <RadioGroupItem
-                  option={{ value: id, label: name }}
-                  data-testid={id}
-                  label={false}
-                />
-                <label
-                  className={cn({
-                    'cursor-pointer': true,
-                    'text-brand-800 font-semibold': isActive === id,
-                  })}
-                  htmlFor={id}
-                >
-                  {name}
-                </label>
-              </div>
+              <RadioGroupItem
+                option={{ value: id, label: name }}
+                data-testid={id}
+                labelClassName={cn({
+                  'cursor-pointer': true,
+                  'text-brand-800 font-semibold': isActive === id,
+                })}
+              />
               {isActive === id && (
                 <div className="ml-6">
                   <DateSelect key={id} mosaic_id={mosaic_id} id={id} />

--- a/src/components/contextual/hi-res-extent-basemap.tsx
+++ b/src/components/contextual/hi-res-extent-basemap.tsx
@@ -49,10 +49,6 @@ const HighResolutionExtentBasemap = () => {
   return (
     <div className="relative flex flex-col text-sm leading-none text-black/85">
       <RadioGroup onValueChange={handleClick} defaultValue={defaultActive} className="space-y-2">
-        {/* The option text is rendered by RadioGroupItem, inside the radio
-            button itself. A sibling <label htmlFor> cannot name a Radix radio
-            (it renders a <button>, which is not labelable), so these radios
-            previously had no accessible name and the text was not clickable. */}
         <RadioGroupItem
           option={{ value: 'no-layer', label: 'No layer' }}
           data-testid="no-layer"

--- a/src/components/contextual/hi-res-extent-basemap.tsx
+++ b/src/components/contextual/hi-res-extent-basemap.tsx
@@ -49,37 +49,30 @@ const HighResolutionExtentBasemap = () => {
   return (
     <div className="relative flex flex-col text-sm leading-none text-black/85">
       <RadioGroup onValueChange={handleClick} defaultValue={defaultActive} className="space-y-2">
-        <div className="flex items-center space-x-4">
-          <RadioGroupItem
-            option={{ value: 'no-layer', label: 'No layer' }}
-            data-testid="no-layer"
-            label={false}
-          />
-          <label
-            className={cn({
-              'cursor-pointer': true,
-              'text-brand-800 font-semibold': isActive === 'no-layer',
-            })}
-            htmlFor="no-layer"
-          >
-            No layer
-          </label>
-        </div>
+        {/* The option text is rendered by RadioGroupItem, inside the radio
+            button itself. A sibling <label htmlFor> cannot name a Radix radio
+            (it renders a <button>, which is not labelable), so these radios
+            previously had no accessible name and the text was not clickable. */}
+        <RadioGroupItem
+          option={{ value: 'no-layer', label: 'No layer' }}
+          data-testid="no-layer"
+          labelClassName={cn({
+            'cursor-pointer': true,
+            'text-brand-800 font-semibold': isActive === 'no-layer',
+          })}
+        />
 
         {HIGH_RESOLUTION_EXTENT.map(({ id, name }) => {
           return (
-            <div key={id} className="flex items-center space-x-4">
-              <RadioGroupItem option={{ value: id, label: name }} data-testid={id} label={false} />
-              <label
-                className={cn({
-                  'cursor-pointer': true,
-                  'text-brand-800 font-semibold': isActive === id,
-                })}
-                htmlFor={id}
-              >
-                {name}
-              </label>
-            </div>
+            <RadioGroupItem
+              key={id}
+              option={{ value: id, label: name }}
+              data-testid={id}
+              labelClassName={cn({
+                'cursor-pointer': true,
+                'text-brand-800 font-semibold': isActive === id,
+              })}
+            />
           );
         })}
       </RadioGroup>

--- a/src/components/error-page/index.tsx
+++ b/src/components/error-page/index.tsx
@@ -16,7 +16,7 @@ const ErrorPage = ({ code, title, message, children }: ErrorPageProps) => {
 
       <p className="text-brand-800 font-sans text-[120px] leading-none font-light">{code}</p>
       <h1 className="text-brand-800 mt-2 font-sans text-3xl font-light">{title}</h1>
-      <p className="text-grey-800 mt-4 max-w-md text-sm leading-relaxed">{message}</p>
+      <p className="text-grey-600 mt-4 max-w-md text-sm leading-relaxed">{message}</p>
 
       <div className="mt-8 flex flex-wrap items-center justify-center gap-4">{children}</div>
     </main>

--- a/src/components/error-page/index.tsx
+++ b/src/components/error-page/index.tsx
@@ -11,7 +11,12 @@ type ErrorPageProps = {
 
 const ErrorPage = ({ code, title, message, children }: ErrorPageProps) => {
   return (
-    <main className="relative flex min-h-screen flex-col items-center justify-center bg-white px-4 text-center">
+    // id="main-content" is the target of the root layout's skip link, which is
+    // rendered on every route.
+    <main
+      id="main-content"
+      className="relative flex min-h-screen flex-col items-center justify-center bg-white px-4 text-center"
+    >
       <Logo position="top-left" width={360} />
 
       <p className="text-brand-800 font-sans text-[120px] leading-none font-light">{code}</p>

--- a/src/components/map/controls/basemap-settings/index.tsx
+++ b/src/components/map/controls/basemap-settings/index.tsx
@@ -27,8 +27,7 @@ const BasemapSettings = () => {
           <DialogTrigger
             data-testid="basemap-settings-button"
             className={cn({
-              'group shadow-control inline-flex h-12 w-12 cursor-pointer flex-col items-center justify-center rounded-full bg-white backdrop-blur-sm backdrop-filter hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none':
-                true,
+              'group shadow-control focus-visible:shadow-control-focus inline-flex h-12 w-12 cursor-pointer flex-col items-center justify-center rounded-full bg-white backdrop-blur-sm backdrop-filter hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
             })}
           >
             <BASEMAP_SETTINGS_SVG

--- a/src/components/map/controls/basemap-settings/index.tsx
+++ b/src/components/map/controls/basemap-settings/index.tsx
@@ -53,7 +53,7 @@ const BasemapSettings = () => {
             tooltipPosition={{ top: -140, left: 0 }}
             message="use these buttons to switch between basemaps"
           >
-            <div className="flex w-[490px] flex-col space-y-2">
+            <div className="flex max-h-[80dvh] w-[min(490px,calc(100vw-3rem))] flex-col space-y-2 overflow-y-auto">
               <p className="text-xs font-bold tracking-[1px] uppercase">map style</p>
               <Basemaps />
             </div>

--- a/src/components/map/controls/basemap-settings/index.tsx
+++ b/src/components/map/controls/basemap-settings/index.tsx
@@ -25,6 +25,7 @@ const BasemapSettings = () => {
       <Tooltip>
         <TooltipTrigger asChild>
           <DialogTrigger
+            aria-label="Basemap settings"
             data-testid="basemap-settings-button"
             className={cn({
               'group shadow-control focus-visible:shadow-control-focus inline-flex h-12 w-12 cursor-pointer flex-col items-center justify-center rounded-full bg-white backdrop-blur-sm backdrop-filter hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
@@ -32,8 +33,7 @@ const BasemapSettings = () => {
           >
             <BASEMAP_SETTINGS_SVG
               className="group-disabled:fill-grey-75 h-4 w-4 group-hover:bg-gray-100"
-              role="img"
-              title="Basemap settings"
+              aria-hidden="true"
             />
           </DialogTrigger>
         </TooltipTrigger>

--- a/src/components/map/controls/fullscreen/index.tsx
+++ b/src/components/map/controls/fullscreen/index.tsx
@@ -28,8 +28,7 @@ const FullScreen = () => {
           aria-label={isFullScreen ? 'Exit fullscreen' : 'Enter fullscreen'}
           aria-pressed={isFullScreen}
           className={cn({
-            'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white disabled:cursor-default disabled:bg-gray-50 disabled:outline-none':
-              true,
+            'group shadow-control focus-visible:shadow-control-focus inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
             'border-brand-800 bg-brand-800': isFullScreen,
             'hover:bg-gray-100': !isFullScreen,
           })}

--- a/src/components/map/controls/pitch-reset/component.tsx
+++ b/src/components/map/controls/pitch-reset/component.tsx
@@ -23,8 +23,7 @@ const PitchReset = ({ className, mapId }: { className?: string; mapId: string })
     >
       <button
         className={cn({
-          'group active:outline-brand-400/40 -mt-2 rounded-b-full bg-white p-3 hover:bg-gray-100 active:outline active:outline-2 active:-outline-offset-[5px] disabled:cursor-default disabled:bg-gray-50 disabled:outline-none':
-            true,
+          'group active:outline-brand-400/40 focus-visible:shadow-control-focus -mt-2 rounded-b-full bg-white p-3 hover:bg-gray-100 active:outline active:outline-2 active:-outline-offset-[5px] disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
         })}
         aria-label="Reset map pitch"
         type="button"

--- a/src/components/map/controls/pitch-reset/component.tsx
+++ b/src/components/map/controls/pitch-reset/component.tsx
@@ -32,8 +32,7 @@ const PitchReset = ({ className, mapId }: { className?: string; mapId: string })
       >
         <NAVIGATION_SVG
           className="group-disabled:fill-grey-75 h-5 w-5 fill-current"
-          role="img"
-          title="Pitch reset"
+          aria-hidden="true"
         />
       </button>
     </div>

--- a/src/components/map/controls/share/index.tsx
+++ b/src/components/map/controls/share/index.tsx
@@ -89,7 +89,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
                   type="button"
                   aria-label="Share"
                   className={cn({
-                    'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white text-black hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
+                    'group shadow-control focus-visible:shadow-control-focus inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white text-black hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
                   })}
                 >
                   <SHARE_SVG className="h-4 w-4 group-hover:bg-gray-100" aria-hidden="true" />
@@ -139,7 +139,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
               disabled
               aria-label="Share (unavailable for custom areas)"
               className={cn(className, {
-                'group shadow-control inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
+                'group shadow-control focus-visible:shadow-control-focus inline-flex h-12 w-12 flex-col items-center justify-center rounded-full bg-white hover:bg-gray-100 disabled:cursor-default disabled:bg-gray-50 disabled:outline-none': true,
               })}
             >
               <SHARE_SVG

--- a/src/components/map/controls/share/index.tsx
+++ b/src/components/map/controls/share/index.tsx
@@ -101,7 +101,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
 
           <DialogContent className="top-[30%] text-black/85">
             <DialogTitle className="mb-2 text-3xl font-light">Share</DialogTitle>
-            <div className="flex w-[480px] flex-col space-y-5">
+            <div className="flex max-h-[80dvh] w-[min(480px,calc(100vw-3rem))] flex-col space-y-5 overflow-y-auto">
               <div className="flex flex-col space-y-1">
                 <h3 className="ml-4 text-[13px] font-semibold">Public url to share</h3>
                 <div className="bg-brand-600/10 flex h-12 items-center justify-between space-x-4 rounded-3xl p-4 text-sm">

--- a/src/components/map/controls/share/index.tsx
+++ b/src/components/map/controls/share/index.tsx
@@ -103,7 +103,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
             <DialogTitle className="mb-2 text-3xl font-light">Share</DialogTitle>
             <div className="flex w-[480px] flex-col space-y-5">
               <div className="flex flex-col space-y-1">
-                <h4 className="ml-4 text-[13px] font-semibold">Public url to share</h4>
+                <h3 className="ml-4 text-[13px] font-semibold">Public url to share</h3>
                 <div className="bg-brand-600/10 flex h-12 items-center justify-between space-x-4 rounded-3xl p-4 text-sm">
                   <p className="truncate">{shareTargets?.url}</p>
                   <button
@@ -115,7 +115,7 @@ const Share = ({ className, disabled = false }: { className?: string; disabled: 
                 </div>
               </div>
               <div>
-                <h4 className="ml-4 text-[13px] font-semibold">Code to embed map</h4>
+                <h3 className="ml-4 text-[13px] font-semibold">Code to embed map</h3>
                 <div className="bg-brand-600/10 flex h-12 items-center space-x-4 rounded-3xl p-4 text-sm">
                   <p className="truncate">{shareTargets?.embedCode}</p>
                   <button

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -55,11 +55,7 @@ const ZoomControl = ({ className, mapId }: { className?: string; mapId: string }
             disabled={zoom >= maxZoom}
             onClick={increaseZoom}
           >
-            <ZOOM_IN_SVG
-              className={`fill-current ${SVG_COMMON_CLASSES}`}
-              role="img"
-              title="Zoom-in"
-            />
+            <ZOOM_IN_SVG className={`fill-current ${SVG_COMMON_CLASSES}`} aria-hidden="true" />
           </button>
         </TooltipTrigger>
         <TooltipContent className="bg-gray-600 px-2 text-white">Zoom in</TooltipContent>
@@ -75,11 +71,7 @@ const ZoomControl = ({ className, mapId }: { className?: string; mapId: string }
             disabled={zoom <= minZoom}
             onClick={decreaseZoom}
           >
-            <ZOOM_OUT_SVG
-              className={`fill-current ${SVG_COMMON_CLASSES}`}
-              role="img"
-              title="Zoom-out"
-            />
+            <ZOOM_OUT_SVG className={`fill-current ${SVG_COMMON_CLASSES}`} aria-hidden="true" />
           </button>
         </TooltipTrigger>
         <TooltipContent className="bg-gray-600 px-2 text-white">Zoom out</TooltipContent>

--- a/src/components/map/controls/zoom/component.tsx
+++ b/src/components/map/controls/zoom/component.tsx
@@ -12,7 +12,7 @@ import ZOOM_IN_SVG from '@/svgs/map/zoom-in';
 import ZOOM_OUT_SVG from '@/svgs/map/zoom-out';
 
 const COMMON_CLASSES =
-  'bg-white group w-full w-12 p-4 hover:bg-gray-100 active:outline active:outline-2 active:-outline-offset-[5px] active:outline-brand-400/40 disabled:bg-gray-50 disabled:outline-none hover:gray-100';
+  'bg-white group focus-visible:shadow-control-focus w-full w-12 p-4 hover:bg-gray-100 active:outline active:outline-2 active:-outline-offset-[5px] active:outline-brand-400/40 disabled:bg-gray-50 disabled:outline-none hover:gray-100';
 
 const SVG_COMMON_CLASSES = 'h-4 w-4 group-disabled:fill-grey-75';
 

--- a/src/components/map/legend/sortable/item.tsx
+++ b/src/components/map/legend/sortable/item.tsx
@@ -14,7 +14,15 @@ const SortableItem: React.FC<SortableItemProps> = ({
   children,
   'data-testid': dataTestId,
 }: SortableItemProps) => {
-  const { attributes, listeners, transform, transition, isDragging, setNodeRef } = useSortable({
+  const {
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+    setNodeRef,
+    setActivatorNodeRef,
+  } = useSortable({
     id,
   });
 
@@ -23,10 +31,14 @@ const SortableItem: React.FC<SortableItemProps> = ({
     transition,
   };
 
+  // The drag activator goes on the child's own handle button. Spreading it here
+  // instead would give this wrapper `role="button"` and `tabindex="0"` around the
+  // item's other controls — nested interactive content (WCAG 4.1.2).
   const CHILD = cloneElement(children as ReactElement, {
     sortable,
     listeners,
     attributes,
+    setActivatorNodeRef,
   });
 
   return (
@@ -39,10 +51,6 @@ const SortableItem: React.FC<SortableItemProps> = ({
       })}
       style={style}
       data-testid={dataTestId}
-      {...(sortable?.handle && {
-        ...listeners,
-        ...attributes,
-      })}
     >
       {CHILD}
     </div>

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -5,18 +5,31 @@ import cn from '@/lib/classnames';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
+/**
+ * Colours resolve to the project palette in `tailwind.config.mjs`.
+ *
+ * This file previously carried shadcn's semantic token names — `ring-ring`,
+ * `ring-offset-background`, `bg-destructive`, `bg-accent`, `text-primary` —
+ * none of which are defined here: there is no `@theme` block, no `:root`
+ * custom properties, and no matching keys in the Tailwind config. Tailwind
+ * emitted nothing for them, so the focus ring had no colour (WCAG 2.4.7) and
+ * the destructive/ghost hover states rendered unstyled.
+ *
+ * They are mapped to real palette values rather than by introducing a
+ * semantic-token layer, because the app has no theming layer to hang one on.
+ */
 const buttonVariants = cva(
-  'cursor-pointer inline-flex items-center justify-center whitespace-nowrap rounded-3xl transition-colors text-sm font-medium ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 border',
+  'cursor-pointer inline-flex items-center justify-center whitespace-nowrap rounded-3xl transition-colors text-sm font-medium ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-800 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 border',
   {
     variants: {
       variant: {
         default: 'bg-brand-800 text-white hover:bg-brand-800/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        destructive: 'bg-red-700 text-white hover:bg-red-700/90',
         outline:
-          'text-brand-800 bg-transparent hover:bg-accent hover:text-accent-foreground border-brand-800/15',
-        secondary: 'bg-white text-brand-800 hover:bg-accent hover:text-accent-foreground',
-        ghost: 'bg-brand-800/15 text-black/85 hover:bg-white hover:text-grey-800',
-        link: 'text-primary rounded-full underline-offset-4 hover:underline',
+          'text-brand-800 bg-transparent hover:bg-brand-100 hover:text-brand-900 border-brand-800/15',
+        secondary: 'bg-white text-brand-800 hover:bg-brand-100 hover:text-brand-900',
+        ghost: 'bg-brand-800/15 text-black/85 hover:bg-white hover:text-grey-600',
+        link: 'text-brand-800 rounded-full underline-offset-4 hover:underline',
         rounded: 'rounded-full',
       },
       size: {
@@ -36,8 +49,7 @@ const buttonVariants = cva(
 );
 
 interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }
 

--- a/src/components/ui/button/index.tsx
+++ b/src/components/ui/button/index.tsx
@@ -5,19 +5,6 @@ import cn from '@/lib/classnames';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-/**
- * Colours resolve to the project palette in `tailwind.config.mjs`.
- *
- * This file previously carried shadcn's semantic token names — `ring-ring`,
- * `ring-offset-background`, `bg-destructive`, `bg-accent`, `text-primary` —
- * none of which are defined here: there is no `@theme` block, no `:root`
- * custom properties, and no matching keys in the Tailwind config. Tailwind
- * emitted nothing for them, so the focus ring had no colour (WCAG 2.4.7) and
- * the destructive/ghost hover states rendered unstyled.
- *
- * They are mapped to real palette values rather than by introducing a
- * semantic-token layer, because the app has no theming layer to hang one on.
- */
 const buttonVariants = cva(
   'cursor-pointer inline-flex items-center justify-center whitespace-nowrap rounded-3xl transition-colors text-sm font-medium ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-800 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 border',
   {

--- a/src/components/ui/command/index.tsx
+++ b/src/components/ui/command/index.tsx
@@ -36,7 +36,7 @@ const CommandInput = forwardRef<
       ref={ref}
       {...props}
       className={cn(className, {
-        'placeholder:text-foreground-muted focus:border-brand-800 flex h-11 w-full rounded-md border-2 bg-transparent py-3 text-2xl outline-none placeholder:text-2xl focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50': true,
+        'focus:border-brand-800 flex h-11 w-full rounded-md border-2 bg-transparent py-3 text-2xl placeholder:text-2xl placeholder:text-black/60 focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50': true,
       })}
     />
   </div>
@@ -84,7 +84,7 @@ const CommandItem = forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(className, {
-      'aria-selected:bg-brand-100 aria-selected:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
+      'aria-selected:bg-brand-100 aria-selected:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
     })}
     {...props}
   />

--- a/src/components/ui/command/index.tsx
+++ b/src/components/ui/command/index.tsx
@@ -11,8 +11,7 @@ const Command = forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(className, {
-      'bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md':
-        true,
+      'flex h-full w-full flex-col overflow-hidden rounded-md bg-white text-black/85': true,
     })}
     {...props}
   />
@@ -37,8 +36,7 @@ const CommandInput = forwardRef<
       ref={ref}
       {...props}
       className={cn(className, {
-        'placeholder:text-foreground-muted focus:border-brand-800 flex h-11 w-full rounded-md border-2 bg-transparent py-3 text-2xl outline-none placeholder:text-2xl focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50':
-          true,
+        'placeholder:text-foreground-muted focus:border-brand-800 flex h-11 w-full rounded-md border-2 bg-transparent py-3 text-2xl outline-none placeholder:text-2xl focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50': true,
       })}
     />
   </div>
@@ -71,8 +69,7 @@ const CommandGroup = forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(className, {
-      'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium':
-        true,
+      'overflow-hidden p-1 text-black/85 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-black/60': true,
     })}
     {...props}
   />
@@ -87,8 +84,7 @@ const CommandItem = forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(className, {
-      'aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
-        true,
+      'aria-selected:bg-brand-100 aria-selected:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
     })}
     {...props}
   />

--- a/src/components/ui/dropdown/index.tsx
+++ b/src/components/ui/dropdown/index.tsx
@@ -17,7 +17,7 @@ const DropdownMenuContent = forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'bg-popover text-popover-foreground z-50 min-w-[--radix-dropdown-menu-trigger-width] overflow-hidden rounded-md p-1 shadow-md',
+        'z-50 min-w-[--radix-dropdown-menu-trigger-width] overflow-hidden rounded-md bg-white p-1 text-black/85 shadow-md',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
         'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
@@ -39,8 +39,7 @@ const DropdownMenuItem = forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(className, {
-      'focus:bg-accent focus:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50':
-        true,
+      'focus:bg-brand-100 focus:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm transition-colors outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
     })}
     {...props}
   />

--- a/src/components/ui/dropdown/index.tsx
+++ b/src/components/ui/dropdown/index.tsx
@@ -39,7 +39,7 @@ const DropdownMenuItem = forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(className, {
-      'focus:bg-brand-100 focus:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm transition-colors outline-none select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
+      'focus:bg-brand-100 focus:text-brand-900 relative flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm transition-colors select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50': true,
     })}
     {...props}
   />

--- a/src/components/ui/form/index.tsx
+++ b/src/components/ui/form/index.tsx
@@ -94,7 +94,7 @@ function FormLabel({
     <Label
       data-slot="form-label"
       data-error={!!error}
-      className={cn('data-[error=true]:text-destructive mb-1 block text-black/85', className)}
+      className={cn('mb-1 block text-black/85 data-[error=true]:text-red-700', className)}
       htmlFor={formItemId}
       {...props}
     >

--- a/src/components/ui/form/index.tsx
+++ b/src/components/ui/form/index.tsx
@@ -120,13 +120,6 @@ function FormLabel({
   );
 }
 
-/**
- * Optional helper text for a field.
- *
- * `FormControl` points `aria-describedby` at this element's id. Until this
- * component existed, that id referenced nothing at all, so every field in the
- * app advertised a description that no assistive technology could resolve.
- */
 function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
   const { formDescriptionId } = useFormField();
   const { registerDescription } = React.useContext(FormItemContext);

--- a/src/components/ui/form/index.tsx
+++ b/src/components/ui/form/index.tsx
@@ -68,15 +68,24 @@ const useFormField = () => {
 
 type FormItemContextValue = {
   id: string;
+  /** Whether a <FormDescription> is mounted inside this item. */
+  hasDescription: boolean;
+  registerDescription: () => void;
 };
 
 const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
 
 function FormItem({ className, ...props }: React.ComponentProps<'div'>) {
   const id = React.useId();
+  const [hasDescription, setHasDescription] = React.useState(false);
+
+  const value = React.useMemo(
+    () => ({ id, hasDescription, registerDescription: () => setHasDescription(true) }),
+    [id, hasDescription]
+  );
 
   return (
-    <FormItemContext.Provider value={{ id }}>
+    <FormItemContext.Provider value={value}>
       <div data-slot="form-item" className={cn('grid gap-2', className)} {...props} />
     </FormItemContext.Provider>
   );
@@ -111,14 +120,48 @@ function FormLabel({
   );
 }
 
+/**
+ * Optional helper text for a field.
+ *
+ * `FormControl` points `aria-describedby` at this element's id. Until this
+ * component existed, that id referenced nothing at all, so every field in the
+ * app advertised a description that no assistive technology could resolve.
+ */
+function FormDescription({ className, ...props }: React.ComponentProps<'p'>) {
+  const { formDescriptionId } = useFormField();
+  const { registerDescription } = React.useContext(FormItemContext);
+
+  React.useEffect(() => {
+    registerDescription();
+  }, [registerDescription]);
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn('text-sm text-black/60', className)}
+      {...props}
+    />
+  );
+}
+
 function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+  const itemContext = React.useContext(FormItemContext);
+
+  // Only advertise the ids that actually exist in the DOM. A dangling
+  // aria-describedby is worse than none: screen readers announce nothing but
+  // the field looks correctly described to automated checks.
+  const describedBy =
+    [itemContext.hasDescription ? formDescriptionId : null, error ? formMessageId : null]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   return (
     <Slot
       data-slot="form-control"
       id={formItemId}
-      aria-describedby={!error ? `${formDescriptionId}` : `${formDescriptionId} ${formMessageId}`}
+      aria-describedby={describedBy}
       aria-invalid={!!error}
       {...props}
     />
@@ -145,4 +188,4 @@ function FormMessage({ className, ...props }: React.ComponentProps<'p'>) {
   );
 }
 
-export { Form, FormItem, FormLabel, FormControl, FormMessage, FormField };
+export { Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -9,8 +9,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...pr
     <input
       type={type}
       className={cn(className, {
-        'border-input ring-offset-background focus-visible:ring-ring border-opacity-15 focus:ring-brand-800 flex h-9 w-full rounded-3xl border border-black/15 bg-transparent px-3 py-2 text-sm text-black/85 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-black/40 focus:ring-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50':
-          true,
+        // `border-input`, `ring-offset-background` and `ring-ring` are shadcn
+        // token names with no definition in this project, so they emitted
+        // nothing — the focus ring had no colour. Mapped to the real palette.
+        // Placeholder raised from black/40 (2.9:1) to black/60 (5.7:1).
+        'focus-visible:ring-brand-800 border-opacity-15 focus:ring-brand-800 flex h-9 w-full rounded-3xl border border-black/15 bg-transparent px-3 py-2 text-sm text-black/85 ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-black/60 focus:ring-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50': true,
       })}
       ref={ref}
       {...props}

--- a/src/components/ui/input/index.tsx
+++ b/src/components/ui/input/index.tsx
@@ -9,10 +9,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ className, type, ...pr
     <input
       type={type}
       className={cn(className, {
-        // `border-input`, `ring-offset-background` and `ring-ring` are shadcn
-        // token names with no definition in this project, so they emitted
-        // nothing — the focus ring had no colour. Mapped to the real palette.
-        // Placeholder raised from black/40 (2.9:1) to black/60 (5.7:1).
         'focus-visible:ring-brand-800 border-opacity-15 focus:ring-brand-800 flex h-9 w-full rounded-3xl border border-black/15 bg-transparent px-3 py-2 text-sm text-black/85 ring-offset-white file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-black/60 focus:ring-2 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50': true,
       })}
       ref={ref}

--- a/src/components/ui/popover/index.tsx
+++ b/src/components/ui/popover/index.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       // (e.g. z-index when nested inside a higher-stacked Dialog) — twMerge
       // keeps the last conflicting utility.
       className={cn(
-        'text-popover-foreground w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85 outline-none',
+        'w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85 outline-none',
         className
       )}
       {...props}

--- a/src/components/ui/popover/index.tsx
+++ b/src/components/ui/popover/index.tsx
@@ -21,7 +21,7 @@ const PopoverContent = React.forwardRef<
       // (e.g. z-index when nested inside a higher-stacked Dialog) — twMerge
       // keeps the last conflicting utility.
       className={cn(
-        'w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85 outline-none',
+        'w-fit-content data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 space-y-2 overflow-y-auto rounded-3xl bg-white p-4 text-sm text-black/85',
         className
       )}
       {...props}

--- a/src/components/ui/radio-group/radio-group-item/index.tsx
+++ b/src/components/ui/radio-group/radio-group-item/index.tsx
@@ -46,7 +46,7 @@ const RadioGroupItem = ({
       className="group-data-[state=checked]:border-brand-800 flex h-3 w-3 shrink-0 items-center justify-center rounded-full border border-black/85 group-data-[state=checked]:border-4"
     >
       <RadioGroup.Indicator className="flex items-center justify-center">
-        <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" />
+        <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" aria-hidden="true" />
       </RadioGroup.Indicator>
     </span>
     {label && (

--- a/src/components/ui/radio-group/radio-group-item/index.tsx
+++ b/src/components/ui/radio-group/radio-group-item/index.tsx
@@ -9,17 +9,6 @@ import { IconBaseProps } from 'react-icons/lib';
 
 import type { RadioOption } from '../types';
 
-/**
- * The visible text lives *inside* the radio button rather than in a sibling
- * <label htmlFor>. Radix renders `RadioGroup.Item` as a <button role="radio">,
- * and `htmlFor` only binds to labelable elements — so the previous markup gave
- * these radios no accessible name at all, and clicking the text did nothing.
- *
- * Putting the text in the button's content makes it the button's own name and
- * makes the whole row a pointer target, with no ref plumbing or click
- * forwarding. When the caller suppresses the text (`label={false}`) the name
- * falls back to `aria-label`.
- */
 const RadioGroupItem = ({
   option,
   className,

--- a/src/components/ui/radio-group/radio-group-item/index.tsx
+++ b/src/components/ui/radio-group/radio-group-item/index.tsx
@@ -9,42 +9,56 @@ import { IconBaseProps } from 'react-icons/lib';
 
 import type { RadioOption } from '../types';
 
+/**
+ * The visible text lives *inside* the radio button rather than in a sibling
+ * <label htmlFor>. Radix renders `RadioGroup.Item` as a <button role="radio">,
+ * and `htmlFor` only binds to labelable elements — so the previous markup gave
+ * these radios no accessible name at all, and clicking the text did nothing.
+ *
+ * Putting the text in the button's content makes it the button's own name and
+ * makes the whole row a pointer target, with no ref plumbing or click
+ * forwarding. When the caller suppresses the text (`label={false}`) the name
+ * falls back to `aria-label`.
+ */
 const RadioGroupItem = ({
   option,
   className,
+  labelClassName,
   label = true,
+  ...props
 }: {
   option: RadioOption;
   className?: string;
+  labelClassName?: string;
   label?: boolean;
-}) => (
-  <div className="flex items-center space-x-4">
-    <RadioGroup.Item
-      className={cn(className, {
-        'group inline-flex h-3 w-3 shrink-0 cursor-pointer items-center justify-center rounded-full':
-          true,
-      })}
-      value={option.value}
-      id={option.value}
+} & Omit<RadioGroup.RadioGroupItemProps, 'value' | 'id'>) => (
+  <RadioGroup.Item
+    className={cn(className, {
+      'group flex cursor-pointer items-center space-x-4': true,
+    })}
+    value={option.value}
+    id={option.value}
+    aria-label={label ? undefined : option.label}
+    {...props}
+  >
+    <span
+      aria-hidden="true"
+      className="group-data-[state=checked]:border-brand-800 flex h-3 w-3 shrink-0 items-center justify-center rounded-full border border-black/85 group-data-[state=checked]:border-4"
     >
-      <span
-        aria-hidden="true"
-        className="group-data-[state=checked]:border-brand-800 flex h-3 w-3 items-center justify-center rounded-full border border-black/85 group-data-[state=checked]:border-4"
-      >
-        <RadioGroup.Indicator className="flex items-center justify-center">
-          <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" />
-        </RadioGroup.Indicator>
-      </span>
-    </RadioGroup.Item>
+      <RadioGroup.Indicator className="flex items-center justify-center">
+        <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" />
+      </RadioGroup.Indicator>
+    </span>
     {label && (
-      <label
-        className="font-sm text-brand-800 m-0 cursor-pointer text-sm leading-none font-semibold"
-        htmlFor={option.value}
+      <span
+        className={
+          labelClassName ?? 'font-sm text-brand-800 m-0 text-sm leading-none font-semibold'
+        }
       >
         {option.label}
-      </label>
+      </span>
     )}
-  </div>
+  </RadioGroup.Item>
 );
 
 export default RadioGroupItem;

--- a/src/components/ui/scroll-area/index.tsx
+++ b/src/components/ui/scroll-area/index.tsx
@@ -19,7 +19,7 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="focus-visible:ring-brand-800/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>

--- a/src/components/ui/select-multi/index.tsx
+++ b/src/components/ui/select-multi/index.tsx
@@ -109,8 +109,7 @@ const Select: FC<MultiSelectProps> = (props: MultiSelectProps) => {
 
             <Listbox.Options
               className={cn({
-                'pointer-events-auto absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-y-auto text-base leading-6 focus:outline-none':
-                  true,
+                'pointer-events-auto absolute top-full left-0 z-50 mt-1 max-h-60 w-full overflow-y-auto text-base leading-6': true,
                 [THEME[theme].menu]: true,
               })}
             >

--- a/src/components/ui/select-multi/index.tsx
+++ b/src/components/ui/select-multi/index.tsx
@@ -152,8 +152,13 @@ const Select: FC<MultiSelectProps> = (props: MultiSelectProps) => {
                   const groupOptions = options?.filter((o) => o.group === g.value);
 
                   return (
-                    <div key={g.value}>
-                      <h3 className="py-2 pl-3 text-xs font-bold">{g.label}</h3>
+                    // A listbox option group, not a document section: an <h3>
+                    // here injected a heading into the page outline and did not
+                    // group the options for assistive tech.
+                    <div key={g.value} role="group" aria-labelledby={`select-group-${g.value}`}>
+                      <p id={`select-group-${g.value}`} className="py-2 pl-3 text-xs font-bold">
+                        {g.label}
+                      </p>
                       {groupOptions?.map((opt) => (
                         <Option key={opt.value} opt={opt} theme={theme} />
                       ))}

--- a/src/components/ui/select-multi/index.tsx
+++ b/src/components/ui/select-multi/index.tsx
@@ -152,9 +152,6 @@ const Select: FC<MultiSelectProps> = (props: MultiSelectProps) => {
                   const groupOptions = options?.filter((o) => o.group === g.value);
 
                   return (
-                    // A listbox option group, not a document section: an <h3>
-                    // here injected a heading into the page outline and did not
-                    // group the options for assistive tech.
                     <div key={g.value} role="group" aria-labelledby={`select-group-${g.value}`}>
                       <p id={`select-group-${g.value}`} className="py-2 pl-3 text-xs font-bold">
                         {g.label}

--- a/src/components/ui/select-multi/option/index.tsx
+++ b/src/components/ui/select-multi/option/index.tsx
@@ -41,10 +41,7 @@ export const Option = ({ opt, theme }: OptionProps) => {
         >
           <Checkbox className="h-3 w-3 cursor-pointer" checked={s}>
             <CheckboxIndicator>
-              <CHECK_SVG
-                className="fill-brand-800/70 h-2.5 w-2.5 fill-current"
-                aria-hidden="true"
-              />
+              <CHECK_SVG className="fill-brand-800/70 h-2.5 w-2.5" aria-hidden="true" />
             </CheckboxIndicator>
           </Checkbox>
 

--- a/src/components/ui/select-multi/option/index.tsx
+++ b/src/components/ui/select-multi/option/index.tsx
@@ -39,7 +39,7 @@ export const Option = ({ opt, theme }: OptionProps) => {
             [THEME[theme].item.disabled]: d,
           })}
         >
-          <Checkbox className="h-4 w-4 cursor-pointer" checked={s}>
+          <Checkbox className="h-3 w-3 cursor-pointer" checked={s}>
             <CheckboxIndicator>
               <CHECK_SVG
                 className="fill-brand-800/70 h-2.5 w-2.5 fill-current"

--- a/src/components/ui/select/index.tsx
+++ b/src/components/ui/select/index.tsx
@@ -89,7 +89,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        'focus:bg-brand-100 focus:text-brand-900 relative w-full cursor-pointer items-center justify-between outline-none',
+        'focus:bg-brand-100 focus:text-brand-900 relative w-full cursor-pointer items-center justify-between',
         className
       )}
       {...props}

--- a/src/components/ui/select/index.tsx
+++ b/src/components/ui/select/index.tsx
@@ -23,7 +23,7 @@ function SelectIcon({
   ...props
 }: ComponentProps<typeof SelectPrimitive.Icon>) {
   return (
-    <SelectPrimitive.Icon className={cn(className, 'text-muted-foreground')} {...props}>
+    <SelectPrimitive.Icon className={cn(className, 'text-black/60')} {...props}>
       {children}
     </SelectPrimitive.Icon>
   );
@@ -38,7 +38,7 @@ function SelectTrigger({
     <SelectPrimitive.Trigger
       className={cn(
         className,
-        'border-input ring-offset-background placeholder:text-muted-foreground focus:ring-ring flex h-9 w-full items-center justify-between rounded-3xl px-3 py-0 text-sm focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
+        'focus:ring-brand-800 flex h-9 w-full items-center justify-between rounded-3xl border-black/15 px-3 py-0 text-sm ring-offset-white placeholder:text-black/60 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50'
       )}
       {...props}
     >
@@ -89,7 +89,7 @@ function SelectItem({
   return (
     <SelectPrimitive.Item
       className={cn(
-        'focus:bg-accent focus:text-accent-foreground relative w-full cursor-pointer items-center justify-between outline-none',
+        'focus:bg-brand-100 focus:text-brand-900 relative w-full cursor-pointer items-center justify-between outline-none',
         className
       )}
       {...props}

--- a/src/components/ui/slider/index.tsx
+++ b/src/components/ui/slider/index.tsx
@@ -67,12 +67,12 @@ const Slider = ({
         aria-label={thumbAriaLabel}
         aria-valuetext={thumbAriaValueText}
         className={cn(
-          'focus-visible:ring-ring relative flex min-h-6 min-w-6 cursor-pointer items-center justify-center bg-transparent before:block before:h-4 before:w-4 before:rounded-full before:border before:border-white before:bg-black before:content-[""] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
+          'focus-visible:ring-brand-800 relative flex min-h-6 min-w-6 cursor-pointer items-center justify-center bg-transparent before:block before:h-4 before:w-4 before:rounded-full before:border before:border-white before:bg-black before:content-[""] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none',
           thumbClassName
         )}
       >
         {showValueLabel && (
-          <p className="absolute bottom-3 text-xs text-black/40">{displayValue}</p>
+          <p className="absolute bottom-3 text-xs text-black/60">{displayValue}</p>
         )}
       </SliderPrimitive.Thumb>
     </SliderPrimitive.Root>

--- a/src/components/ui/switch/index.tsx
+++ b/src/components/ui/switch/index.tsx
@@ -37,7 +37,7 @@ const SwitchRoot = ({
 }) => (
   <SwitchRadix.Root
     className={cn(className, {
-      'border-brand-800/20 data-[state=checked]:bg-brand-800 relative h-7.5 w-12 cursor-pointer rounded-full border-2 bg-transparent outline-none': true,
+      'border-brand-800/20 data-[state=checked]:bg-brand-800 relative h-7.5 w-12 cursor-pointer rounded-full border-2 bg-transparent': true,
       [SIZE['root'][size]]: true,
     })}
     {...props}

--- a/src/components/ui/switch/index.tsx
+++ b/src/components/ui/switch/index.tsx
@@ -73,15 +73,17 @@ const SwitchWrapper = ({ id, label, children, className }: WrapperProps) => {
     : children;
   return (
     <div className="flex items-center">
-      <label
+      {/* Not a <label htmlFor>: Radix renders Switch.Root as a <button>, which
+          is not a labelable element, so htmlFor bound to nothing. The name is
+          carried by aria-labelledby on the switch itself (see childWithId). */}
+      <span
         id={labelId}
         className={cn(className, {
           'sr-only pr-[15px] text-[15px] leading-none text-white': true,
         })}
-        htmlFor={id}
       >
         {label}
-      </label>
+      </span>
       {childWithId}
     </div>
   );

--- a/src/components/ui/tabs/index.tsx
+++ b/src/components/ui/tabs/index.tsx
@@ -87,7 +87,7 @@ function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPr
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"
-      className={cn('flex-1 text-sm outline-none', className)}
+      className={cn('flex-1 text-sm', className)}
       {...props}
     />
   );

--- a/src/components/ui/tabs/index.tsx
+++ b/src/components/ui/tabs/index.tsx
@@ -23,7 +23,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  'rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
+  'rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-black/60 inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col',
   {
     variants: {
       variant: {

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -55,7 +55,7 @@ const TimelineSlider = ({
                 style={{
                   left: `calc(12px + (100% - 24px) * ${i / Math.max(1, years.length - 1)})`,
                 }}
-                className="absolute top-1/2 flex min-h-6 min-w-6 -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center focus-visible:outline-none"
+                className="absolute top-1/2 flex min-h-6 min-w-6 -translate-x-1/2 -translate-y-1/2 cursor-pointer items-center"
               >
                 <span
                   aria-hidden="true"
@@ -100,7 +100,7 @@ const TimelineSlider = ({
                   transform: 'translateX(-50%)',
                 }}
                 className={cn(
-                  'inline-flex min-h-6 cursor-pointer items-center px-1 text-[12px] leading-5 whitespace-nowrap focus-visible:outline-none',
+                  'inline-flex min-h-6 cursor-pointer items-center px-1 text-[12px] leading-5 whitespace-nowrap',
                   isCurrent
                     ? 'text-brand-800 font-bold'
                     : 'font-normal text-black/56 hover:text-black/80'

--- a/src/components/ui/timeline-slider/index.tsx
+++ b/src/components/ui/timeline-slider/index.tsx
@@ -29,7 +29,7 @@ const TimelineSlider = ({
         aria-pressed={isPlaying}
         type="button"
         onClick={onTogglePlay}
-        className="border-brand-800 text-brand-800 hover:bg-brand-800/10 focus-visible:ring-ring flex h-[30px] w-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+        className="border-brand-800 text-brand-800 hover:bg-brand-800/10 focus-visible:ring-brand-800 flex h-[30px] w-[30px] shrink-0 cursor-pointer items-center justify-center rounded-full border-2 transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
       >
         {isPlaying ? (
           <PauseIcon aria-hidden="true" className="h-3.5 w-3.5" />

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -21,11 +21,20 @@ const Toaster = ({ icon = false, ...props }: ToasterProps & { icon?: boolean }) 
         !icon
           ? undefined
           : {
-              success: <CheckCircledIcon className="text-brand-800 size-4 fill-current" />,
-              info: <InfoCircledIcon className="bg-brand-800 size-4" />,
-              warning: <ExclamationTriangleIcon className="bg-brand-800 size-4" />,
-              error: <Cross1Icon className="bg-brand-800 size-4" />,
-              loading: <ReloadIcon className="bg-brand-800 size-4 animate-spin" />,
+              success: (
+                <CheckCircledIcon
+                  className="text-brand-800 size-4 fill-current"
+                  aria-hidden="true"
+                />
+              ),
+              info: <InfoCircledIcon className="bg-brand-800 size-4" aria-hidden="true" />,
+              warning: (
+                <ExclamationTriangleIcon className="bg-brand-800 size-4" aria-hidden="true" />
+              ),
+              error: <Cross1Icon className="bg-brand-800 size-4" aria-hidden="true" />,
+              loading: (
+                <ReloadIcon className="bg-brand-800 size-4 animate-spin" aria-hidden="true" />
+              ),
             }
       }
       style={

--- a/src/components/widget-controls/download.tsx
+++ b/src/components/widget-controls/download.tsx
@@ -75,7 +75,7 @@ const Download = ({ id, content }) => {
       </Helper>
       <DialogContent>
         <DialogTitle className="sr-only">Download Data</DialogTitle>
-        <div className="no-scrollbar w-120 overflow-y-auto">
+        <div className="no-scrollbar max-h-[80dvh] w-[min(30rem,calc(100vw-3rem))] overflow-y-auto">
           {id && <DownloadInfo />}
           {content && !id && (
             <div className="flex flex-col items-start justify-start space-y-4">

--- a/src/containers/alert/index.tsx
+++ b/src/containers/alert/index.tsx
@@ -94,11 +94,7 @@ const AnalysisAlert = () => {
                 onClick={() => setAnalysisAlert(false)}
                 aria-label="Reset analysis"
               >
-                <CLOSE_SVG
-                  className="absolute right-8 h-8 w-8 fill-current"
-                  role="img"
-                  title="Close"
-                />
+                <CLOSE_SVG className="absolute right-8 h-8 w-8 fill-current" aria-hidden="true" />
               </button>
             </div>
             <div className="flex flex-col space-y-5">

--- a/src/containers/auth/login-container.tsx
+++ b/src/containers/auth/login-container.tsx
@@ -44,9 +44,6 @@ export default function LoginPage() {
         style={{ backgroundImage: 'url(/images/login/image.webp)' }}
       >
         <div className="mx-24 max-w-xl space-y-6 text-white">
-          {/* Not a heading: this decorative hero precedes the page <h1> in
-              DOM order, so marking it up as one put an h2 before the h1. A
-              region's aria-labelledby can point at any text node. */}
           <p id="mrt-hero-title" className="text-6xl font-light">
             Welcome to Global Mangrove Watch
           </p>

--- a/src/containers/auth/login-container.tsx
+++ b/src/containers/auth/login-container.tsx
@@ -44,9 +44,12 @@ export default function LoginPage() {
         style={{ backgroundImage: 'url(/images/login/image.webp)' }}
       >
         <div className="mx-24 max-w-xl space-y-6 text-white">
-          <h2 id="mrt-hero-title" className="text-6xl font-light">
+          {/* Not a heading: this decorative hero precedes the page <h1> in
+              DOM order, so marking it up as one put an h2 before the h1. A
+              region's aria-labelledby can point at any text node. */}
+          <p id="mrt-hero-title" className="text-6xl font-light">
             Welcome to Global Mangrove Watch
-          </h2>
+          </p>
           <p className="text-sm leading-relaxed text-white">
             A coordinated effort across sectors and geographies will accomplish more, faster. Global
             Mangrove Watch is the evidence base informing the Global Mangrove Alliance, a

--- a/src/containers/auth/login-container.tsx
+++ b/src/containers/auth/login-container.tsx
@@ -65,10 +65,14 @@ export default function LoginPage() {
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-md px-4 pb-20">
+      <div className="mx-auto w-full max-w-md px-4 pb-20">
         <LandingNavigation />
         <div className="h-full">
-          <div className="flex h-full w-full flex-col justify-center space-y-10">
+          {/* The form column is the main content of this route, so the landmark
+              (and the root layout's skip target) sits here rather than around the
+              whole screen: the logo, the decorative hero and the landing nav are
+              not what someone skipping the chrome wants to land on. */}
+          <main id="main-content" className="flex h-full w-full flex-col justify-center space-y-10">
             <h1 className="text-brand-800 font-sans text-[40px] font-light">Log in</h1>
 
             {searchParams.get('verified') === 'pending' && (
@@ -83,9 +87,9 @@ export default function LoginPage() {
                 <FooterSignup />
               </div>
             </div>
-          </div>
+          </main>
         </div>
-      </section>
+      </div>
     </div>
   );
 }

--- a/src/containers/auth/login-form.tsx
+++ b/src/containers/auth/login-form.tsx
@@ -118,7 +118,7 @@ function LoginForm() {
                     type="email"
                     autoComplete="email"
                     placeholder="Enter your email"
-                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                   />
                 </FormControl>
                 <FormMessage />
@@ -140,7 +140,7 @@ function LoginForm() {
                     type="password"
                     autoComplete="current-password"
                     placeholder="Enter your password"
-                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                   />
                 </FormControl>
                 <FormMessage />

--- a/src/containers/categories-menu/index.tsx
+++ b/src/containers/categories-menu/index.tsx
@@ -97,8 +97,7 @@ const Category = () => {
                   {isSelected && (
                     <CHECK_SVG
                       className="h-full w-full fill-current p-px text-white"
-                      role="img"
-                      title="Checkmark"
+                      aria-hidden="true"
                     />
                   )}
                 </span>

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -126,8 +126,7 @@ const AlertsWidget = () => {
                   {selectedStartDate?.label}
                   <ARROW_SVG
                     className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </span>
               </PopoverTrigger>
@@ -170,8 +169,7 @@ const AlertsWidget = () => {
                   {selectedEndDate?.label}
                   <ARROW_SVG
                     className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </span>
               </PopoverTrigger>

--- a/src/containers/datasets/alerts/widget.tsx
+++ b/src/containers/datasets/alerts/widget.tsx
@@ -133,8 +133,10 @@ const AlertsWidget = () => {
 
               <PopoverContent className="shadow-border rounded-2xl px-2">
                 <ul className="z-20 max-h-56 space-y-0.5">
-                  {startDateOptions?.map((date) => (
-                    <li key={date?.label} className="last-of-type:pb-4">
+                  {/* Keyed by value + index: the label degrades to ", <year>" for any
+                      month the MONTHS lookup misses, which would repeat within a year. */}
+                  {startDateOptions?.map((date, i) => (
+                    <li key={`${date?.value}-${i}`} className="last-of-type:pb-4">
                       <button
                         aria-label="Select start date"
                         className={cn({
@@ -176,8 +178,8 @@ const AlertsWidget = () => {
 
               <PopoverContent className="shadow-border rounded-2xl px-2">
                 <ul className="z-20 max-h-56 space-y-0.5">
-                  {endDateOptions?.map((date) => (
-                    <li key={date?.label} className="last-of-type:pb-4">
+                  {endDateOptions?.map((date, i) => (
+                    <li key={`${date?.value}-${i}`} className="last-of-type:pb-4">
                       <button
                         aria-label="Select end date"
                         className={cn({

--- a/src/containers/datasets/carbon-market-potential/widget.tsx
+++ b/src/containers/datasets/carbon-market-potential/widget.tsx
@@ -54,8 +54,7 @@ const CarbonMarketPotentialWidget = () => {
                   {label}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </button>
               </PopoverTrigger>
@@ -97,8 +96,7 @@ const CarbonMarketPotentialWidget = () => {
                   {unit.label}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </button>
               </PopoverTrigger>

--- a/src/containers/datasets/contextual-layers/basemaps-planet/hooks.tsx
+++ b/src/containers/datasets/contextual-layers/basemaps-planet/hooks.tsx
@@ -22,13 +22,24 @@ type MosaicsResponse = {
   data?: Mosaics[];
 };
 
-const getDates = (data: Mosaics[] = []) =>
-  data
+// Mosaics collapse to month granularity, so two mosaics acquired in the same month
+// yield the same option `value` — an ambiguous Radix select value and a duplicate
+// React key. Keep the first of each month.
+const getDates = (data: Mosaics[] = []) => {
+  const seen = new Set<string>();
+
+  return data
     .filter((m) => m?.first_acquired)
     .map(({ first_acquired }) => ({
       value: format(new Date(first_acquired), 'yyyy-MM'),
       label: format(new Date(first_acquired), 'MMMM yyyy'),
-    }));
+    }))
+    .filter(({ value }) => {
+      if (seen.has(value)) return false;
+      seen.add(value);
+      return true;
+    });
+};
 
 type DateOption = { value: string; label: string };
 

--- a/src/containers/datasets/customize-widgets-deck/widget.tsx
+++ b/src/containers/datasets/customize-widgets-deck/widget.tsx
@@ -64,8 +64,7 @@ const CustomizeWidgetsDeck = () => {
                   {filteredWidgetsToDisplay.length} of {widgets.length - 1}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </span>
               </DialogTrigger>

--- a/src/containers/datasets/drawing-tool/index.tsx
+++ b/src/containers/datasets/drawing-tool/index.tsx
@@ -71,11 +71,7 @@ const WidgetDrawingTool = ({ menuItemStyle }: { menuItemStyle?: string }) => {
         data-testid="drawing-tool-button"
         disabled={!!uploadedGeojson}
       >
-        {isDrawingToolEnabled ? (
-          <DeleteDrawingButton size="sm" />
-        ) : (
-          <DRAW_SVG role="img" title="Draw area" />
-        )}
+        {isDrawingToolEnabled ? <DeleteDrawingButton size="sm" /> : <DRAW_SVG aria-hidden="true" />}
         <span
           className={cn({
             // Minimum width is customized to prevent layout shifts in the menu when the text changes.

--- a/src/containers/datasets/drawing-upload-tool/index.tsx
+++ b/src/containers/datasets/drawing-upload-tool/index.tsx
@@ -139,8 +139,18 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
     setMapCursor(isDrawingUploadToolEnabled ? 'cell' : 'grab');
   }, [setMapCursor, isDrawingUploadToolEnabled]);
 
+  // react-dropzone's root gets `tabIndex: 0` and `role: 'presentation'`, i.e. a
+  // focusable element with no role and no name — keyboard users land on it and
+  // hear nothing. The real <input type="file"> is `display: none`, so its label
+  // cannot name anything either. Naming the root as a button is what actually
+  // reaches assistive tech.
   const conditionalProps =
-    (!uploadedGeojson && !!customGeojson) || !isDrawingToolEnabled ? { ...getRootProps() } : {};
+    (!uploadedGeojson && !!customGeojson) || !isDrawingToolEnabled
+      ? getRootProps({
+          role: 'button',
+          'aria-label': uploadingFile ? 'Uploading shapefile' : 'Upload shapefile',
+        })
+      : {};
 
   return (
     <Helper
@@ -161,28 +171,24 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
               'cursor-default opacity-30': !!customGeojson || isDrawingToolEnabled,
             })}
           >
+            {/* The input carried no `id`, so both labels' `htmlFor` pointed at
+                nothing and the file input was unlabelled. They also shared one
+                `id`, duplicating it in the DOM. There is now a single label
+                bound to a real id, with the state in its text. */}
             <input
+              id="input-file-upload"
               data-testid="shapefile-upload"
               className="w-full"
               {...getInputProps()}
               disabled={isDrawingToolEnabled || !!customGeojson || !!uploadedGeojson}
             />
             <div className="flex flex-col items-center space-y-1">
-              <UPLOAD_SVG role="img" title="Upload" />
-              {!uploadingFile && (
-                <label id="label-file-upload" htmlFor="input-file-upload">
-                  <p className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">
-                    Shapefile
-                  </p>
-                </label>
-              )}
-              {uploadingFile && (
-                <label id="label-file-upload" htmlFor="input-file-upload">
-                  <p className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">
-                    ...uploading
-                  </p>
-                </label>
-              )}
+              <UPLOAD_SVG aria-hidden="true" />
+              <label id="label-file-upload" htmlFor="input-file-upload">
+                <p className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">
+                  {uploadingFile ? '...uploading' : 'Shapefile'}
+                </p>
+              </label>
             </div>
           </div>
         )}

--- a/src/containers/datasets/drawing-upload-tool/index.tsx
+++ b/src/containers/datasets/drawing-upload-tool/index.tsx
@@ -171,10 +171,6 @@ const WidgetDrawingUploadTool = ({ menuItemStyle }: { menuItemStyle?: string }) 
               'cursor-default opacity-30': !!customGeojson || isDrawingToolEnabled,
             })}
           >
-            {/* The input carried no `id`, so both labels' `htmlFor` pointed at
-                nothing and the file input was unlabelled. They also shared one
-                `id`, duplicating it in the DOM. There is now a single label
-                bound to a real id, with the state in its text. */}
             <input
               id="input-file-upload"
               data-testid="shapefile-upload"

--- a/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
+++ b/src/containers/datasets/fisheries/commercial-fisheries-production/widget.tsx
@@ -134,8 +134,7 @@ const CommercialFisheriesProduction = () => {
                 <SelectValue className="inline-flex w-fit" />
                 <ARROW_SVG
                   className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2"
-                  role="img"
-                  title="Arrow"
+                  aria-hidden="true"
                 />
               </SelectTrigger>
               <SelectContent
@@ -193,7 +192,6 @@ const CommercialFisheriesProduction = () => {
                     >
                       <IndicatorIcon
                         className="box-content h-6 w-6 rounded-md fill-current p-1"
-                        role="img"
                         aria-hidden={true}
                       />
                     </div>

--- a/src/containers/datasets/flood-protection/widget.tsx
+++ b/src/containers/datasets/flood-protection/widget.tsx
@@ -188,8 +188,7 @@ const FloodProtection = ({
                   {LABELS[selectedPeriod].short}
                   <ARROW_SVG
                     className="absolute -bottom-2.5 left-1/2 inline-block h-2 w-2 -translate-x-1/2 fill-current"
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </button>
               </PopoverTrigger>
@@ -243,8 +242,7 @@ const FloodProtection = ({
                 <TRIANGLE_SVG
                   className="absolute -top-7 h-5 w-5 fill-current"
                   style={{ left: trianglePosition }}
-                  role="img"
-                  title="Arrow"
+                  aria-hidden="true"
                 />
               )}
             </div>

--- a/src/containers/datasets/habitat-change/hooks.tsx
+++ b/src/containers/datasets/habitat-change/hooks.tsx
@@ -65,7 +65,8 @@ export function useMangroveHabitatChange(
   const { data, isFetched } = query;
   const noData = isFetched && !data?.data?.length;
 
-  const years = data?.metadata?.years;
+  // Deduped: both year selectors key their options by the year itself.
+  const years = data?.metadata?.years ? [...new Set(data.metadata.years)] : undefined;
   const unit = data?.metadata?.units?.[0]?.value || [];
   const currentStartYear = startYear || years?.[0];
   const currentEndYear = endYear || years?.[years?.length - 1];

--- a/src/containers/datasets/habitat-change/widget.tsx
+++ b/src/containers/datasets/habitat-change/widget.tsx
@@ -77,8 +77,7 @@ const HabitatExtent = () => {
                     {currentStartYear}
                     <TRIANGLE_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                      role="img"
-                      title="Arrow"
+                      aria-hidden="true"
                     />
                   </button>
                 </PopoverTrigger>
@@ -125,8 +124,7 @@ const HabitatExtent = () => {
                     {currentEndYear}
                     <TRIANGLE_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                      role="img"
-                      title="Arrow"
+                      aria-hidden="true"
                     />
                   </button>
                 </PopoverTrigger>
@@ -206,8 +204,7 @@ const HabitatExtent = () => {
                 'text-brand-800 inline-block h-2 w-2 fill-current': true,
                 'rotate-180 transform': limit === 10,
               })}
-              role="img"
-              title="Arrow"
+              aria-hidden="true"
             />
           </button>
         </div>

--- a/src/containers/datasets/habitat-extent/get-data.tsx
+++ b/src/containers/datasets/habitat-extent/get-data.tsx
@@ -29,7 +29,10 @@ export function getHabitatExtentData({
   widgetSlug,
 }: GetHabitatExtentDataArgs) {
   const metadata = data?.metadata;
-  const years = metadata?.year?.sort();
+  // Copy before sorting (`sort` would mutate the cached response), sort numerically
+  // (the default comparator is lexicographic) and drop repeats — a duplicate year
+  // reaches the selector, the timeline and the map sources as a duplicate key.
+  const years = metadata?.year ? [...new Set(metadata.year)].sort((a, b) => a - b) : undefined;
   const currentYear = year || years?.[years?.length - 1];
   const dataByYear = data?.data?.filter(({ year: y }) => y === currentYear);
   const dataParsed = dataByYear?.reduce(

--- a/src/containers/datasets/habitat-extent/widget.tsx
+++ b/src/containers/datasets/habitat-extent/widget.tsx
@@ -168,8 +168,7 @@ const HabitatExtent = () => {
                     {selectedUnitAreaExtent}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                      role="img"
-                      title="Arrow"
+                      aria-hidden="true"
                     />
                   </button>
                 </PopoverTrigger>
@@ -203,8 +202,7 @@ const HabitatExtent = () => {
                   {currentYear}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
-                    title="Arrow"
+                    aria-hidden="true"
                   />
                 </button>
               </PopoverTrigger>

--- a/src/containers/datasets/international-status/climate-watch/indicator/index.tsx
+++ b/src/containers/datasets/international-status/climate-watch/indicator/index.tsx
@@ -29,7 +29,7 @@ const Indicator = (indicator: IndicatorTypes) => {
         {info && (
           <Tooltip>
             <TooltipTrigger className="border-brand-800/20 text-brand-800 flex h-5 w-5 items-center justify-center rounded-full border-2">
-              <INFO_SVG className="h-3 w-3 shrink-0 fill-current" role="img" title="Info" />
+              <INFO_SVG className="h-3 w-3 shrink-0 fill-current" role="img" aria-label="Info" />
             </TooltipTrigger>
 
             <TooltipPortal>
@@ -58,7 +58,7 @@ const Indicator = (indicator: IndicatorTypes) => {
         </a>
       )}
       {!!check && (
-        <CheckIcon className="col-span-1 h-5 w-5 fill-current" role="img" title="Check" />
+        <CheckIcon className="col-span-1 h-5 w-5 fill-current" role="img" aria-label="Yes" />
       )}
     </div>
   );

--- a/src/containers/datasets/iucn-ecoregion/map-popup.tsx
+++ b/src/containers/datasets/iucn-ecoregion/map-popup.tsx
@@ -78,11 +78,11 @@ const IucnEcoregionPopup = ({ info }: { info: IUCNEcoregionPopUpInfo }) => {
   };
   return (
     <Collapsible onOpenChange={handleAnalytics}>
-      <CollapsibleTrigger className="min-w-[375px]" iconType="plus-minus">
+      <CollapsibleTrigger className="min-w-[min(375px,100%)]" iconType="plus-minus">
         <h3 className={WIDGET_SUBTITLE_STYLE}>IUCN ECOSYSTEM RED LIST ASSESSMENT</h3>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <div className="flex w-full min-w-[450px] flex-col space-y-2 border-none px-6 shadow-none">
+        <div className="flex w-full min-w-[min(450px,100%)] flex-col space-y-2 border-none px-6 shadow-none">
           <a
             className="text-brand-800 w-full text-right text-xs underline"
             target="_blank"

--- a/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
+++ b/src/containers/datasets/mangroves-in-protected-areas/widget.tsx
@@ -50,7 +50,6 @@ const MangrovesInProtectedAreas = () => {
                     {selectedUnit}
                     <ARROW_SVG
                       className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                      role="img"
                       aria-hidden={true}
                     />
                   </button>
@@ -93,7 +92,6 @@ const MangrovesInProtectedAreas = () => {
                   {selectedUnit}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
                     aria-hidden={true}
                   />
                 </button>

--- a/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
@@ -12,12 +12,13 @@ const UNIT_ARIA = {
 
 const IndicatorExtent = ({ unit, dataSource }: IndicatorExtentProps) => {
   if (!dataSource?.value) {
-    return <span />;
+    return <span role="cell" />;
   }
   const displayUnit = unit ? LABEL_UNITS[unit] || unit : '';
   const ariaUnit = unit ? UNIT_ARIA[unit] || unit : '';
   return (
     <span
+      role="cell"
       className="whitespace-nowrap"
       aria-label={`${numberFormat(dataSource.value)} ${ariaUnit}`.trim()}
     >

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -127,12 +127,12 @@ const IndicatorSources = ({
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
   return (
-    <div className={className}>
+    <div role="row" className={className}>
       <IndicatorSource source={source} color={color} />
       <IndicatorYear yearSelected={yearSelected} setYearSelected={setYearSelected} years={years} />
       <IndicatorExtent unit={unit} dataSource={dataSource} />
 
-      <div className="flex min-h-min justify-end space-x-2">
+      <div role="cell" className="flex min-h-min justify-end space-x-2">
         <WidgetControls
           content={{
             link: dataSource?.download_link ?? undefined,

--- a/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
@@ -1,7 +1,7 @@
 import type { IndicatorSourceProps } from './types';
 
 const IndicatorSource = ({ source, color }: IndicatorSourceProps) => (
-  <div className="flex w-full items-start space-x-2" aria-label={source}>
+  <div role="cell" className="flex w-full items-start space-x-2" aria-label={source}>
     <div
       style={{ backgroundColor: color }}
       className="mt-1 h-4 w-2 shrink-0 rounded-md"

--- a/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
@@ -9,7 +9,7 @@ import type { IndicatorYearProps } from './types';
 
 const IndicatorYear = ({ years, yearSelected, setYearSelected }: IndicatorYearProps) => {
   return (
-    <div>
+    <div role="cell">
       {years?.length === 1 && <span>{years?.[0]}</span>}
       {years?.length > 1 && (
         <Popover>

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -33,7 +33,7 @@ const SortableList = dynamic(() => import('@/components/map/legend/sortable/list
 });
 
 const iconBtn =
-  'inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+  'inline-flex h-7.5 w-7.5 items-center justify-center rounded-full text-black/60 hover:bg-black/5';
 
 type SourceRowProps = {
   id: string;
@@ -90,7 +90,7 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
       <button
         type="button"
         aria-label={`Reorder source ${name}`}
-        className="flex shrink-0 cursor-grab items-center justify-center text-black/42"
+        className="flex shrink-0 cursor-grab items-center justify-center text-black/60"
       >
         <DRAG_SVG aria-hidden={true} />
       </button>

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -125,6 +125,7 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
           >
             <Slider
               className="w-[150px] pt-2"
+              thumbAriaLabel={`Opacity of ${name}`}
               defaultValue={[parseFloat(layer.opacity)]}
               onValueChange={(op: number[]) => changeOpacity(op[0])}
             />

--- a/src/containers/datasets/national-dashboard/no-metadata.tsx
+++ b/src/containers/datasets/national-dashboard/no-metadata.tsx
@@ -15,7 +15,7 @@ import NO_DATA_SVG from '@/svgs/ui/no-data';
 const NoMetadata = () => {
   return (
     <div className="m-auto flex w-full max-w-full break-inside-avoid flex-col items-center justify-center space-y-4 rounded-3xl bg-white py-8">
-      <NO_DATA_SVG className="h-40 w-40 fill-current" role="img" title="No data" />
+      <NO_DATA_SVG className="h-40 w-40 fill-current" aria-hidden="true" />
       <p className="max-w-80 text-center font-sans text-lg leading-5 font-light sm:text-base sm:leading-6">
         No data available. Help us expand our coverage by submitting yours.
       </p>

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -66,7 +66,9 @@ const Sources = ({ data, iso }) => {
                 key={layerKey}
                 indicator={indicator}
                 source={source}
-                years={years}
+                // Deduped: the year selector keys its options by the year, and a
+                // repeated year would also turn a single-year source into a dropdown.
+                years={years ? [...new Set(years)] : years}
                 unit={unit}
                 data_source={data_source}
                 color={color}

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -27,12 +27,31 @@ const Sources = ({ data, iso }) => {
   return (
     <section className="space-y-6.25">
       {data?.map(({ indicator, sources }) => (
-        <div key={indicator}>
-          <div className={`${gridCols} py-2`}>
-            <h5 className="text-sm font-normal">Source</h5>
-            <h5 className="text-sm font-normal">Year</h5>
-            <h5 className="text-sm font-normal">Extent</h5>
-            <span />
+        /*
+         * ARIA table roles rather than <table> markup: the visual layout is a
+         * CSS grid whose cells are rendered by three separate components, and
+         * real table elements would force either display:contents on the cells
+         * (which drops them from the accessibility tree in some browsers) or a
+         * layout rewrite. The roles give screen readers row/column association
+         * with no rendering change at all.
+         *
+         * The column labels were <h5> elements — they are not headings, and
+         * they polluted the page outline with three entries per indicator.
+         */
+        <div key={indicator} role="table" aria-label={`${indicator} sources`}>
+          <div role="row" className={`${gridCols} py-2`}>
+            <span role="columnheader" className="text-sm font-normal">
+              Source
+            </span>
+            <span role="columnheader" className="text-sm font-normal">
+              Year
+            </span>
+            <span role="columnheader" className="text-sm font-normal">
+              Extent
+            </span>
+            <span role="columnheader" className="sr-only">
+              Layer controls
+            </span>
           </div>
           {sources.map(({ source, years, unit, data_source }) => {
             const colorIndex = sourceColorMap.get(source) ?? 0;

--- a/src/containers/datasets/net-change/widget.tsx
+++ b/src/containers/datasets/net-change/widget.tsx
@@ -155,7 +155,6 @@ const NetChangeWidget = () => {
                   {selectedUnit}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
                     aria-hidden={true}
                   />
                 </button>
@@ -198,7 +197,6 @@ const NetChangeWidget = () => {
                   {currentStartYear}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
                     aria-hidden={true}
                   />
                 </button>
@@ -235,7 +233,6 @@ const NetChangeWidget = () => {
                   {currentEndYear}
                   <ARROW_SVG
                     className={`fill-current ${WIDGET_SELECT_ARROW_STYLES}`}
-                    role="img"
                     aria-hidden={true}
                   />
                 </button>

--- a/src/containers/datasets/restoration/fisheries/widget.tsx
+++ b/src/containers/datasets/restoration/fisheries/widget.tsx
@@ -37,7 +37,8 @@ const PotentialBenefitsToFisheries = () => {
         <div className="space-y-4">
           <h3 className="text-xs uppercase">potential benefits to fisheries</h3>
           <p className={WIDGET_SENTENCE_STYLE}>
-            Mangrove restoration enhanced the production of new individuals for commercial purposes:{' '}
+            Mangrove restoration enhanced the production of new individuals for commercial
+            purposes:{' '}
           </p>
           <div className="grid flex-1 grid-cols-2 flex-col items-center gap-2 pb-10">
             {data?.map(({ indicator, value }) => {
@@ -55,7 +56,6 @@ const PotentialBenefitsToFisheries = () => {
                       className={cn({
                         'box-content h-6 w-6 rounded-md fill-current p-1': true,
                       })}
-                      role="img"
                       aria-hidden={true}
                     />
                   </div>

--- a/src/containers/datasets/restoration/map-legend.tsx
+++ b/src/containers/datasets/restoration/map-legend.tsx
@@ -5,7 +5,11 @@ const RestorationMapLegend = () => (
       <p>100%</p>
     </div>
 
+    {/* The bar carried no name: only the two end labels were exposed, with
+        nothing saying what the colour ramp between them means. */}
     <div
+      role="img"
+      aria-label="Restoration potential, from 0% (lightest) to 100% (darkest)"
       className="h-3 w-full border"
       style={{
         background:

--- a/src/containers/datasets/restoration/map-legend.tsx
+++ b/src/containers/datasets/restoration/map-legend.tsx
@@ -5,8 +5,6 @@ const RestorationMapLegend = () => (
       <p>100%</p>
     </div>
 
-    {/* The bar carried no name: only the two end labels were exposed, with
-        nothing saying what the colour ramp between them means. */}
     <div
       role="img"
       aria-label="Restoration potential, from 0% (lightest) to 100% (darkest)"

--- a/src/containers/datasets/restoration/map-popup/sections/restoration-scores.tsx
+++ b/src/containers/datasets/restoration/map-popup/sections/restoration-scores.tsx
@@ -21,7 +21,7 @@ const RestorationScores = ({ data }: { data: RestorationPopUp }) => {
   };
 
   return (
-    <Collapsible className="w-full min-w-[450px]" onOpenChange={handleAnalytics}>
+    <Collapsible className="w-full min-w-[min(450px,100%)]" onOpenChange={handleAnalytics}>
       <CollapsibleTrigger iconType="plus-minus">
         <h3 className={WIDGET_SUBTITLE_STYLE}>RESTORATION SCORES</h3>
       </CollapsibleTrigger>

--- a/src/containers/datasets/restoration/overview/mean-restoration/chart.tsx
+++ b/src/containers/datasets/restoration/overview/mean-restoration/chart.tsx
@@ -30,7 +30,6 @@ const RestorationOverviewChart = ({
       >
         <TRIANGLE_SVG
           className="absolute -top-5 left-1/2 inline-block h-4 w-5 -translate-x-1/2 fill-current"
-          role="img"
           aria-hidden={true}
           style={{ left: !!trianglePosition && trianglePosition }}
         />

--- a/src/containers/datasets/species-distribution/map-legend.tsx
+++ b/src/containers/datasets/species-distribution/map-legend.tsx
@@ -9,7 +9,10 @@ const SpeciesDistributionMapLegend = () => {
         <p>{legend[0]}</p>
         <p>{legend[2]}</p>
       </div>
+      {/* The bar carried no name — see restoration/map-legend.tsx. */}
       <div
+        role="img"
+        aria-label={`Species distribution, from ${legend[0]} (lightest) to ${legend[2]} (darkest)`}
         className="h-3 w-full border"
         style={{
           background:

--- a/src/containers/datasets/species-distribution/map-legend.tsx
+++ b/src/containers/datasets/species-distribution/map-legend.tsx
@@ -9,7 +9,6 @@ const SpeciesDistributionMapLegend = () => {
         <p>{legend[0]}</p>
         <p>{legend[2]}</p>
       </div>
-      {/* The bar carried no name — see restoration/map-legend.tsx. */}
       <div
         role="img"
         aria-label={`Species distribution, from ${legend[0]} (lightest) to ${legend[2]} (darkest)`}

--- a/src/containers/datasets/species-distribution/widget.tsx
+++ b/src/containers/datasets/species-distribution/widget.tsx
@@ -70,7 +70,6 @@ const SpeciesDistribution = () => {
             {!isWorldwide && (
               <TRIANGLE_SVG
                 className="absolute -top-7 h-5 w-5 fill-current"
-                role="img"
                 aria-hidden={true}
                 style={{ left: trianglePosition ? trianglePosition : 0 }}
               />

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -170,7 +170,12 @@ const SpeciesLocation = () => {
                           { 'border-brand-800 border-4': isSelected }
                         )}
                       >
-                        {isSelected && <RadioCheckIcon className="text-brand-800 h-2.5 w-2.5" />}
+                        {isSelected && (
+                          <RadioCheckIcon
+                            className="text-brand-800 h-2.5 w-2.5"
+                            aria-hidden="true"
+                          />
+                        )}
                       </span>
                       <span className="text-brand-800 text-sm leading-none font-semibold">
                         {specie.label}

--- a/src/containers/datasets/species-location/widget.tsx
+++ b/src/containers/datasets/species-location/widget.tsx
@@ -7,8 +7,6 @@ import { SpeciesLocationState } from '@/store/widgets/species-location';
 
 import type { PrimitiveAtom } from 'jotai';
 import { useAtom } from 'jotai';
-import { CgRadioCheck } from 'react-icons/cg';
-import type { IconBaseProps } from 'react-icons/lib';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
@@ -29,8 +27,6 @@ import { WIDGET_CARD_WRAPPER_STYLE, WIDGET_SENTENCE_STYLE } from '@/styles/widge
 
 import { useMangroveSpeciesLocation } from './hooks';
 import type { DataResponse, Specie } from './types';
-
-const RadioCheckIcon = CgRadioCheck as unknown as (p: IconBaseProps) => JSX.Element;
 
 const SpeciesLocation = () => {
   const { type: locationType, id } = useSyncLocation();
@@ -161,25 +157,18 @@ const SpeciesLocation = () => {
                       key={specie.value}
                       value={specie.value}
                       onSelect={() => onSelectSpecies(specie.value)}
-                      className="flex cursor-pointer items-center space-x-4 py-1"
+                      className="flex cursor-pointer items-center gap-2.5 py-1"
                     >
                       <span
                         aria-hidden="true"
                         className={cn(
-                          'flex h-3 w-3 shrink-0 items-center justify-center rounded-full border border-black/85',
-                          { 'border-brand-800 border-4': isSelected }
+                          'border-grey-400 flex size-5 shrink-0 items-center justify-center rounded-full border bg-white',
+                          { 'border-brand-800 border-2': isSelected }
                         )}
                       >
-                        {isSelected && (
-                          <RadioCheckIcon
-                            className="text-brand-800 h-2.5 w-2.5"
-                            aria-hidden="true"
-                          />
-                        )}
+                        {isSelected && <span className="bg-brand-800 size-2.5 rounded-full" />}
                       </span>
-                      <span className="text-brand-800 text-sm leading-none font-semibold">
-                        {specie.label}
-                      </span>
+                      <span className="text-sm leading-5 text-black/85">{specie.label}</span>
                     </CommandItem>
                   );
                 })}

--- a/src/containers/datasets/species-threatened/legend.tsx
+++ b/src/containers/datasets/species-threatened/legend.tsx
@@ -32,7 +32,7 @@ const Legend = ({ items }: Legend) => {
                   <span className="whitespace-nowrap text-black/85">{d.label}</span>
                   <ARROW_SVG
                     className={cn({
-                      'text-grey-400 w-3 fill-current': true,
+                      'text-grey-600 w-3 fill-current': true,
                       'rotate-180': !!collapse[d.label],
                     })}
                     role="img"
@@ -44,8 +44,7 @@ const Legend = ({ items }: Legend) => {
                   <ul
                     style={{ maxHeight: !!collapse[d.label] ? 85 : 0 }}
                     className={cn({
-                      'text-brand-800 w-fit overflow-y-auto px-4 py-1 font-bold italic underline':
-                        true,
+                      'text-brand-800 w-fit overflow-y-auto px-4 py-1 font-bold italic underline': true,
                       'py-0': !collapse[d.label],
                     })}
                   >

--- a/src/containers/datasets/species-threatened/legend.tsx
+++ b/src/containers/datasets/species-threatened/legend.tsx
@@ -41,7 +41,9 @@ const Legend = ({ items }: Legend) => {
 
                 {
                   <ul
-                    style={{ maxHeight: !!collapse[d.label] ? 85 : 0 }}
+                    // rem, not px: an inline pixel cap does not grow when the
+                    // user increases text size, so the list clipped at 200% zoom.
+                    style={{ maxHeight: !!collapse[d.label] ? '5.3125rem' : 0 }}
                     className={cn({
                       'text-brand-800 w-fit overflow-y-auto px-4 py-1 font-bold italic underline': true,
                       'py-0': !collapse[d.label],

--- a/src/containers/datasets/species-threatened/legend.tsx
+++ b/src/containers/datasets/species-threatened/legend.tsx
@@ -35,7 +35,6 @@ const Legend = ({ items }: Legend) => {
                       'text-grey-600 w-3 fill-current': true,
                       'rotate-180': !!collapse[d.label],
                     })}
-                    role="img"
                     aria-hidden={true}
                   />
                 </button>

--- a/src/containers/embedded/wrapper/index.tsx
+++ b/src/containers/embedded/wrapper/index.tsx
@@ -6,8 +6,12 @@ import EmbeddedMap from '@/containers/embedded/map';
 
 export default function EmbeddedWrapper() {
   return (
-    <Suspense>
-      <EmbeddedMap mapId="embedded" />
-    </Suspense>
+    // id="main-content" is the target of the root layout's skip link, which is
+    // rendered on every route including this one.
+    <main id="main-content" className="h-full w-full">
+      <Suspense>
+        <EmbeddedMap mapId="embedded" />
+      </Suspense>
+    </main>
   );
 }

--- a/src/containers/help/helper/index.tsx
+++ b/src/containers/help/helper/index.tsx
@@ -120,7 +120,10 @@ const Helper = ({
             aria-label="Show help for this control"
             aria-expanded={popOver}
             className={cn({
-              'focus-visible:ring-brand-800 absolute flex h-5 w-5 items-center justify-center rounded-full focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none': true,
+              // 20x20 visually, but absolutely positioned, so it cannot rely on the
+              // spacing exemption in WCAG 2.2 2.5.8. The ::before pseudo-element
+              // extends the hit area to 24x24 without changing the visual size.
+              'focus-visible:ring-brand-800 absolute flex h-5 w-5 items-center justify-center rounded-full before:absolute before:-inset-[2px] before:content-[""] focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none': true,
               [className.button]: !!className.button,
               'pointer-events-none': popOver,
             })}

--- a/src/containers/help/index.tsx
+++ b/src/containers/help/index.tsx
@@ -70,7 +70,7 @@ const HelpContainer = ({
               className
             )}
           >
-            <HELP_ICON className="h-8 w-8" />
+            <HELP_ICON className="h-8 w-8" aria-hidden="true" />
             <span className="text-xxs font-sans leading-none">Help</span>
           </PopoverTrigger>
         ) : (
@@ -78,9 +78,9 @@ const HelpContainer = ({
             data-testid="guide-button"
             className={cn('flex cursor-pointer items-center space-x-2', THEME[theme], className)}
           >
-            <HELP_ICON className="h-6 w-6" />
+            <HELP_ICON className="h-6 w-6" aria-hidden="true" />
             <p className="font-sans text-sm">Help</p>
-            {hasArrow && <CHEVRON_ICON role="img" className="h-4 w-4" />}
+            {hasArrow && <CHEVRON_ICON aria-hidden="true" className="h-4 w-4" />}
           </PopoverTrigger>
         )}
 

--- a/src/containers/help/index.tsx
+++ b/src/containers/help/index.tsx
@@ -65,7 +65,7 @@ const HelpContainer = ({
             data-testid="guide-button-mobile"
             aria-label="Help"
             className={cn(
-              'flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none',
+              'flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white',
               THEME[theme],
               className
             )}

--- a/src/containers/legend/index.tsx
+++ b/src/containers/legend/index.tsx
@@ -33,10 +33,12 @@ const Legend = ({ title, subtitle, items, variant = 'vertical' }: LegendTypes) =
         </h3>
       )}
       {/* opacity-30 put this subtitle at ~1.9:1. black/60 is 5.7:1. */}
+      {/* Was an <h2> immediately after the <h3> above, i.e. the level went
+          backwards. It is a subtitle of that title, so h4. */}
       {subtitle && (
-        <h2 className="flex max-w-[120px] flex-col justify-center text-sm font-bold text-black/60">
+        <h4 className="flex max-w-[120px] flex-col justify-center text-sm font-bold text-black/60">
           {subtitle}
-        </h2>
+        </h4>
       )}
       {items?.map(
         ({

--- a/src/containers/legend/index.tsx
+++ b/src/containers/legend/index.tsx
@@ -32,8 +32,9 @@ const Legend = ({ title, subtitle, items, variant = 'vertical' }: LegendTypes) =
           {title}
         </h3>
       )}
+      {/* opacity-30 put this subtitle at ~1.9:1. black/60 is 5.7:1. */}
       {subtitle && (
-        <h2 className="flex max-w-[120px] flex-col justify-center text-sm font-bold opacity-30">
+        <h2 className="flex max-w-[120px] flex-col justify-center text-sm font-bold text-black/60">
           {subtitle}
         </h2>
       )}

--- a/src/containers/location-widget/index.tsx
+++ b/src/containers/location-widget/index.tsx
@@ -81,10 +81,6 @@ const LocationWidget = () => {
   return (
     <>
       <div className="bg-brand-600 shadow-control relative flex h-52 flex-col justify-between rounded-3xl bg-[url(/images/location-bg.svg)] bg-cover bg-center text-center">
-        {/* The <h1> sits outside the button: a heading inside an interactive
-            control is not exposed as a heading, and the page had no h1 at all
-            until the location query resolved (the fallback was a bare skeleton
-            div). It now always renders, with a placeholder while loading. */}
         <h1 className="contents">
           <button
             type="button"

--- a/src/containers/location-widget/index.tsx
+++ b/src/containers/location-widget/index.tsx
@@ -81,33 +81,43 @@ const LocationWidget = () => {
   return (
     <>
       <div className="bg-brand-600 shadow-control relative flex h-52 flex-col justify-between rounded-3xl bg-[url(/images/location-bg.svg)] bg-cover bg-center text-center">
-        <button
-          type="button"
-          onClick={handleOnClickTitle}
-          disabled={isGuideActive || !locationName}
-        >
-          {!!locationName ? (
-            <div
-              className={cn({
-                'inline-block flex-1 grow cursor-pointer px-10 pt-8 text-6xl font-light text-black/85 first-letter:uppercase': true,
-                'text-2.75xl': width >= 540,
+        {/* The <h1> sits outside the button: a heading inside an interactive
+            control is not exposed as a heading, and the page had no h1 at all
+            until the location query resolved (the fallback was a bare skeleton
+            div). It now always renders, with a placeholder while loading. */}
+        <h1 className="contents">
+          <button
+            type="button"
+            onClick={handleOnClickTitle}
+            disabled={isGuideActive || !locationName}
+          >
+            {!!locationName ? (
+              <div
+                className={cn({
+                  'inline-block flex-1 grow cursor-pointer px-10 pt-8 text-6xl font-light text-black/85 first-letter:uppercase': true,
+                  'text-2.75xl': width >= 540,
 
-                'text-5xl': locationName.length > 10,
-                'text-3xl': locationName.length > 30 && locationName.length <= 55,
-                'text-2xl': locationName.length > 55 && locationName.length <= 120,
-                'text-base break-all': locationName.length > 120,
-              })}
-            >
-              <h1 className="cursor-pointer text-white" ref={titleRef}>
-                {locationName}
-              </h1>
-            </div>
-          ) : (
-            !locationName && (
-              <div className="bg-secondary-900 h-[20px] w-[100px] animate-pulse rounded-md" />
-            )
-          )}
-        </button>
+                  'text-5xl': locationName.length > 10,
+                  'text-3xl': locationName.length > 30 && locationName.length <= 55,
+                  'text-2xl': locationName.length > 55 && locationName.length <= 120,
+                  'text-base break-all': locationName.length > 120,
+                })}
+              >
+                <span className="cursor-pointer text-white" ref={titleRef}>
+                  {locationName}
+                </span>
+              </div>
+            ) : (
+              <>
+                <span className="sr-only">Loading location</span>
+                <div
+                  aria-hidden="true"
+                  className="bg-secondary-900 h-[20px] w-[100px] animate-pulse rounded-md"
+                />
+              </>
+            )}
+          </button>
+        </h1>
         <MenuTools />
       </div>
       <AnalysisAlert />

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
 import { AutoSizer, CellMeasurer, CellMeasurerCache, List, Parent, Style } from 'react-virtualized';
 
@@ -55,10 +55,17 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
   } = useLocations({ select: ({ data }) => data });
   const searchResults = useSearch(locations, searchValue, ['name', 'iso', 'location_type']);
   const locationsToDisplay = searchValue === '' ? locations : searchResults;
-  const cache = new CellMeasurerCache({
-    fixedWidth: true,
-    defaultHeight: 100,
-  });
+  // A fresh cache on every render discards all measured row heights, so the next
+  // render re-measures and the rows shift. That shift lands between a click's
+  // mousedown and mouseup and the click is lost — see the focus guard below.
+  const cache = useMemo(
+    () =>
+      new CellMeasurerCache({
+        fixedWidth: true,
+        defaultHeight: 100,
+      }),
+    []
+  );
 
   const handleLocation = useCallback(
     (location: Location) => {
@@ -247,7 +254,12 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
                     : undefined
                 }
                 onKeyDown={handleListKeyDown}
-                onFocus={() => {
+                // React's onFocus is focusin, which bubbles: pressing the mouse on an
+                // option focuses that option and would activate the keyboard cursor
+                // here, re-rendering the list (scrollToIndex) before mouseup and
+                // swallowing the click. Only a Tab onto the listbox itself counts.
+                onFocus={(e) => {
+                  if (e.target !== e.currentTarget) return;
                   if (focusedIndex < 0) setFocusedIndex(0);
                 }}
                 // The listbox holds DOM focus while `aria-activedescendant`

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -143,8 +143,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
               aria-disabled={locationId === locationsToDisplay[index].id || undefined}
               tabIndex={-1}
               className={cn({
-                'hover:bg-brand-800/10 flex h-full w-full flex-1 cursor-pointer items-center justify-between px-4 py-1 hover:rounded-2xl':
-                  true,
+                'hover:bg-brand-800/10 flex h-full w-full flex-1 cursor-pointer items-center justify-between px-4 py-1 hover:rounded-2xl': true,
                 'pointer-events-none': locationId === locationsToDisplay[index].id,
                 'bg-brand-800/5 border-brand-800 rounded-2xl border-2': focusedIndex === index,
               })}
@@ -167,7 +166,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
               >
                 {locationsToDisplay[index].name}
               </p>
-              <span className="text-grey-800 text-opacity-90 text-xs">
+              <span className="text-grey-600 text-xs">
                 {locationNames[locationsToDisplay[index].location_type]}
               </span>
             </button>

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -220,11 +220,7 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
             className="absolute top-1/2 right-6 flex -translate-y-1/2 cursor-pointer items-center"
             onClick={() => setSearchValue('')}
           >
-            <CLOSE_SVG
-              className="h-5 w-5 transform fill-current opacity-50"
-              role="img"
-              aria-hidden={true}
-            />
+            <CLOSE_SVG className="h-5 w-5 transform fill-current opacity-50" aria-hidden={true} />
           </button>
         )}
       </div>

--- a/src/containers/locations-list/index.tsx
+++ b/src/containers/locations-list/index.tsx
@@ -254,6 +254,10 @@ const LocationsList = ({ onSelectLocation }: { onSelectLocation?: () => void }) 
                 onFocus={() => {
                   if (focusedIndex < 0) setFocusedIndex(0);
                 }}
+                // The listbox holds DOM focus while `aria-activedescendant`
+                // moves the active option. Suppressing the container outline is
+                // correct here *because* the active option carries its own
+                // visible indicator (border-2 border-brand-800, see renderRow).
                 className="focus:outline-none"
                 style={{ width, height }}
               >

--- a/src/containers/main-app/index.tsx
+++ b/src/containers/main-app/index.tsx
@@ -40,14 +40,17 @@ export default function MainApp() {
         <MobileLayout />
       </Media>
 
-      <main id="main-content" className="pointer-events-none relative h-screen w-screen">
+      <div className="pointer-events-none relative h-screen w-screen">
         {/* h-full is required: the widgets layout scrolls internally
             (h-full + overflow-y-auto) and needs a definite-height parent —
             without it the list grows to content height and mobile can't scroll. */}
-        <div className={cn('h-full', { 'hidden lg:block': mapView })}>
+        {/* A labelled region, not the main landmark: main lives in the route
+            layout around the map (see src/app/[[...params]]/layout.tsx). The
+            label lets screen-reader users jump to the widget list directly. */}
+        <section aria-label="Widgets" className={cn('h-full', { 'hidden lg:block': mapView })}>
           <WidgetsContainer />
-        </div>
-      </main>
+        </section>
+      </div>
 
       <WelcomeIntroMessage />
     </>

--- a/src/containers/map/delete-drawing-button/index.tsx
+++ b/src/containers/map/delete-drawing-button/index.tsx
@@ -43,12 +43,15 @@ const DeleteDrawingButton = ({
           [SIZE[size]]: true,
         })}
       >
-        <button onClick={handleResetPage} data-testid="delete-custom-area-button">
-          <REMOVE_SVG
-            className="h-3.5 w-3.5 fill-current text-white"
-            role="img"
-            aria-hidden={true}
-          />
+        {/* The only child is aria-hidden, so without an explicit label this
+            button had no accessible name at all. */}
+        <button
+          type="button"
+          onClick={handleResetPage}
+          aria-label="Delete custom area"
+          data-testid="delete-custom-area-button"
+        >
+          <REMOVE_SVG className="h-3.5 w-3.5 fill-current text-white" aria-hidden={true} />
         </button>
       </div>
     </div>

--- a/src/containers/map/delete-drawing-button/index.tsx
+++ b/src/containers/map/delete-drawing-button/index.tsx
@@ -43,8 +43,6 @@ const DeleteDrawingButton = ({
           [SIZE[size]]: true,
         })}
       >
-        {/* The only child is aria-hidden, so without an explicit label this
-            button had no accessible name at all. */}
         <button
           type="button"
           onClick={handleResetPage}

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -636,8 +636,6 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
                 >
                   <button
                     type="button"
-                    // The name came from the image alt, which described the
-                    // graphic rather than what activating the button does.
                     aria-label="Remove map marker"
                     onClick={(e) => {
                       e.stopPropagation();

--- a/src/containers/map/index.tsx
+++ b/src/containers/map/index.tsx
@@ -636,6 +636,9 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
                 >
                   <button
                     type="button"
+                    // The name came from the image alt, which described the
+                    // graphic rather than what activating the button does.
+                    aria-label="Remove map marker"
                     onClick={(e) => {
                       e.stopPropagation();
                       setCoordinates(null);
@@ -643,7 +646,7 @@ const MapContainer = ({ mapId, hideControls }: { mapId: string; hideControls?: b
                       setPin(false);
                     }}
                   >
-                    <Image src="/images/MapMarker.png" alt="Map Marker" width={24} height={40} />
+                    <Image src="/images/MapMarker.png" alt="" width={24} height={40} />
                   </button>
                 </Marker>
               )}

--- a/src/containers/map/legend/index.tsx
+++ b/src/containers/map/legend/index.tsx
@@ -36,8 +36,7 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
             onClick={openLegend}
             data-testid="show-legend-button"
             className={cn({
-              'shadow-control flex h-11 cursor-pointer items-center justify-center space-x-2 rounded-3xl bg-white px-5 py-2':
-                true,
+              'shadow-control flex h-11 cursor-pointer items-center justify-center space-x-2 rounded-3xl bg-white px-5 py-2': true,
               hidden: isOpen,
             })}
           >
@@ -45,7 +44,7 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
               Show legend
             </p>
 
-            <FaArrowUpIcon className="mb-1" />
+            <FaArrowUpIcon className="mb-1" aria-hidden="true" />
           </button>
 
           <AnimatePresence>
@@ -74,10 +73,12 @@ const Legend = ({ embedded = false }: { embedded?: boolean }) => {
                 </div>
 
                 <button
+                  type="button"
                   onClick={closeLegend}
+                  aria-label="Close legend"
                   className="absolute -top-8 right-5 -z-10 rounded-t-3xl bg-white p-2"
                 >
-                  <FaArrowDownIcon />
+                  <FaArrowDownIcon aria-hidden="true" />
                 </button>
               </motion.div>
             )}

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -5,6 +5,8 @@ import cn from '@/lib/classnames';
 import { activeGuideAtom } from '@/store/guide';
 import { useSyncActiveLayers } from '@/store/layers';
 
+import type { DraggableAttributes } from '@dnd-kit/core';
+import type { SyntheticListenerMap } from '@dnd-kit/core/dist/hooks/utilities';
 import { DialogTitle } from '@radix-ui/react-dialog';
 import { useAtomValue } from 'jotai';
 
@@ -26,7 +28,23 @@ import LegendControls from '../legend-controls';
 
 const NATIONAL_DASHBOARD_PREFIX = 'mangrove_national_dashboard_layer_';
 
-const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolean; l: Layer }) => {
+const LegendItem = ({
+  id,
+  embedded = false,
+  l,
+  listeners,
+  attributes,
+  setActivatorNodeRef,
+}: {
+  id: string;
+  embedded?: boolean;
+  l: Layer;
+  // Injected by SortableItem. The drag activator belongs on the handle button
+  // below, not on the wrapper around the item's other controls.
+  listeners?: SyntheticListenerMap;
+  attributes?: DraggableAttributes;
+  setActivatorNodeRef?: (element: HTMLElement | null) => void;
+}) => {
   const [statisticsDialogVisibility, setStatisticsDialogVisibility] = useState(false);
   const [activeLayers] = useSyncActiveLayers();
   const guideIsActive = useAtomValue(activeGuideAtom);
@@ -80,8 +98,11 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
             {!embedded && (
               <button
                 type="button"
+                ref={setActivatorNodeRef}
                 aria-label="Drag to reorder"
                 className="flex min-h-6 min-w-6 cursor-grab items-center justify-center active:cursor-grabbing"
+                {...attributes}
+                {...listeners}
               >
                 <DRAG_SVG aria-hidden="true" />
               </button>

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -111,7 +111,7 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
 
             <DialogContent
               className={cn({
-                'h-screen w-screen min-w-135 md:mb-20 md:h-auto md:w-auto': true,
+                'h-screen w-screen min-w-[min(33.75rem,100%)] md:mb-20 md:h-auto md:w-auto': true,
                 hidden: guideIsActive,
               })}
               overlay={false}

--- a/src/containers/map/legend/item/index.tsx
+++ b/src/containers/map/legend/item/index.tsx
@@ -83,7 +83,7 @@ const LegendItem = ({ id, embedded = false, l }: { id: string; embedded?: boolea
                 aria-label="Drag to reorder"
                 className="flex min-h-6 min-w-6 cursor-grab items-center justify-center active:cursor-grabbing"
               >
-                <DRAG_SVG role="img" title="Order layer" />
+                <DRAG_SVG aria-hidden="true" />
               </button>
             )}
           </Media>

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -219,6 +219,7 @@ const LegendControls = ({
           >
             <Slider
               className="w-[150px] pt-2"
+              thumbAriaLabel={`Opacity of ${layerNameToDisplay ?? 'layer'}`}
               defaultValue={[parseFloat(l.opacity)]}
               onValueChange={(op: number[]) => onChangeOpacity(op[0], l.id)}
             />

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -144,14 +144,14 @@ const LegendControls = ({
   if (l.id === 'custom-area') return null;
 
   const iconBtn = compact
-    ? 'inline-flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full text-black/42 hover:bg-black/5'
-    : 'inline-flex h-7.5 w-7.5 cursor-pointer items-center justify-center rounded-full text-black/42 hover:bg-black/5';
+    ? 'inline-flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full text-black/60 hover:bg-black/5'
+    : 'inline-flex h-7.5 w-7.5 cursor-pointer items-center justify-center rounded-full text-black/60 hover:bg-black/5';
   const opacityIconCls = compact ? 'h-4 w-4' : 'h-6.5 w-6.5';
   const showHideIconCls = compact ? 'h-5 w-5' : 'h-7 w-7';
   const closeIconCls = compact ? 'h-3 w-3' : '';
   const infoBtnCls = compact
-    ? 'mr-1 flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-black/42 text-black/42'
-    : 'mr-1 flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-black/42 text-black/42';
+    ? 'mr-1 flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-black/60 text-black/60'
+    : 'mr-1 flex min-h-6 min-w-6 cursor-pointer items-center justify-center rounded-full border-[1.5px] border-black/60 text-black/60';
   const infoIconCls = compact ? 'h-2 w-2 fill-current' : 'h-3 w-3 fill-current';
 
   return (

--- a/src/containers/map/legend/legend-controls/index.tsx
+++ b/src/containers/map/legend/legend-controls/index.tsx
@@ -165,12 +165,7 @@ const LegendControls = ({
                 onClick={() => setInfoDialogVisibility(!infoDialogVisibility)}
               >
                 <button type="button" aria-label="Layer info" className={infoBtnCls}>
-                  <INFO_SVG
-                    className={infoIconCls}
-                    role="img"
-                    aria-hidden={true}
-                    aria-label="Info layer"
-                  />
+                  <INFO_SVG className={infoIconCls} aria-hidden={true} />
                 </button>
               </TooltipTrigger>
               <TooltipPortal>

--- a/src/containers/map/legend/mobile/index.tsx
+++ b/src/containers/map/legend/mobile/index.tsx
@@ -34,8 +34,14 @@ const Legend = () => {
           <span className="group-data-[state=open]:hidden">Show legend</span>
           <span className="group-data-[state=closed]:hidden">Hide legend</span>
         </p>
-        <FaArrowUpIcon className="shrink-0 text-black/85 group-data-[state=open]:hidden" />
-        <FaArrowDownIcon className="shrink-0 text-black/85 group-data-[state=closed]:hidden" />
+        <FaArrowUpIcon
+          className="shrink-0 text-black/85 group-data-[state=open]:hidden"
+          aria-hidden="true"
+        />
+        <FaArrowDownIcon
+          className="shrink-0 text-black/85 group-data-[state=closed]:hidden"
+          aria-hidden="true"
+        />
       </CollapsibleTrigger>
 
       <CollapsibleContent

--- a/src/containers/map/pop-up/pop-up-controls/close.tsx
+++ b/src/containers/map/pop-up/pop-up-controls/close.tsx
@@ -15,7 +15,7 @@ const MapPopupClose = ({ handleClose }: MapPopupCloseProps) => {
         <button
           type="button"
           aria-label="Close popup"
-          className="inline-flex items-center justify-center rounded-md leading-none text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+          className="inline-flex min-h-6 min-w-6 items-center justify-center rounded-md p-1 leading-none text-gray-500 hover:bg-gray-100 hover:text-gray-700"
           onClick={handleClose}
         >
           <HixIcon className="text-brand-800 block h-6 w-6" aria-hidden="true" />

--- a/src/containers/map/pop-up/pop-up-controls/close.tsx
+++ b/src/containers/map/pop-up/pop-up-controls/close.tsx
@@ -18,7 +18,7 @@ const MapPopupClose = ({ handleClose }: MapPopupCloseProps) => {
           className="inline-flex items-center justify-center rounded-md leading-none text-gray-500 hover:bg-gray-100 hover:text-gray-700"
           onClick={handleClose}
         >
-          <HixIcon className="text-brand-800 block h-6 w-6" />
+          <HixIcon className="text-brand-800 block h-6 w-6" aria-hidden="true" />
         </button>
       </TooltipTrigger>
       <TooltipPortal>

--- a/src/containers/map/pop-up/pop-up-controls/drag.tsx
+++ b/src/containers/map/pop-up/pop-up-controls/drag.tsx
@@ -31,7 +31,10 @@ const MapPopupDragHandler = ({
           onMouseDown={(e) => e.stopPropagation()}
           onDoubleClick={handleClickToDocker}
         >
-          <MdOutlineDragHandleIcon className="text-brand-800 mt-3 ml-6 h-6 w-6" />
+          <MdOutlineDragHandleIcon
+            className="text-brand-800 mt-3 ml-6 h-6 w-6"
+            aria-hidden="true"
+          />
         </button>
       </TooltipTrigger>
       <TooltipContent className="bg-gray-600 px-2 text-white">

--- a/src/containers/navigation/find-locations/index.tsx
+++ b/src/containers/navigation/find-locations/index.tsx
@@ -77,7 +77,7 @@ const FindLocations = ({ menuItemStyle }: { menuItemStyle?: string }) => {
             className={menuItemStyle}
             data-testid="search-button"
           >
-            <GLASS_SVG role="img" title="Glass" />
+            <GLASS_SVG aria-hidden="true" />
             <p className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">
               <span className="lg:hidden">Locations</span>
               <span className="hidden lg:inline">Find locations</span>

--- a/src/containers/navigation/index.tsx
+++ b/src/containers/navigation/index.tsx
@@ -7,7 +7,10 @@ import News from '@/containers/navigation/news';
 const HELPER_ID = 'menu-categories';
 
 const AppTools = () => (
-  <div className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[540px] rounded-[32px] px-5 shadow-md lg:block">
+  <nav
+    aria-label="Main"
+    className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[540px] rounded-[32px] px-5 shadow-md lg:block"
+  >
     {/* <div className="grid h-full grid-cols-4 gap-4"> */}
     <div className="flex h-full items-center justify-around">
       <div className="flex items-center justify-center">
@@ -35,7 +38,7 @@ const AppTools = () => (
         </Helper>
       </div>
     </div>
-  </div>
+  </nav>
 );
 
 export default AppTools;

--- a/src/containers/navigation/index.tsx
+++ b/src/containers/navigation/index.tsx
@@ -9,7 +9,7 @@ const HELPER_ID = 'menu-categories';
 const AppTools = () => (
   <nav
     aria-label="Main"
-    className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[540px] rounded-[32px] px-5 shadow-md lg:block"
+    className="bg-brand-800 fixed top-2 left-4 z-20 hidden h-11 w-[min(540px,calc(100vw-2rem))] rounded-[32px] px-5 shadow-md lg:block"
   >
     {/* <div className="grid h-full grid-cols-4 gap-4"> */}
     <div className="flex h-full items-center justify-around">

--- a/src/containers/navigation/language-selector/index.tsx
+++ b/src/containers/navigation/language-selector/index.tsx
@@ -56,9 +56,9 @@ const LanguageSelector = ({
             className
           )}
         >
-          <LANGUAGES_ICON className="h-6 w-6 shrink-0" />
+          <LANGUAGES_ICON className="h-6 w-6 shrink-0" aria-hidden="true" />
           <span className="text-sm">{currentLanguage?.name}</span>
-          {hasArrow && <CHEVRON_ICON role="img" className="h-4 w-4" />}
+          {hasArrow && <CHEVRON_ICON aria-hidden="true" className="h-4 w-4" />}
         </DropdownMenuTrigger>
         <DropdownMenuContent className="bg-white">
           {languages.map((lang) => (

--- a/src/containers/navigation/map-settings/index.tsx
+++ b/src/containers/navigation/map-settings/index.tsx
@@ -35,6 +35,7 @@ const MapSettings = () => {
             'bg-brand-800': mapSettings,
           })}
           onClick={handleMapSettingsView}
+          aria-label="Map settings"
           data-testid="map-settings-button"
         >
           <MAP_SETTINGS_SVG
@@ -42,8 +43,7 @@ const MapSettings = () => {
               'text-brand-800 h-9 w-9 fill-current p-1': true,
               'text-white': mapSettings,
             })}
-            role="img"
-            title="Map settings"
+            aria-hidden="true"
           />
         </button>
       </div>

--- a/src/containers/navigation/menu-tools/index.tsx
+++ b/src/containers/navigation/menu-tools/index.tsx
@@ -62,7 +62,7 @@ const LocationTools = () => {
           message="Click this icon to return to default settings: Global statistics, zoomed out view, and default widget deck."
         >
           <div className={CARD_MENU_ITEM}>
-            <RESET_SVG role="img" title="Reset page" />
+            <RESET_SVG aria-hidden="true" />
             <span className="font-sans text-xs whitespace-nowrap lg:text-sm">
               <span className="lg:hidden">Reset</span>
               <span className="hidden lg:inline">Reset page</span>

--- a/src/containers/navigation/menu/index.tsx
+++ b/src/containers/navigation/menu/index.tsx
@@ -32,7 +32,7 @@ const Menu = ({ variant = 'desktop' }: { variant?: 'desktop' | 'mobile' }) => {
             type="button"
             onClick={() => setSection('main')}
             aria-label="Menu"
-            className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
+            className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
             <MENU_SVG className="h-8 w-8 fill-current text-white" role="img" title="Menu" />
             <span className="text-xxs font-sans leading-none text-white">Menu</span>

--- a/src/containers/navigation/menu/index.tsx
+++ b/src/containers/navigation/menu/index.tsx
@@ -34,7 +34,7 @@ const Menu = ({ variant = 'desktop' }: { variant?: 'desktop' | 'mobile' }) => {
             aria-label="Menu"
             className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
-            <MENU_SVG className="h-8 w-8 fill-current text-white" role="img" title="Menu" />
+            <MENU_SVG className="h-8 w-8 fill-current text-white" aria-hidden="true" />
             <span className="text-xxs font-sans leading-none text-white">Menu</span>
           </button>
         </DialogTrigger>
@@ -54,7 +54,7 @@ const Menu = ({ variant = 'desktop' }: { variant?: 'desktop' | 'mobile' }) => {
               onClick={() => setSection('main')}
               className="flex h-full cursor-pointer items-center space-x-2"
             >
-              <MENU_SVG className="h-6 w-6 fill-current" role="img" title="Menu" />
+              <MENU_SVG className="h-6 w-6 fill-current" aria-hidden="true" />
               <span className="font-sans text-sm text-white">Menu</span>
             </button>
           </DialogTrigger>

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -362,11 +362,7 @@ const AccountContent = () => {
                     disabled={true}
                   >
                     <CheckboxIndicator className="text-black/85">
-                      <CHECK_SVG
-                        className="h-full w-full fill-current"
-                        role="img"
-                        title="Checkmark"
-                      />
+                      <CHECK_SVG className="h-full w-full fill-current" aria-hidden="true" />
                     </CheckboxIndicator>
                   </Checkbox>
                   <FormLabel className="m-0 text-xs font-semibold">Delete account</FormLabel>

--- a/src/containers/navigation/menu/profile/account.tsx
+++ b/src/containers/navigation/menu/profile/account.tsx
@@ -185,8 +185,9 @@ const AccountContent = () => {
                 <FormControl>
                   <Input
                     {...field}
-                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                     placeholder="Name"
+                    autoComplete="name"
                   />
                 </FormControl>
                 <FormMessage />
@@ -203,8 +204,9 @@ const AccountContent = () => {
                 <FormControl>
                   <Input
                     {...field}
-                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                     placeholder="Email"
+                    autoComplete="email"
                   />
                 </FormControl>
                 <FormMessage />
@@ -221,8 +223,9 @@ const AccountContent = () => {
                 <FormControl>
                   <Input
                     {...field}
-                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                    className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                     placeholder="Organization"
+                    autoComplete="organization"
                   />
                 </FormControl>
                 <FormMessage />
@@ -269,8 +272,9 @@ const AccountContent = () => {
                   <FormControl>
                     <Input
                       {...field}
-                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                       placeholder="Tell us your role"
+                      autoComplete="organization-title"
                     />
                   </FormControl>
                   <FormMessage />
@@ -299,9 +303,10 @@ const AccountContent = () => {
                           form.clearErrors('current_password');
                         }
                       }}
-                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                      className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                       // Masked dots so the (unknown) stored password reads as set.
                       placeholder="••••••••"
+                      autoComplete="new-password"
                     />
                   </FormControl>
                 </FormItem>
@@ -320,8 +325,9 @@ const AccountContent = () => {
                       <Input
                         type="password"
                         {...field}
-                        className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-zinc-400"
+                        className="focus:border-brand-800 block w-full rounded-[100px] border border-black/10 px-3 py-2 text-sm placeholder:text-black/60"
                         placeholder="Enter your current password"
+                        autoComplete="current-password"
                       />
                     </FormControl>
                   </FormItem>

--- a/src/containers/navigation/menu/profile/saved-areas/item-new.tsx
+++ b/src/containers/navigation/menu/profile/saved-areas/item-new.tsx
@@ -163,7 +163,7 @@ const LocationItemNew = ({ name, systemLocationId, locationType, disabled }: Pro
             isDisabled && 'cursor-not-allowed opacity-60'
           )}
         >
-          <LuPlusIcon className="h-5 w-5 stroke-2" />
+          <LuPlusIcon className="h-5 w-5 stroke-2" aria-hidden="true" />
         </button>
       </div>
     </li>

--- a/src/containers/navigation/menu/resources.tsx
+++ b/src/containers/navigation/menu/resources.tsx
@@ -93,6 +93,7 @@ const ResourcesMenu = ({ setSection }) => {
                 'h-4 w-4 stroke-[1px]': true,
                 'text-brand-800 rotate-180': isOpen,
               })}
+              aria-hidden="true"
             />
             <span className="sr-only">Toggle</span>
           </div>

--- a/src/containers/navigation/mobile/configure/index.tsx
+++ b/src/containers/navigation/mobile/configure/index.tsx
@@ -13,7 +13,7 @@ const ConfigureWidgets = () => {
           <DialogTrigger asChild>
             <button
               type="button"
-              className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
+              className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
               data-testid="widgets-deck-trigger-mobile"
               aria-label="Configure widgets"
             >

--- a/src/containers/navigation/mobile/configure/index.tsx
+++ b/src/containers/navigation/mobile/configure/index.tsx
@@ -17,11 +17,7 @@ const ConfigureWidgets = () => {
               data-testid="widgets-deck-trigger-mobile"
               aria-label="Configure widgets"
             >
-              <CONFIGS_SVG
-                className="h-8 w-8 fill-current text-white"
-                role="img"
-                title="Widgets deck"
-              />
+              <CONFIGS_SVG className="h-8 w-8 fill-current text-white" aria-hidden="true" />
               <span className="text-xxs font-sans leading-none text-white">Configure</span>
             </button>
           </DialogTrigger>

--- a/src/containers/navigation/mobile/index.tsx
+++ b/src/containers/navigation/mobile/index.tsx
@@ -11,14 +11,17 @@ const NavigationMobile = () => {
       {/* max-w matches the widgets column: `max-w-155` minus its `px-2`
           gutters (see src/layouts/widgets), so the bar never outgrows the
           cards above it on wider mobile viewports. */}
-      <div className="pointer-events-auto fixed inset-x-4 bottom-4 z-50 mx-auto max-w-151">
+      <nav
+        aria-label="Main"
+        className="pointer-events-auto fixed inset-x-4 bottom-4 z-50 mx-auto max-w-151"
+      >
         <div className="bg-brand-800 flex items-center justify-around rounded-[32px] px-8 py-2 shadow-[0px_4px_6px_rgba(0,60,57,0.15)]">
           <Menu variant="mobile" />
           <News />
           <LanguageSelector />
           <HelpContainer variant="mobile" />
         </div>
-      </div>
+      </nav>
     </TooltipProvider>
   );
 };

--- a/src/containers/navigation/mobile/language-selector/index.tsx
+++ b/src/containers/navigation/mobile/language-selector/index.tsx
@@ -28,7 +28,7 @@ const LanguageSelector = () => {
             aria-label="Language"
             className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
-            <LANGUAGE_SVG className="h-8 w-8 fill-current text-white" role="img" title="Language" />
+            <LANGUAGE_SVG className="h-8 w-8 fill-current text-white" aria-hidden="true" />
             <span className="text-xxs font-sans leading-none text-white">
               {currentLanguage?.name}
             </span>

--- a/src/containers/navigation/mobile/language-selector/index.tsx
+++ b/src/containers/navigation/mobile/language-selector/index.tsx
@@ -26,7 +26,7 @@ const LanguageSelector = () => {
         <TooltipTrigger asChild>
           <DropdownMenuTrigger
             aria-label="Language"
-            className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
+            className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
             <LANGUAGE_SVG className="h-8 w-8 fill-current text-white" role="img" title="Language" />
             <span className="text-xxs font-sans leading-none text-white">

--- a/src/containers/navigation/mobile/locations/index.tsx
+++ b/src/containers/navigation/mobile/locations/index.tsx
@@ -35,7 +35,7 @@ const LocationsMobile = () => {
               aria-label="Locations"
               className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             >
-              <GLASS_SVG className="h-8 w-8 fill-current stroke-white" role="img" title="Glass" />
+              <GLASS_SVG className="h-8 w-8 fill-current stroke-white" aria-hidden="true" />
               <span className="text-xxs font-sans leading-none text-white">Locations</span>
             </button>
           </DialogTrigger>

--- a/src/containers/navigation/mobile/locations/index.tsx
+++ b/src/containers/navigation/mobile/locations/index.tsx
@@ -33,7 +33,7 @@ const LocationsMobile = () => {
               type="button"
               onClick={openMenu}
               aria-label="Locations"
-              className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-none"
+              className="flex w-14 cursor-pointer flex-col items-center justify-center space-y-1 text-white transition-opacity hover:opacity-80 focus-visible:opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
             >
               <GLASS_SVG className="h-8 w-8 fill-current stroke-white" role="img" title="Glass" />
               <span className="text-xxs font-sans leading-none text-white">Locations</span>

--- a/src/containers/navigation/mobile/view-tabs/index.tsx
+++ b/src/containers/navigation/mobile/view-tabs/index.tsx
@@ -7,6 +7,8 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import DASHBOARD_SVG from '@/svgs/ui/dashboard';
 import MAP_VIEW_SVG from '@/svgs/ui/map-view';
 
+// The icons duplicate the adjacent visible text; naming them made the
+// tabs announce "Dashboard Dashboard".
 const ViewTabs = () => {
   const [mapView, setMapView] = useAtom(mapViewAtom);
 
@@ -17,11 +19,11 @@ const ViewTabs = () => {
     >
       <TabsList variant="pill" className="pointer-events-auto">
         <TabsTrigger variant="pill" value="dashboard">
-          <DASHBOARD_SVG className="h-3 w-3" role="img" title="Dashboard" />
+          <DASHBOARD_SVG className="h-3 w-3" aria-hidden="true" />
           Dashboard
         </TabsTrigger>
         <TabsTrigger variant="pill" value="map">
-          <MAP_VIEW_SVG className="h-3 w-3" role="img" title="Map" />
+          <MAP_VIEW_SVG className="h-3 w-3" aria-hidden="true" />
           Map
         </TabsTrigger>
       </TabsList>

--- a/src/containers/navigation/news/index.tsx
+++ b/src/containers/navigation/news/index.tsx
@@ -48,8 +48,7 @@ const NewsButton = ({
             <span className="relative inline-block h-8 w-8 lg:h-6 lg:w-6">
               <NEWS_SVG
                 className="h-8 w-8 fill-current text-white lg:h-6 lg:w-6"
-                role="img"
-                title="News"
+                aria-hidden="true"
               />
               {showIndicator && (
                 <span

--- a/src/containers/navigation/news/index.tsx
+++ b/src/containers/navigation/news/index.tsx
@@ -36,7 +36,7 @@ const NewsButton = ({
       data-testid="news-button"
       aria-label="Open news and updates"
       onClick={onClick}
-      className="relative flex h-full w-14 cursor-pointer items-center justify-center rounded transition outline-none lg:w-auto lg:px-2"
+      className="relative flex h-full w-14 cursor-pointer items-center justify-center rounded transition lg:w-auto lg:px-2"
     >
       <Helper
         className={{ button: '-top-2.5 -right-4 z-20', tooltip: 'w-fit-content' }}

--- a/src/containers/navigation/news/news-tooltip-body.tsx
+++ b/src/containers/navigation/news/news-tooltip-body.tsx
@@ -37,18 +37,28 @@ const NewsTooltipBody = ({
   onDismissTooltip: () => void;
 }) => (
   <>
+    {/* Was a bare <HiXIcon onClick>: not focusable, no role, no accessible
+        name, and no keyboard path to dismissing the tooltip. It was also
+        rendered twice — once per branch — so both copies stacked at the same
+        absolute position when there were no unseen posts, and the copy inside
+        the <ul> was an invalid child of a list. */}
+    <button
+      type="button"
+      aria-label="Dismiss"
+      className="absolute top-2 right-2 cursor-pointer p-1 font-extrabold"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        onDismissTooltip();
+      }}
+    >
+      <HiXIcon className="h-4 w-4" aria-hidden="true" />
+    </button>
+
     {!unseenPosts?.length && (
       <div className="max-w-xs space-y-1 sm:max-w-70">
         <div className="flex items-center justify-between space-x-2 font-bold">
           <span className="text-xs uppercase">Tool updated!</span>
-          <HiXIcon
-            className="absolute top-2 right-2 h-4 w-4 cursor-pointer font-extrabold"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onDismissTooltip();
-            }}
-          />
         </div>
         <p className="text-sm">
           A new version is live. See what’s been improved and discover the new features added to the
@@ -58,15 +68,9 @@ const NewsTooltipBody = ({
     )}
 
     <ul className="max-w-2xs space-y-2">
-      {unseenPosts?.map((post) => <TooltipItem key={post.id} post={post} />)}
-      <HiXIcon
-        className="absolute top-2 right-2 h-4 w-4 cursor-pointer font-extrabold"
-        onClick={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onDismissTooltip();
-        }}
-      />
+      {unseenPosts?.map((post) => (
+        <TooltipItem key={post.id} post={post} />
+      ))}
     </ul>
   </>
 );

--- a/src/containers/navigation/news/news-tooltip-body.tsx
+++ b/src/containers/navigation/news/news-tooltip-body.tsx
@@ -37,11 +37,6 @@ const NewsTooltipBody = ({
   onDismissTooltip: () => void;
 }) => (
   <>
-    {/* Was a bare <HiXIcon onClick>: not focusable, no role, no accessible
-        name, and no keyboard path to dismissing the tooltip. It was also
-        rendered twice — once per branch — so both copies stacked at the same
-        absolute position when there were no unseen posts, and the copy inside
-        the <ul> was an invalid child of a list. */}
     <button
       type="button"
       aria-label="Dismiss"

--- a/src/containers/news/post/index.tsx
+++ b/src/containers/news/post/index.tsx
@@ -43,9 +43,9 @@ const Post = ({ post }: { post: PostProps }) => {
             );
           })}
         </div>
-        <h5 data-testid="post-title" className="text-2lg line-clamp-3 text-left font-light">
+        <h4 data-testid="post-title" className="text-2lg line-clamp-3 text-left font-light">
           {post.title.rendered}
-        </h5>
+        </h4>
       </div>
     </div>
   );

--- a/src/containers/print-report/index.tsx
+++ b/src/containers/print-report/index.tsx
@@ -38,9 +38,9 @@ const PrintReportPage = () => {
             key={slug}
             className="mb-4 break-inside-avoid overflow-hidden rounded-3xl border border-gray-100 bg-white p-6 shadow-sm print:max-h-[calc(100vh-20mm)]"
           >
-            <h3 className="mb-3 text-xs font-semibold tracking-wider text-black/60 uppercase">
+            <h2 className="mb-3 text-xs font-semibold tracking-wider text-black/60 uppercase">
               {name}
-            </h3>
+            </h2>
             <Widget />
           </div>
         );

--- a/src/containers/print-report/print-legend.tsx
+++ b/src/containers/print-report/print-legend.tsx
@@ -34,7 +34,7 @@ const PrintLegend = () => {
 
   return (
     <div className="absolute right-4 bottom-4 z-50 max-w-72 rounded-2xl bg-white/90 p-4 shadow-md backdrop-blur-sm">
-      <h4 className="mb-2 text-xs font-bold tracking-wider text-black/85 uppercase">Legend</h4>
+      <h2 className="mb-2 text-xs font-bold tracking-wider text-black/85 uppercase">Legend</h2>
       <div className="space-y-3">
         {legendItems.map((item) => (
           <div key={item.id}>

--- a/src/containers/saved-areas/index.tsx
+++ b/src/containers/saved-areas/index.tsx
@@ -33,15 +33,19 @@ const SavedAreas = ({ menuItemStyle }: { menuItemStyle?: string }) => {
         tooltipPosition={{ top: -65, left: -5 }}
         message="Coming soon"
       >
-        <DialogTrigger>
-          <div className={menuItemStyle}>
-            <LuBookmarkIcon
-              className={cn({
-                'h-8 w-8 stroke-1 text-white': true,
-              })}
-            />
-            <p className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">Saved areas</p>
-          </div>
+        {/* DialogTrigger renders a <button>; a <div> and <p> inside it is flow
+            content in a button, which is invalid HTML. Inline elements keep the
+            same layout without the nesting violation. */}
+        <DialogTrigger className={menuItemStyle}>
+          <LuBookmarkIcon
+            aria-hidden="true"
+            className={cn({
+              'h-8 w-8 stroke-1 text-white': true,
+            })}
+          />
+          <span className="font-sans text-xs whitespace-nowrap text-white lg:text-sm">
+            Saved areas
+          </span>
         </DialogTrigger>
       </Helper>
       <DialogContent classNameContent="max-w-[calc(100vw-2rem)]">

--- a/src/containers/saved-areas/index.tsx
+++ b/src/containers/saved-areas/index.tsx
@@ -33,9 +33,6 @@ const SavedAreas = ({ menuItemStyle }: { menuItemStyle?: string }) => {
         tooltipPosition={{ top: -65, left: -5 }}
         message="Coming soon"
       >
-        {/* DialogTrigger renders a <button>; a <div> and <p> inside it is flow
-            content in a button, which is invalid HTML. Inline elements keep the
-            same layout without the nesting violation. */}
         <DialogTrigger className={menuItemStyle}>
           <LuBookmarkIcon
             aria-hidden="true"

--- a/src/containers/widget/context.ts
+++ b/src/containers/widget/context.ts
@@ -1,14 +1,5 @@
 import { createContext, useContext } from 'react';
 
-/**
- * The slug of the widget card currently being rendered.
- *
- * Deep children (charts, legends) need to name themselves after the widget
- * they belong to. The alternative — threading a label prop through every
- * dataset's hooks and chart config — would touch ~20 widgets and drift the
- * moment a widget is renamed, since the card header already renders the
- * canonical title.
- */
 export const WidgetIdContext = createContext<string | null>(null);
 
 /** `widget-<slug>-title` — the id of the current card's <h2>, if inside one. */

--- a/src/containers/widget/context.ts
+++ b/src/containers/widget/context.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * The slug of the widget card currently being rendered.
+ *
+ * Deep children (charts, legends) need to name themselves after the widget
+ * they belong to. The alternative — threading a label prop through every
+ * dataset's hooks and chart config — would touch ~20 widgets and drift the
+ * moment a widget is renamed, since the card header already renders the
+ * canonical title.
+ */
+export const WidgetIdContext = createContext<string | null>(null);
+
+/** `widget-<slug>-title` — the id of the current card's <h2>, if inside one. */
+export function useWidgetTitleId(): string | null {
+  const id = useContext(WidgetIdContext);
+  return id ? `widget-${id}-title` : null;
+}

--- a/src/containers/widget/header.tsx
+++ b/src/containers/widget/header.tsx
@@ -34,7 +34,7 @@ const WidgetHeader = ({ title, id, isCollapsed, children }: PropsWithChildren<He
 
   return (
     <header className="flex items-center justify-between">
-      <h2 className="flex min-w-0 flex-1">
+      <h2 id={`widget-${id}-title`} className="flex min-w-0 flex-1">
         <button
           type="button"
           onClick={handleWidgetCollapsed}

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -60,6 +60,12 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
     <AnimatePresence>
       <motion.div
         id={`widget-${id}`}
+        // Each card is a labelled region, so screen-reader users can jump
+        // between widgets by landmark and hear which one they are in. The
+        // label is the card's own <h2>, which previously belonged to no
+        // container at all.
+        role="region"
+        aria-labelledby={`widget-${id}-title`}
         initial={false}
         variants={widgetVariants}
         animate={isCollapsed ? 'collapsed' : 'expanded'}

--- a/src/containers/widget/index.tsx
+++ b/src/containers/widget/index.tsx
@@ -14,6 +14,7 @@ import WidgetControls from '@/components/widget-controls';
 import { WidgetSlugType } from 'types/widget';
 
 import WidgetApplicability from './applicability';
+import { WidgetIdContext } from './context';
 import WidgetHeader from './header';
 import { useIsLayerActive } from './selector';
 
@@ -57,80 +58,82 @@ const WidgetWrapper: FC<WidgetLayoutProps> = (props: WidgetLayoutProps) => {
   const [isContentOverflowVisible, setIsContentOverflowVisible] = useState(!isCollapsed);
 
   return (
-    <AnimatePresence>
-      <motion.div
-        id={`widget-${id}`}
-        // Each card is a labelled region, so screen-reader users can jump
-        // between widgets by landmark and hear which one they are in. The
-        // label is the card's own <h2>, which previously belonged to no
-        // container at all.
-        role="region"
-        aria-labelledby={`widget-${id}-title`}
-        initial={false}
-        variants={widgetVariants}
-        animate={isCollapsed ? 'collapsed' : 'expanded'}
-        exit="expanded"
-        transition={{ type: 'tween', duration: 0.3 }}
-        className={cn({
-          'bg-blur group shadow-card isolate w-full rounded-4xl bg-white md:ml-0': true,
-          'w-full! border-none p-0! shadow-none!': info,
-          [className]: !!className,
-          'border-none p-0': info,
-        })}
-        style={props.index !== undefined ? { zIndex: 1000 - props.index } : undefined}
-      >
-        <div className="relative overflow-hidden rounded-3xl">
-          {/* border layer */}
-          <div
-            aria-hidden
-            className={cn(
-              'pointer-events-none absolute inset-1 rounded-[inherit] border-2',
-              isLayerActive
-                ? 'border-brand-800/10 transition delay-150 ease-in-out'
-                : 'border-transparent'
-            )}
-          />
+    <WidgetIdContext.Provider value={id}>
+      <AnimatePresence>
+        <motion.div
+          id={`widget-${id}`}
+          // Each card is a labelled region, so screen-reader users can jump
+          // between widgets by landmark and hear which one they are in. The
+          // label is the card's own <h2>, which previously belonged to no
+          // container at all.
+          role="region"
+          aria-labelledby={`widget-${id}-title`}
+          initial={false}
+          variants={widgetVariants}
+          animate={isCollapsed ? 'collapsed' : 'expanded'}
+          exit="expanded"
+          transition={{ type: 'tween', duration: 0.3 }}
+          className={cn({
+            'bg-blur group shadow-card isolate w-full rounded-4xl bg-white md:ml-0': true,
+            'w-full! border-none p-0! shadow-none!': info,
+            [className]: !!className,
+            'border-none p-0': info,
+          })}
+          style={props.index !== undefined ? { zIndex: 1000 - props.index } : undefined}
+        >
+          <div className="relative overflow-hidden rounded-3xl">
+            {/* border layer */}
+            <div
+              aria-hidden
+              className={cn(
+                'pointer-events-none absolute inset-1 rounded-[inherit] border-2',
+                isLayerActive
+                  ? 'border-brand-800/10 transition delay-150 ease-in-out'
+                  : 'border-transparent'
+              )}
+            />
 
-          {/* content layer */}
-          <div className="relative z-10 min-w-0">
-            <div className="min-w-0 px-10 py-6" data-testid={`widget-${id}`}>
-              <Helper
-                className={{
-                  button: id === 'widgets_deck_tool' ? 'top-0 -right-6 z-20' : 'hidden',
-                  tooltip: 'max-w-100',
-                }}
-                tooltipPosition={{ top: -50, left: 0 }}
-                message="Opens deck to select which widgets and map layers are displayed on the left side of the screen. Widgets provide information and statistics about a selected geography, protected area, or user-inputted polygon. Most widgets also come with a map layer that can be toggled on and off. Users can select groups of widgets organized by theme or customize their own combination of widgets and map layers. Some layers and widgets are not available for certain locations. Select applicable geography to enable layer."
-              >
-                <WidgetHeader title={title} id={id} isCollapsed={isCollapsed}>
-                  {!info && <WidgetControls id={id} />}
-                </WidgetHeader>
-              </Helper>
-              <motion.div
-                id={`widget-${id}-content`}
-                data-testid={`widget-${id}-content`}
-                // Collapsed content stays in the DOM for the height animation, so `inert` is what
-                // keeps it out of the tab order and the accessibility tree.
-                inert={isCollapsed ? '' : undefined}
-                initial={false}
-                animate={isCollapsed ? 'collapsed' : 'expanded'}
-                variants={{
-                  collapsed: { height: 0, opacity: 0 },
-                  expanded: { height: 'auto', opacity: 1 },
-                }}
-                transition={{ type: 'tween', duration: 0.3 }}
-                onAnimationStart={() => isCollapsed && setIsContentOverflowVisible(false)}
-                onAnimationComplete={() => !isCollapsed && setIsContentOverflowVisible(true)}
-                style={{ overflow: isContentOverflowVisible ? 'visible' : 'hidden' }}
-              >
-                <div className="mt-4">{children}</div>
-              </motion.div>
-              {applicability && <WidgetApplicability id={id} applicability={applicability} />}
+            {/* content layer */}
+            <div className="relative z-10 min-w-0">
+              <div className="min-w-0 px-10 py-6" data-testid={`widget-${id}`}>
+                <Helper
+                  className={{
+                    button: id === 'widgets_deck_tool' ? 'top-0 -right-6 z-20' : 'hidden',
+                    tooltip: 'max-w-100',
+                  }}
+                  tooltipPosition={{ top: -50, left: 0 }}
+                  message="Opens deck to select which widgets and map layers are displayed on the left side of the screen. Widgets provide information and statistics about a selected geography, protected area, or user-inputted polygon. Most widgets also come with a map layer that can be toggled on and off. Users can select groups of widgets organized by theme or customize their own combination of widgets and map layers. Some layers and widgets are not available for certain locations. Select applicable geography to enable layer."
+                >
+                  <WidgetHeader title={title} id={id} isCollapsed={isCollapsed}>
+                    {!info && <WidgetControls id={id} />}
+                  </WidgetHeader>
+                </Helper>
+                <motion.div
+                  id={`widget-${id}-content`}
+                  data-testid={`widget-${id}-content`}
+                  // Collapsed content stays in the DOM for the height animation, so `inert` is what
+                  // keeps it out of the tab order and the accessibility tree.
+                  inert={isCollapsed ? '' : undefined}
+                  initial={false}
+                  animate={isCollapsed ? 'collapsed' : 'expanded'}
+                  variants={{
+                    collapsed: { height: 0, opacity: 0 },
+                    expanded: { height: 'auto', opacity: 1 },
+                  }}
+                  transition={{ type: 'tween', duration: 0.3 }}
+                  onAnimationStart={() => isCollapsed && setIsContentOverflowVisible(false)}
+                  onAnimationComplete={() => !isCollapsed && setIsContentOverflowVisible(true)}
+                  style={{ overflow: isContentOverflowVisible ? 'visible' : 'hidden' }}
+                >
+                  <div className="mt-4">{children}</div>
+                </motion.div>
+                {applicability && <WidgetApplicability id={id} applicability={applicability} />}
+              </div>
             </div>
           </div>
-        </div>
-      </motion.div>
-    </AnimatePresence>
+        </motion.div>
+      </AnimatePresence>
+    </WidgetIdContext.Provider>
   );
 };
 

--- a/src/containers/widgets/no-data/index.tsx
+++ b/src/containers/widgets/no-data/index.tsx
@@ -3,7 +3,7 @@ import NO_DATA_SVG from '@/svgs/ui/no-data';
 const NoData = () => {
   return (
     <div className="m-auto flex w-full max-w-full break-inside-avoid flex-col items-center justify-center rounded-3xl bg-white py-8">
-      <NO_DATA_SVG className="h-40 w-40 fill-current" role="img" title="No data" />
+      <NO_DATA_SVG className="h-40 w-40 fill-current" aria-hidden="true" />
       <p className="text-center font-sans text-xs leading-5 sm:text-base sm:leading-6">
         Sorry, there are <b>no data</b> for this location.
         <br />

--- a/src/containers/widgets/widgets-deck-button.tsx
+++ b/src/containers/widgets/widgets-deck-button.tsx
@@ -55,7 +55,7 @@ export default function WidgetsDeckButton() {
             className="bg-brand-800 shadow-control hover:bg-brand-800/90 focus-visible:ring-brand-400 flex h-12 min-w-[48px] cursor-pointer items-center gap-2 rounded-full py-4 pr-5 pl-4 text-sm font-semibold text-white transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
             variants={buttonMotion}
           >
-            <SETTINGS_SVG className="h-4 w-4 shrink-0 fill-current" role="img" aria-hidden={true} />
+            <SETTINGS_SVG className="h-4 w-4 shrink-0 fill-current" aria-hidden={true} />
             <motion.span variants={textMotion} className="whitespace-nowrap">
               Widgets deck
             </motion.span>

--- a/src/containers/widgets/widgets-menu/index.tsx
+++ b/src/containers/widgets/widgets-menu/index.tsx
@@ -150,7 +150,10 @@ const WidgetsMenu: FC = () => {
             })}
           >
             <CheckboxIndicator>
-              <FaCheckIcon className="h-2.5 w-2.5 fill-current font-bold text-white" />
+              <FaCheckIcon
+                className="h-2.5 w-2.5 fill-current font-bold text-white"
+                aria-hidden="true"
+              />
             </CheckboxIndicator>
           </Checkbox>
 
@@ -167,7 +170,10 @@ const WidgetsMenu: FC = () => {
             })}
           >
             <CheckboxIndicator>
-              <FaCheckIcon className="h-2.5 w-2.5 fill-current font-bold text-white" />
+              <FaCheckIcon
+                className="h-2.5 w-2.5 fill-current font-bold text-white"
+                aria-hidden="true"
+              />
             </CheckboxIndicator>
           </Checkbox>
           <p
@@ -209,6 +215,7 @@ const WidgetsMenu: FC = () => {
                         'h-2.5 w-2.5 fill-current font-bold': true,
                         'text-white': activeWidgets.includes(slug),
                       })}
+                      aria-hidden="true"
                     />
                   </CheckboxIndicator>
                 )}
@@ -234,6 +241,7 @@ const WidgetsMenu: FC = () => {
                         'h-2.5 w-2.5 fill-current font-bold': true,
                         'text-white': activeLayersIds?.includes(slug),
                       })}
+                      aria-hidden="true"
                     />
                   </CheckboxIndicator>
                 </Checkbox>

--- a/src/containers/widgets/widgets-menu/index.tsx
+++ b/src/containers/widgets/widgets-menu/index.tsx
@@ -120,8 +120,17 @@ const WidgetsMenu: FC = () => {
   );
 
   return (
-    <div>
-      <div className="grid grid-cols-[57px_42px_auto] gap-4 text-xs font-bold tracking-[1px] uppercase">
+    /* A checkbox group, not tabular data: each row is two independent toggles
+       for one dataset. A fieldset/legend names the group; every checkbox gets
+       its own aria-label combining the column ("widget" / "layer") with the
+       dataset name, since the visible <p> is a sibling and the column headings
+       below are not programmatically associated with anything. */
+    <fieldset>
+      <legend className="sr-only">Widgets and map layers to display</legend>
+      <div
+        aria-hidden="true"
+        className="grid grid-cols-[57px_42px_auto] gap-4 text-xs font-bold tracking-[1px] uppercase"
+      >
         <div>Widget</div>
         <div>Layer</div>
         <div>Name</div>
@@ -130,13 +139,13 @@ const WidgetsMenu: FC = () => {
         <div key="menu-item-all" className="grid grid-cols-[57px_42px_auto] gap-4 text-sm">
           <Checkbox
             id="all-widgets"
+            aria-label="Select all widgets"
             data-testid="all-widgets-checkbox"
             onCheckedChange={handleAllWidgets}
             checked={widgets.length === activeWidgets.length}
             defaultChecked={categorySelected === 'all_datasets'}
             className={cn({
-              'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white text-white':
-                true,
+              'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white text-white': true,
               'bg-brand-800': widgets.length === activeWidgets.length,
             })}
           >
@@ -147,13 +156,13 @@ const WidgetsMenu: FC = () => {
 
           <Checkbox
             id="all-layers"
+            aria-label="Select all layers"
             data-testid="all-layers-checkbox"
             onCheckedChange={handleAllLayers}
             defaultChecked={false}
             checked={LAYERS.length === activeLayers?.length}
             className={cn({
-              'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white text-white':
-                true,
+              'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white text-white': true,
               'bg-brand-800': LAYERS.length === activeLayers?.length,
             })}
           >
@@ -180,15 +189,15 @@ const WidgetsMenu: FC = () => {
               })}
             >
               <Checkbox
-                id={slug}
-                data-testid={`${slug}-checkbox`}
+                id={`${slug}-widget`}
+                aria-label={`${name} widget`}
+                data-testid={`${slug}-widget-checkbox`}
                 onCheckedChange={() => handleWidgets(slug)}
                 defaultChecked
                 disabled={!enabledWidgets.includes(slug)}
                 checked={activeWidgets.includes(slug)}
                 className={cn({
-                  'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white':
-                    true,
+                  'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white': true,
                   'bg-brand-800 text-white':
                     activeWidgets.includes(slug) && enabledWidgets.includes(slug),
                 })}
@@ -206,15 +215,15 @@ const WidgetsMenu: FC = () => {
               </Checkbox>
               {!!layersIds && !!layersIds.length && slug !== 'mangrove_national_dashboard' && (
                 <Checkbox
-                  id={slug}
-                  data-testid={`${slug}-checkbox`}
+                  id={`${slug}-layer`}
+                  aria-label={`${name} layer`}
+                  data-testid={`${slug}-layer-checkbox`}
                   onCheckedChange={() => handleLayers(slug)}
                   disabled={!enabledWidgets.includes(slug)}
                   defaultChecked
                   checked={activeLayersIds?.includes(slug)}
                   className={cn({
-                    'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white':
-                      true,
+                    'text-brand-500 m-auto h-3 w-3 cursor-pointer rounded-sm border border-black/15 bg-white': true,
                     'bg-brand-800 font-bold text-white':
                       activeLayersIds?.includes(slug) && enabledWidgets.includes(slug),
                   })}
@@ -244,7 +253,7 @@ const WidgetsMenu: FC = () => {
           );
         })}
       </div>
-    </div>
+    </fieldset>
   );
 };
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -159,6 +159,23 @@
   scrollbar-color: #cdd0d0 #f3f5f5;
 }
 
+/*
+ * CSS-driven motion (Tailwind `animate-*`, the collapsible keyframes, the help
+ * hotspot ping) is outside motion/react's control, so it needs its own opt-out.
+ * WCAG 2.3.3. Kept near-zero rather than `none` so animation/transition end
+ * events still fire and JS that waits on them does not hang.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Brush charts: don't clip axis labels that overflow the plot. The first/last year
    labels are centered on edge ticks and would otherwise be cut by the svg surface
    (e.g. the alerts brush). No-op for charts whose labels already sit within bounds. */

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -31,6 +31,28 @@
 }
 
 @layer base {
+  :root {
+    /* Consumed by `.bg-blur` below, which referenced it while it was never
+       defined anywhere — an invalid-at-computed-value-time declaration.
+       (`.bg-blur` is currently tree-shaken out of the build entirely, so
+       widget cards render as plain `bg-white`; defining this makes the rule
+       correct if the utility is ever emitted again.) */
+    --background-rgb: 255, 255, 255;
+  }
+
+  /*
+   * Global focus fallback.
+   *
+   * Individual components layer their own `focus-visible:ring-*` on top; this
+   * exists so that a control which forgets one — or which strips the UA
+   * outline with `outline-none` — still shows a visible focus indicator
+   * (WCAG 2.4.7). Keyed on :focus-visible, so pointer users never see it.
+   */
+  :focus-visible {
+    outline: 2px solid #00857f; /* brand-800 */
+    outline-offset: 2px;
+  }
+
   input[type='search']::-webkit-search-decoration,
   input[type='search']::-webkit-search-cancel-button,
   input[type='search']::-webkit-search-results-button,
@@ -130,10 +152,11 @@
   }
 }
 
-/* Firefox */
+/* Firefox equivalent of the ::-webkit-scrollbar rules above. `--secondary` and
+   `--primary` were never defined, so this silently fell back to the UA default. */
 * {
   scrollbar-width: thin;
-  scrollbar-color: var(--secondary) var(--primary);
+  scrollbar-color: #cdd0d0 #f3f5f5;
 }
 
 /* Brush charts: don't clip axis labels that overflow the plot. The first/last year

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -37,6 +37,10 @@ const tailwindConfig = {
           75: '#CDD0D0',
           100: '#D8D8D8',
           400: '#939393',
+          // Accessible body-text grey: 5.3:1 on white. `grey-800` (#808080) is
+          // only 3.9:1 and `grey-400` (#939393) only 3.0:1, so neither can
+          // carry text at WCAG AA. Both are kept for decorative use.
+          600: '#6B6B6B',
           800: '#808080',
         },
         brand: {

--- a/tests/a11y/auth.spec.ts
+++ b/tests/a11y/auth.spec.ts
@@ -9,10 +9,10 @@ test.describe('a11y: auth pages', () => {
     test(`${route} has no WCAG violations`, async ({ page }) => {
       await page.goto(route);
       // Auth pages are client components behind a form — the submit button is
-      // the last thing to render, so it is the reliable settle signal.
-      await expect(
-        page.getByRole('button', { name: /sign in|sign up|send|reset/i }).first()
-      ).toBeVisible();
+      // the last thing to render, so it is the reliable settle signal. Matched
+      // by type rather than by name: the three pages label it "Log in",
+      // "Register" and "Submit", and the copy is translated.
+      await expect(page.locator('main#main-content button[type="submit"]')).toBeVisible();
 
       await expectNoViolations(page, { route });
     });

--- a/tests/a11y/auth.spec.ts
+++ b/tests/a11y/auth.spec.ts
@@ -18,9 +18,8 @@ test.describe('a11y: auth pages', () => {
     });
 
     test(`${route} exposes a main landmark for the skip link`, async ({ page }) => {
-      // Unblocked by phase 5B (src/app/auth/layout.tsx). Auth pages currently
-      // use <section>, so the root layout's skip link points at nothing here.
-      test.fixme(true, 'No <main id="main-content"> on auth routes until phase 5B');
+      // Exactly one: each auth page marks its own form column, so a stray
+      // wrapper landmark in the shared layout would show up as a second.
       await page.goto(route);
       await expect(page.locator('main#main-content')).toHaveCount(1);
     });

--- a/tests/a11y/auth.spec.ts
+++ b/tests/a11y/auth.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '../fixtures/test';
+
+import { expectNoViolations } from './utils/axe';
+
+const AUTH_ROUTES = ['/auth/signin', '/auth/signup', '/auth/forgot-password'] as const;
+
+test.describe('a11y: auth pages', () => {
+  for (const route of AUTH_ROUTES) {
+    test(`${route} has no WCAG violations`, async ({ page }) => {
+      await page.goto(route);
+      // Auth pages are client components behind a form — the submit button is
+      // the last thing to render, so it is the reliable settle signal.
+      await expect(
+        page.getByRole('button', { name: /sign in|sign up|send|reset/i }).first()
+      ).toBeVisible();
+
+      await expectNoViolations(page, { route });
+    });
+
+    test(`${route} exposes a main landmark for the skip link`, async ({ page }) => {
+      // Unblocked by phase 5B (src/app/auth/layout.tsx). Auth pages currently
+      // use <section>, so the root layout's skip link points at nothing here.
+      test.fixme(true, 'No <main id="main-content"> on auth routes until phase 5B');
+      await page.goto(route);
+      await expect(page.locator('main#main-content')).toHaveCount(1);
+    });
+  }
+});

--- a/tests/a11y/embedded.spec.ts
+++ b/tests/a11y/embedded.spec.ts
@@ -5,7 +5,9 @@ import { expectNoViolations } from './utils/axe';
 test.describe('a11y: embedded view', () => {
   test('has no WCAG violations', async ({ page }) => {
     await page.goto('/embedded/country/IDN');
-    await expect(page.getByTestId('widgets-wrapper')).toBeVisible();
+    // The embedded view is the map and its legend — there is no widgets column
+    // here, so the legend is the last thing to settle.
+    await expect(page.getByTestId('legend-content')).toBeVisible();
 
     await expectNoViolations(page, { route: '/embedded' });
   });

--- a/tests/a11y/embedded.spec.ts
+++ b/tests/a11y/embedded.spec.ts
@@ -11,9 +11,8 @@ test.describe('a11y: embedded view', () => {
   });
 
   test('exposes a main landmark for the skip link', async ({ page }) => {
-    // Unblocked by phase 5B. The root layout renders a skip link on every
-    // route, so #main-content must exist here too.
-    test.fixme(true, 'No <main id="main-content"> on /embedded until phase 5B');
+    // The root layout renders a skip link on every route, so #main-content must
+    // exist here too.
     await page.goto('/embedded/country/IDN');
     await expect(page.locator('main#main-content')).toHaveCount(1);
   });

--- a/tests/a11y/embedded.spec.ts
+++ b/tests/a11y/embedded.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '../fixtures/test';
+
+import { expectNoViolations } from './utils/axe';
+
+test.describe('a11y: embedded view', () => {
+  test('has no WCAG violations', async ({ page }) => {
+    await page.goto('/embedded/country/IDN');
+    await expect(page.getByTestId('widgets-wrapper')).toBeVisible();
+
+    await expectNoViolations(page, { route: '/embedded' });
+  });
+
+  test('exposes a main landmark for the skip link', async ({ page }) => {
+    // Unblocked by phase 5B. The root layout renders a skip link on every
+    // route, so #main-content must exist here too.
+    test.fixme(true, 'No <main id="main-content"> on /embedded until phase 5B');
+    await page.goto('/embedded/country/IDN');
+    await expect(page.locator('main#main-content')).toHaveCount(1);
+  });
+});

--- a/tests/a11y/error-pages.spec.ts
+++ b/tests/a11y/error-pages.spec.ts
@@ -12,8 +12,6 @@ test.describe('a11y: error pages', () => {
   });
 
   test('404 exposes a main landmark for the skip link', async ({ page }) => {
-    // Unblocked by phase 5B.
-    test.fixme(true, 'No <main id="main-content"> on not-found until phase 5B');
     await page.goto('/this-route-does-not-exist');
     await expect(page.locator('main#main-content')).toHaveCount(1);
   });

--- a/tests/a11y/error-pages.spec.ts
+++ b/tests/a11y/error-pages.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '../fixtures/test';
+
+import { expectNoViolations } from './utils/axe';
+
+test.describe('a11y: error pages', () => {
+  test('404 has no WCAG violations', async ({ page }) => {
+    // Any top-level path outside ALLOWED_LOCATION_TYPES resolves to not-found.
+    await page.goto('/this-route-does-not-exist');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    await expectNoViolations(page, { route: '/404' });
+  });
+
+  test('404 exposes a main landmark for the skip link', async ({ page }) => {
+    // Unblocked by phase 5B.
+    test.fixme(true, 'No <main id="main-content"> on not-found until phase 5B');
+    await page.goto('/this-route-does-not-exist');
+    await expect(page.locator('main#main-content')).toHaveCount(1);
+  });
+});

--- a/tests/a11y/home.spec.ts
+++ b/tests/a11y/home.spec.ts
@@ -1,0 +1,55 @@
+import type { Page } from '@playwright/test';
+
+import { expect, test } from '../fixtures/test';
+
+import { expectNoViolations } from './utils/axe';
+
+/**
+ * Anchor every scan on a settled widget, never `networkidle`.
+ *
+ * Widget cards render skeletons while their React Query hooks resolve against
+ * the live API. Scanning mid-skeleton produces both false passes (the failing
+ * markup has not rendered yet) and false failures (colour-contrast against a
+ * pulsing placeholder).
+ */
+async function waitForWidgets(page: Page) {
+  await expect(page.getByTestId('widgets-wrapper')).toBeVisible();
+  await expect(page.getByTestId('widget-mangrove_habitat_extent-content')).toBeVisible();
+}
+
+test.describe('a11y: map application', () => {
+  test('worldwide view has no WCAG violations', async ({ page }) => {
+    await page.goto('/');
+    await waitForWidgets(page);
+
+    await expectNoViolations(page, { route: '/' });
+  });
+
+  test('country view has no WCAG violations', async ({ page }) => {
+    await page.goto('/country/IDN');
+    await waitForWidgets(page);
+
+    await expectNoViolations(page, { route: '/country/IDN' });
+  });
+
+  test('page has exactly one h1 that names the location', async ({ page }) => {
+    await page.goto('/country/IDN');
+    await waitForWidgets(page);
+
+    const h1 = page.locator('h1');
+    await expect(h1).toHaveCount(1);
+    await expect(h1).not.toBeEmpty();
+  });
+
+  test('skip link is the first focusable element and targets a real node', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('body').press('Tab');
+
+    const focused = page.locator(':focus');
+    await expect(focused).toHaveText(/skip to main content/i);
+
+    const href = await focused.getAttribute('href');
+    expect(href).toBe('#main-content');
+    await expect(page.locator('#main-content')).toHaveCount(1);
+  });
+});

--- a/tests/a11y/known-issues.ts
+++ b/tests/a11y/known-issues.ts
@@ -1,0 +1,61 @@
+/**
+ * Axe rules that are knowingly failing, per route.
+ *
+ * This ledger exists so the a11y harness can land green *before* the fixes,
+ * and then tighten monotonically: every remediation phase deletes its own
+ * entries, and a phase is not done until they are gone. The alternative —
+ * landing the specs red — reliably ends with the whole suite muted.
+ *
+ * Every entry MUST name the phase that removes it. When this object is empty,
+ * delete the file and the `getKnownIssues` call in `utils/axe.ts`.
+ */
+const KNOWN_ISSUES: Record<string, string[]> = {
+  '/': [
+    // Phase 1C — text-black/42 in legend controls, text-grey-400 in the
+    // species-threatened legend, opacity-30 legend subtitle.
+    'color-contrast',
+    // Phase 4C — icon-only buttons in the map legend and the news tooltip.
+    'button-name',
+    // Phase 5C — h3 before h2 in containers/legend, h5 news post titles.
+    'heading-order',
+  ],
+  '/country/IDN': [
+    // Phase 1C — see '/'.
+    'color-contrast',
+    // Phase 4C — see '/'.
+    'button-name',
+    // Phase 5C — see '/'.
+    'heading-order',
+  ],
+  '/embedded': [
+    // Phase 1C — shared widget styles.
+    'color-contrast',
+  ],
+  '/print-report': [
+    // Phase 1C — shared widget styles.
+    'color-contrast',
+    // Phase 5C — h3 under h1 in print-report, h4 in print-legend.
+    'heading-order',
+  ],
+  '/auth/signin': [
+    // Phase 5C — hero h2 renders before the page h1.
+    'heading-order',
+  ],
+  '/auth/signup': [
+    // Phase 3B — the privacy-policy checkbox is wrapped in a <button> and its
+    // <label htmlFor> targets a Radix button, so it has no accessible name.
+    'label',
+    'nested-interactive',
+  ],
+  '/auth/forgot-password': [],
+  '/404': [
+    // Phase 1C — text-grey-800 body copy on the error page.
+    'color-contrast',
+  ],
+};
+
+export function getKnownIssues(route: string): string[] {
+  return KNOWN_ISSUES[route] ?? [];
+}
+
+export default KNOWN_ISSUES;

--- a/tests/a11y/print-report.spec.ts
+++ b/tests/a11y/print-report.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '../fixtures/test';
+
+import { expectNoViolations } from './utils/axe';
+
+test.describe('a11y: print report', () => {
+  test('has no WCAG violations', async ({ page }) => {
+    await page.goto('/print-report/country/IDN');
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+
+    await expectNoViolations(page, { route: '/print-report' });
+  });
+
+  test('exposes a main landmark for the skip link', async ({ page }) => {
+    // Unblocked by phase 5B.
+    test.fixme(true, 'No <main id="main-content"> on /print-report until phase 5B');
+    await page.goto('/print-report/country/IDN');
+    await expect(page.locator('main#main-content')).toHaveCount(1);
+  });
+});

--- a/tests/a11y/print-report.spec.ts
+++ b/tests/a11y/print-report.spec.ts
@@ -11,8 +11,6 @@ test.describe('a11y: print report', () => {
   });
 
   test('exposes a main landmark for the skip link', async ({ page }) => {
-    // Unblocked by phase 5B.
-    test.fixme(true, 'No <main id="main-content"> on /print-report until phase 5B');
     await page.goto('/print-report/country/IDN');
     await expect(page.locator('main#main-content')).toHaveCount(1);
   });

--- a/tests/a11y/utils/axe.ts
+++ b/tests/a11y/utils/axe.ts
@@ -4,15 +4,6 @@ import type { Result } from 'axe-core';
 
 import { getKnownIssues } from '../known-issues';
 
-/**
- * WCAG tags we hold the app to.
- *
- * `best-practice` is deliberately excluded. It fires `region` and
- * `page-has-heading-one` on every scan, and both are asserted explicitly and
- * more precisely elsewhere (landmark and heading coverage live in the phase 5
- * specs). Including it would bury real WCAG failures under advisory noise and
- * push us toward muting rules wholesale.
- */
 export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] as const;
 
 interface ScanOptions {

--- a/tests/a11y/utils/axe.ts
+++ b/tests/a11y/utils/axe.ts
@@ -1,0 +1,74 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page } from '@playwright/test';
+import type { Result } from 'axe-core';
+
+import { getKnownIssues } from '../known-issues';
+
+/**
+ * WCAG tags we hold the app to.
+ *
+ * `best-practice` is deliberately excluded. It fires `region` and
+ * `page-has-heading-one` on every scan, and both are asserted explicitly and
+ * more precisely elsewhere (landmark and heading coverage live in the phase 5
+ * specs). Including it would bury real WCAG failures under advisory noise and
+ * push us toward muting rules wholesale.
+ */
+export const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa', 'wcag22aa'] as const;
+
+interface ScanOptions {
+  /**
+   * Key into `known-issues.ts`. Rules listed there are disabled for this scan
+   * and each entry names the phase that deletes it.
+   */
+  route: string;
+  /** Restrict the scan to a CSS selector (e.g. a single dialog). */
+  include?: string;
+  /** Exclude a CSS selector — use for third-party widgets we do not own. */
+  exclude?: string;
+  /** Extra rules to disable for this scan only, beyond the ledger. */
+  disableRules?: string[];
+}
+
+function formatViolations(violations: Result[]): string {
+  return violations
+    .map((violation) => {
+      const nodes = violation.nodes
+        .map((node) => `      - ${node.target.join(' ')}\n        ${node.failureSummary ?? ''}`)
+        .join('\n');
+      return `  [${violation.impact ?? 'unknown'}] ${violation.id}: ${violation.help}\n    ${
+        violation.helpUrl
+      }\n${nodes}`;
+    })
+    .join('\n\n');
+}
+
+/**
+ * Run axe against the current page state and assert there are no violations.
+ *
+ * Always attaches the full violation list to the Playwright report before
+ * asserting — a bare "expected 0, got 7" tells you nothing about which nodes
+ * failed, and the HTML report is where anyone debugging a CI failure looks.
+ */
+export async function expectNoViolations(page: Page, options: ScanOptions): Promise<void> {
+  const disabled = [...getKnownIssues(options.route), ...(options.disableRules ?? [])];
+
+  let builder = new AxeBuilder({ page }).withTags([...WCAG_TAGS]);
+
+  if (options.include) builder = builder.include(options.include);
+  if (options.exclude) builder = builder.exclude(options.exclude);
+  if (disabled.length > 0) builder = builder.disableRules(disabled);
+
+  const results = await builder.analyze();
+
+  await test.info().attach(`axe-${options.route.replace(/[^a-z0-9]+/gi, '-')}`, {
+    body: JSON.stringify(results.violations, null, 2),
+    contentType: 'application/json',
+  });
+
+  expect(
+    results.violations,
+    results.violations.length === 0
+      ? 'no accessibility violations'
+      : `Accessibility violations on ${options.route}:\n\n${formatViolations(results.violations)}\n`
+  ).toEqual([]);
+}

--- a/tests/component/components/chart/data-table.test.tsx
+++ b/tests/component/components/chart/data-table.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+
+import ChartDataTable from '@/components/chart/data-table';
+
+// A monthly series charted against `year` — the shape the alerts and net-change
+// brushes pass in, where the x value repeats for every month of the same year.
+const monthlyRows = [
+  { year: 2025, alerts: 10 },
+  { year: 2025, alerts: 20 },
+  { year: 2026, alerts: 30 },
+  { year: 2026, alerts: 40 },
+];
+
+describe('ChartDataTable', () => {
+  it('renders one row per data point when the x value repeats, without duplicate keys', () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ChartDataTable data={monthlyRows} xKey="year" seriesKeys={['alerts']} caption="Alerts" />
+    );
+
+    // header row + one row per data point
+    expect(screen.getAllByRole('row')).toHaveLength(monthlyRows.length + 1);
+    expect(screen.getAllByRole('rowheader').map((th) => th.textContent)).toEqual([
+      '2025',
+      '2025',
+      '2026',
+      '2026',
+    ]);
+    expect(screen.getAllByRole('cell').map((td) => td.textContent)).toEqual([
+      '10',
+      '20',
+      '30',
+      '40',
+    ]);
+    expect(error.mock.calls.flat().join(' ')).not.toContain('same key');
+
+    error.mockRestore();
+  });
+
+  it('names rows by position when they carry no label at all', () => {
+    render(
+      <ChartDataTable
+        data={[{ alerts: 1 }, { alerts: 2 }]}
+        seriesKeys={['alerts']}
+        caption="Alerts"
+      />
+    );
+
+    expect(screen.getAllByRole('rowheader').map((th) => th.textContent)).toEqual([
+      'Row 1',
+      'Row 2',
+    ]);
+  });
+});

--- a/tests/legend.spec.ts
+++ b/tests/legend.spec.ts
@@ -24,3 +24,44 @@ test('test legend order', async ({ page, browserName }) => {
   //   targetPosition: { x: 10, y: 20 },
   // });
 });
+
+// The drag activator lives on the "Drag to reorder" handle rather than the item
+// wrapper (nesting it around the item's other controls is a nested-interactive
+// violation), so the handle has to be what dnd-kit's KeyboardSensor responds to.
+test('a legend item can be reordered from its drag handle with the keyboard', async ({
+  page,
+  browserName,
+}) => {
+  test.fixme(browserName === 'firefox', 'Firefox: Recoil/hydration instability');
+  await page.goto('/');
+
+  const legendContent = page.getByTestId('legend-content');
+  await expect(legendContent).toBeVisible();
+
+  const netChangeLayerSwitcher = page.getByTestId('mangrove_net_change');
+  await netChangeLayerSwitcher.click();
+  await expect(netChangeLayerSwitcher).toHaveAttribute('data-state', 'checked');
+
+  const items = legendContent.locator('[data-testid^="legend-item-"]');
+  await expect(items).toHaveCount(2);
+  const order = () => items.evaluateAll((els) => els.map((el) => el.dataset.testid));
+  const before = await order();
+
+  // dnd-kit drives the keyboard drag off animation frames, so each key has to
+  // land before the next one is meaningful. Its own live region is the signal.
+  const announcement = () =>
+    page.evaluate(() =>
+      Array.from(document.querySelectorAll('[role="status"]'))
+        .map((el) => el.textContent ?? '')
+        .join(' ')
+    );
+
+  await legendContent.getByRole('button', { name: 'Drag to reorder' }).first().focus();
+  await page.keyboard.press('Space');
+  await expect.poll(announcement).toContain('Draggable item');
+  await page.keyboard.press('ArrowDown');
+  await expect.poll(announcement).toContain(before[1].replace('legend-item-', ''));
+  await page.keyboard.press('Space');
+
+  await expect.poll(order).toEqual([before[1], before[0]]);
+});

--- a/tests/navigation.spec.ts
+++ b/tests/navigation.spec.ts
@@ -33,7 +33,10 @@ test.describe('Blog navigation', () => {
     await postsList.waitFor();
 
     // Get the first post and its title
-    const firstPost = postsList.locator('h5').first();
+    // Selected by test id, not heading level: post titles moved from h5 to h4
+    // to close a gap in the heading hierarchy, and the level is presentation,
+    // not the thing this test is about.
+    const firstPost = postsList.getByTestId('post-title').first();
     const postTitle = await firstPost.textContent();
 
     // Click on the first post

--- a/tests/unit/styles/contrast.test.ts
+++ b/tests/unit/styles/contrast.test.ts
@@ -1,0 +1,87 @@
+import chroma from 'chroma-js';
+
+import tailwindConfig from '../../../tailwind.config.mjs';
+
+/**
+ * Contrast guard for the design tokens.
+ *
+ * axe only ever sees the colours a given test route happens to render, so it
+ * cannot tell us that a palette entry is unusable for text — it only tells us
+ * that one particular node failed. This asserts the property at the source.
+ *
+ * WCAG 1.4.3: 4.5:1 for normal text, 3:1 for large text (>=18.66px bold or
+ * >=24px). WCAG 1.4.11: 3:1 for UI components and graphical objects.
+ */
+
+const WHITE = '#ffffff';
+
+const colors = (tailwindConfig as { theme: { extend: { colors: Record<string, unknown> } } }).theme
+  .extend.colors;
+
+const flatten = (input: Record<string, unknown>, prefix = ''): Record<string, string> =>
+  Object.entries(input).reduce<Record<string, string>>((acc, [key, value]) => {
+    const name = prefix ? `${prefix}-${key}` : key;
+    if (typeof value === 'string') return { ...acc, [name]: value };
+    return { ...acc, ...flatten(value as Record<string, unknown>, name) };
+  }, {});
+
+const PALETTE = flatten(colors as Record<string, unknown>);
+
+/** Tokens the codebase uses to render body text on a white/near-white surface. */
+const BODY_TEXT_TOKENS = ['black', 'grey-600', 'brand-800', 'brand-900'];
+
+/** Tokens used for non-text UI on white: borders, icon fills, focus rings. */
+const NON_TEXT_TOKENS = ['brand-800', 'grey-600'];
+
+/**
+ * Tokens that are decorative only — large fills, backgrounds, chart series.
+ * Listed explicitly so that using one for text is a deliberate, visible choice
+ * rather than an accident.
+ */
+const DECORATIVE_ONLY = [
+  'grey-50',
+  'grey-75',
+  'grey-100',
+  'grey-400',
+  'grey-800',
+  'brand-100',
+  'brand-400',
+  // 2.7:1 on white. Only ever used as a background fill or as an inset ring on
+  // bg-brand-800 — never as a foreground on white.
+  'brand-600',
+  'blue-400',
+  'yellow-400',
+];
+
+describe('palette contrast on white', () => {
+  it.each(BODY_TEXT_TOKENS)('%s meets 4.5:1 for body text', (token) => {
+    expect(PALETTE[token], `${token} is not defined in tailwind.config.mjs`).toBeDefined();
+    expect(chroma.contrast(PALETTE[token], WHITE)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it.each(NON_TEXT_TOKENS)('%s meets 3:1 for non-text UI', (token) => {
+    expect(chroma.contrast(PALETTE[token], WHITE)).toBeGreaterThanOrEqual(3);
+  });
+
+  it('every palette token is classified', () => {
+    const classified = new Set([...BODY_TEXT_TOKENS, ...NON_TEXT_TOKENS, ...DECORATIVE_ONLY]);
+    const unclassified = Object.keys(PALETTE).filter((token) => !classified.has(token));
+
+    // A new token must be deliberately placed in one of the three buckets, so
+    // that adding an unreadable grey cannot slip in unnoticed.
+    expect(unclassified).toEqual([]);
+  });
+});
+
+describe('black alpha ramps used for text', () => {
+  // Tailwind opacity utilities on `black` composited over white. These are the
+  // ramps the widget styles use (text-black/85, /60) — /40 and /42 were 2.9:1
+  // and 3.0:1 respectively and have been removed from text usage.
+  it.each([
+    [0.85, 4.5],
+    [0.6, 4.5],
+  ])('text-black/%s meets %s:1', (alpha, minimum) => {
+    const composited = chroma.mix(WHITE, '#000000', alpha, 'rgb');
+    expect(chroma.contrast(composited, WHITE)).toBeGreaterThanOrEqual(minimum);
+  });
+});


### PR DESCRIPTION
## What

WCAG 2.2 AA remediation across the app, plus an axe-core Playwright harness that keeps it from regressing. 19 commits, one per criterion group, each self-contained and reviewable on its own.

Draft: the harness lands green against a ledger of knowingly-failing rules, and phases 1C / 3B / 4C / 5C are still open (see below).

## Commits, grouped by criterion

**Harness**
- `test(a11y)` — `@axe-core/playwright` specs for the map app, embedded view, print report, auth pages and 404, held to `wcag2a/2aa/21a/21aa/22aa`. `tests/a11y/known-issues.ts` lists the rules knowingly failing today, each annotated with the phase that deletes it, so the suite tightens monotonically instead of landing red and getting muted. Scans anchor on widget testids, not `networkidle` — widget cards render skeletons against the live API.

**Perceivable**
- `fix(a11y)` **1.4.3 / 1.4.11 contrast** — resolved phantom design tokens and raised text contrast.
- `fix(a11y)` **1.4.4 text resize, 1.4.10 reflow** — every hard-pixel panel width (share, download, basemap, legend info, IUCN + restoration popups, desktop nav) becomes `min(<designed>, <available>)`, so panels shrink instead of forcing horizontal scroll at 320 CSS px / 400% zoom. Tall dialog bodies gain `max-h-[80dvh] overflow-y-auto`. Species-threatened legend's inline pixel `maxHeight` → rem, so it stops clipping at 200% text size.
- `fix(a11y)` **1.4.1 use of colour** — Recharts conveys series identity through stroke and fill alone, so every chart is now a `<figure>` with an `aria-hidden` SVG alongside a visually hidden `<table>` of the same numbers. One change in the shared wrapper covers all 20 dataset charts. National dashboard sources and the gradient ramps get real tabular/labelled semantics.

**Operable**
- `fix(a11y)` **2.4.7 focus visible** — restored a visible focus indicator on interactive controls.
- `fix(a11y)` **2.5.8 target size** — the help hotspot is 20×20 and absolutely positioned, so it cannot claim the spacing exemption; a `::before` extends the hit area to 24×24 with no visual change. Map popup close button gets a real box.
- `fix(a11y)` **2.3.3 animation from interactions** — `MotionConfig reducedMotion="user"` at the provider root covers every motion/react component in one place; a `prefers-reduced-motion` media query covers CSS-driven motion outside its control (Tailwind `animate-*`, collapsible keyframes, help ping). Durations near-zero rather than `none` so animation/transition end events still fire.

**Understandable / Robust**
- `fix(a11y)` **1.3.1 / 4.1.2 forms** — real labels, accessible names and `autocomplete` on form controls.
- `fix(a11y)` **1.1.1 / 4.1.2 icons** — fixed icon semantics and named every icon-only control.
- `fix(a11y)` **2.4.2 / 1.3.1 document structure** — a title, a `main` landmark and a sane heading order on every route.
- `fix(a11y)` **2.4.1 / 1.3.1 landmark placement** — main was in two wrong places. On the map routes it wrapped only the widgets column while `MapContainer` sat outside it, so the skip link jumped *past* the map into the widget list; main moves to the route layout around both, and the widgets column becomes a labelled region. On `/auth/*` the shared layout wrapped the whole screen — logo, decorative hero and landing nav included — so each auth page now marks its own form column instead. Also removes an `aria-labelledby` on the signup / forgot-password / reset heroes that pointed at an id which only exists on signin, and unblocks four landmark specs left `test.fixme`'d after the phase-5B commit landed.

**Fallout from the remediation**

- `fix` **first click on a location was swallowed** — `tests/drawing-tool.spec.ts:26` timed out at the 2 minute cap. Not a flake: the locations listbox's `onFocus` is `focusin`, which bubbles, so pressing the mouse on an option focused that option and armed the keyboard cursor added for arrow-key navigation. The re-render moved the list (`scrollToIndex`) between mousedown and mouseup, so `click` was dispatched on the shared ancestor and the option's `onClick` never ran — every location needed two clicks. Only a Tab onto the listbox itself arms the cursor now. `CellMeasurerCache` was also constructed on every render, discarding measured row heights and shifting rows for the same reason; it is memoised.
- `fix` **duplicate React keys** — labels are not unique. A monthly series charted against `year` repeats one label per year, Planet mosaics collapse to month granularity, and the year lists from the API can repeat. A repeated year also turned a single-year source into a dropdown and gave Radix an ambiguous select value. Year lists are deduped at the source; chart rows and date options fall back to the index. `habitat-extent` also copies before sorting (`sort` mutated the cached response) and sorts numerically rather than lexicographically. Covered by `tests/component/components/chart/data-table.test.tsx`.
- `fix(a11y)` **legend drag activator moves onto its handle button** — `SortableItem` spread dnd-kit's `listeners` and `attributes` onto the item *wrapper*, giving it `role="button"` and `tabindex="0"` around the item's six other controls (drag, statistics, info, opacity, hide, remove). That is `nested-interactive` — serious, WCAG 4.1.2 — and it failed the map and embedded axe scans. The visible "Drag to reorder" button was inert the whole time: it received those props via `cloneElement` and never applied them. The activator now lives on that button, with `setActivatorNodeRef` so dnd-kit starts keyboard coordinates there, covered by a keyboard reorder test in `tests/legend.spec.ts`. Consequence: reordering is handle-only, so it is gone from the embedded view and from mobile, where no handle is rendered — it was undiscoverable in both, and dragging the wrapper was the violation.
- `test(a11y)` **two scans never actually ran** — `tests/a11y/auth.spec.ts` settled on `getByRole('button', { name: /sign in|sign up|send|reset/i })`, but the three pages label their submit button "Log in", "Register" and "Submit", so the locator never resolved and all three burned the full 120s timeout instead of scanning. Now matched by `type="submit"` inside `main#main-content`, which also survives translation. `tests/a11y/embedded.spec.ts` settled on `widgets-wrapper`, which `/embedded/*` never renders — it settles on the legend now.
- `style` — species selector radio is plain markup (20px ring, filled dot) instead of a react-icons glyph, dropping another `react-icons` import; multi-select checkbox shrinks to match. `fill-current` dropped from the multi-select check icon: it came after `fill-brand-800/70`, so currentColor won and the tick lost the brand colour.
- `docs` — removed unwanted comments.

## Still open (tracked in the ledger)

| Phase | Rule | Where |
|---|---|---|
| 1C | `color-contrast` | legend controls, species-threatened legend, opacity-30 subtitle, 404 body copy |
| 3B | `label`, `nested-interactive` | signup privacy-policy checkbox wrapped in a `<button>` |
| 4C | `button-name` | icon-only buttons in the map legend and news tooltip |
| 5C | `heading-order` | `h3` before `h2` in the legend, `h5` news titles, print-report and signin hero |

Each remediation phase deletes its own ledger entries; a phase is not done until they are gone.

Two more surfaced while chasing the drawing-tool timeout, both pre-existing on `develop` and left alone here:

- `WidgetDrawingTool`'s `drawing-tool-button` wraps `DeleteDrawingButton`, which renders its own `<button>` (`src/containers/datasets/drawing-tool/index.tsx:63-74`). Nested interactive controls — invalid HTML, a React hydration error on every load, and a `nested-interactive` violation.
- The geojson upload test logs `Error uploading file: AxiosError: Request failed with status code 400`. The test still passes; the API rejects the request.

## Test plan

- [x] `pnpm check-types` clean.
- [x] `pnpm lint` — 14 errors remain, all pre-existing prettier violations in files this branch does not touch (`components/ui/{checkbox,collapsible,dialog,tooltip}`, `types/widget.ts`, `restoration-sites/*`, …). Verified untouched vs `develop`.
- [x] `npx playwright test tests/drawing-tool.spec.ts tests/planet-date-select.spec.ts` — 12 passed locally, including the previously timing-out `clicking in search icon and selecting a place`.
- [x] `npx vitest run tests/component/components/chart/data-table.test.tsx` — 2 passed.
- [x] `npx playwright test tests/a11y` — 16 passed locally, no violations on any route. Includes the four landmark specs that were previously skipped, and the auth and embedded scans that had never run.
- [x] `npx playwright test tests/legend.spec.ts tests/layers.spec.ts` — 27 passed locally, including the new keyboard reorder test.
- [ ] `npx playwright test tests/a11y` green on the preview deploy.
- [ ] Skip link check per route: exactly one `main#main-content`, and it lands on the map (map routes) / the form column (auth routes).
- [ ] Full Playwright suite green on the preview deploy.
- [ ] 320px viewport / 400% zoom: open share, download, basemap, legend info, IUCN + restoration popups — no horizontal page scroll.
- [ ] Browser text size 200%: species-threatened legend list not clipped.
- [ ] OS *Reduce motion* on: widget collapse and legend transitions do not animate.
- [ ] Screen reader pass (VoiceOver) over one widget card: chart table readable, icon controls named, heading order sane.
- [ ] Keyboard-only pass: focus visible on every control, no trapped focus in dialogs.
- [ ] Legend drag with a mouse still reorders from the handle on desktop.
- [ ] Print report and embedded view unchanged visually.


