### PR TITLE
fix: resolve saved WDPA areas to canonical location before navigating

### DIFF
--- a/src/containers/datasets/locations/user-locations.tsx
+++ b/src/containers/datasets/locations/user-locations.tsx
@@ -4,13 +4,15 @@ import type GeoJSON from 'geojson';
 
 import API from 'services/api';
 
+import type { LocationTypes } from './types';
+
 export type UserLocationType = 'system' | 'custom';
 
 type SystemLocation = {
   id: number;
   name: string;
   iso: string;
-  location_type: UserLocationType;
+  location_type: LocationTypes;
   bounds: Bounds | null;
 };
 

--- a/src/containers/navigation/menu/profile/saved-areas/index.tsx
+++ b/src/containers/navigation/menu/profile/saved-areas/index.tsx
@@ -6,7 +6,7 @@ import { groupBy } from 'lodash-es';
 
 import { useSyncLocation } from 'hooks/use-sync-location';
 
-import { useLocation } from '@/containers/datasets/locations/hooks';
+import { useLocation, useLocations } from '@/containers/datasets/locations/hooks';
 import {
   useGetUserLocations,
   useGetUserSites,
@@ -23,6 +23,7 @@ const SavedAreasContent = () => {
   const { type: locationType, id: routeId } = useSyncLocation();
 
   const { data: location } = useLocation(routeId, locationType ?? undefined);
+  const { data: locationsRes } = useLocations();
   const { data: userLocationsRes, isLoading: isLoadingUserLocations } = useGetUserLocations();
 
   const userLocations = userLocationsRes?.data ?? [];
@@ -76,7 +77,7 @@ const SavedAreasContent = () => {
                     userLocationId={ul.id}
                     name={ul.name}
                     locationType={ul.location_type}
-                    location={ul.location}
+                    location={locationsRes?.data?.find((l) => l.id === ul.location?.id) ?? null}
                   />
                 ) : (
                   <LocationItem

--- a/src/containers/navigation/menu/profile/saved-areas/item.tsx
+++ b/src/containers/navigation/menu/profile/saved-areas/item.tsx
@@ -16,6 +16,7 @@ import { LuPencil, LuCheck } from 'react-icons/lu';
 
 import { useLocationNavigation, locationToNavTarget } from 'hooks/location-navigation';
 
+import type { Location } from '@/containers/datasets/locations/types';
 import {
   useDeleteUserLocation,
   useGetUserLocations,
@@ -80,7 +81,7 @@ type Props = {
   userLocationId: number;
   name: string;
   locationType: UserLocationType;
-  location?: Feature<Polygon> | null;
+  location?: Location | null;
   geometry?: CustomGeometry;
 };
 

--- a/src/hooks/location-navigation/index.ts
+++ b/src/hooks/location-navigation/index.ts
@@ -38,6 +38,7 @@ export const locationToNavTarget = (
     case 'country':
       return { type: 'country', iso: location.iso };
     case 'wdpa':
+      if (!location.location_id) return { type: 'worldwide' };
       return { type: 'wdpa', locationId: location.location_id };
     case 'custom-area':
       return { type: 'custom-area' };

--- a/tests/unit/hooks/location-navigation/index.test.ts
+++ b/tests/unit/hooks/location-navigation/index.test.ts
@@ -26,6 +26,12 @@ describe('locationToNavTarget', () => {
     });
   });
 
+  it('falls back to worldwide for a wdpa location missing its location_id', () => {
+    expect(
+      locationToNavTarget({ location_type: 'wdpa', iso: '', location_id: undefined as never })
+    ).toEqual({ type: 'worldwide' });
+  });
+
   it('maps a custom-area location', () => {
     expect(
       locationToNavTarget({ location_type: 'custom-area', iso: '', location_id: '0' })


### PR DESCRIPTION
## Summary

Closes #1659 — clicking a saved WDPA in "My areas" navigated to `/wdpa/undefined?bounds=...` and tripped the 500 error boundary.

**Root cause:** the nested `location` object returned by `GET /user_locations` carries `{ id, name, iso, location_type, bounds }` but **no `location_id`**. `locationToNavTarget` reads `location.location_id` for the WDPA branch, producing a literal `/wdpa/undefined` URL. Countries worked by accident because their branch navigates by `iso`.

**Changes:**
- `saved-areas/index.tsx`: resolve each saved system area's numeric `id` against the cached `useLocations()` list and pass the full canonical `Location` (with string `location_id` and GeoJSON bounds) to `LocationItem`.
- `saved-areas/item.tsx`: correct the prop type from the false `Feature<Polygon> | null` (which masked the bug under `strict: false`) to `Location | null`.
- `hooks/location-navigation`: defensive guard — a wdpa location without `location_id` falls back to `worldwide` instead of emitting `undefined` in the URL.
- `user-locations.tsx`: `SystemLocation.location_type` is really `LocationTypes` (`'wdpa' | 'country' | ...`) at runtime, not the `'system' | 'custom'` discriminator — type corrected.
- Regression unit test for the guard.

**Follow-ups (out of scope):**
- Backend could include `location_id` in the `user_locations` nested location serializer.
- `app/[[...params]]/page.tsx` accepts garbage ids and ~25 widget hooks destructure `useLocation().data` non-defensively (this is what turns a bad id into the error boundary).

## Test plan
- [x] Unit tests pass (`pnpm test:unit`, 119 tests) incl. new regression test
- [x] `tsc` + eslint clean on changed files
- [ ] Manual: login, save a WDPA, click it in My areas → flies to `/wdpa/<location_id>`, no error page
- [ ] Regression: saved country + saved custom area still navigate correctly