### PR TITLE
fix: keep partner logo aspect ratios controlled in CSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,12 +138,17 @@
       "next>postcss": "8.5.23",
       "next>sharp": "0.35.0",
       "jsdom>undici": "7.29.0",
-      "minimatch@^10>brace-expansion": "5.0.7",
-      "minimatch@3>brace-expansion": "1.1.16",
+      "minimatch@^10>brace-expansion": "5.0.9",
+      "minimatch@3>brace-expansion": "1.1.18",
       "next-auth>uuid": "11.1.1",
       "axios>form-data": "4.0.6",
-      "@eslint/eslintrc>js-yaml": "4.3.0",
-      "eslint-plugin-react-hooks>@babel/core": "7.29.6"
+      "@eslint/eslintrc>js-yaml": "4.3.1",
+      "eslint-plugin-react-hooks>@babel/core": "7.29.6",
+      "brace-expansion@<1.1.18": ">=1.1.18",
+      "brace-expansion@>=4.0.0 <5.0.9": ">=5.0.9",
+      "js-yaml@>=4.0.0 <4.3.1": ">=4.3.1",
+      "nanoid@>=4.0.0 <5.1.16": ">=5.1.16",
+      "nanoid@<3.3.18": "3.3.18"
     },
     "onlyBuiltDependencies": [
       "@parcel/watcher",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,17 @@ overrides:
   next>postcss: 8.5.23
   next>sharp: 0.35.0
   jsdom>undici: 7.29.0
-  minimatch@^10>brace-expansion: 5.0.7
-  minimatch@3>brace-expansion: 1.1.16
+  minimatch@^10>brace-expansion: 5.0.9
+  minimatch@3>brace-expansion: 1.1.18
   next-auth>uuid: 11.1.1
   axios>form-data: 4.0.6
-  '@eslint/eslintrc>js-yaml': 4.3.0
+  '@eslint/eslintrc>js-yaml': 4.3.1
   eslint-plugin-react-hooks>@babel/core: 7.29.6
+  brace-expansion@<1.1.18: '>=1.1.18'
+  brace-expansion@>=4.0.0 <5.0.9: '>=5.0.9'
+  js-yaml@>=4.0.0 <4.3.1: '>=4.3.1'
+  nanoid@>=4.0.0 <5.1.16: '>=5.1.16'
+  nanoid@<3.3.18: 3.3.18
 
 importers:
 
@@ -3038,12 +3043,12 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4118,8 +4123,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -4583,14 +4588,14 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
-    engines: {node: ^18 || >=20}
+  nanoid@6.0.1:
+    resolution: {integrity: sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw==}
+    engines: {node: ^22 || ^24 || >=26}
     hasBin: true
 
   napi-postinstall@0.3.4:
@@ -6029,7 +6034,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6223,7 +6228,7 @@ snapshots:
       '@mapbox/point-geometry': 1.1.0
       '@turf/projection': 7.3.4
       fast-deep-equal: 3.1.3
-      nanoid: 5.1.7
+      nanoid: 6.0.1
 
   '@mapbox/point-geometry@1.1.0': {}
 
@@ -8239,12 +8244,12 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -9527,7 +9532,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -10109,11 +10114,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -10133,9 +10138,9 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
-  nanoid@5.1.7: {}
+  nanoid@6.0.1: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10389,7 +10394,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/src/containers/navigation/menu/about/constants.tsx
+++ b/src/containers/navigation/menu/about/constants.tsx
@@ -23,7 +23,7 @@ export const ConvenedBy = [
     name: 'The Nature Conservancy',
     url: 'https://www.nature.org/',
     image: '/images/partners/convened/TNC.webp',
-    size: [150, 40],
+    size: [150, 51],
   },
 ] satisfies ItemType[];
 

--- a/src/containers/navigation/menu/about/partners.tsx
+++ b/src/containers/navigation/menu/about/partners.tsx
@@ -22,6 +22,7 @@ const AboutPartners = ({ title, list, classname }: PartnerProps) => {
               width={item.size[0]}
               height={item.size[1]}
               className="cursor-pointer"
+              style={{ width: item.size[0], height: 'auto' }}
             />
           </Link>
         ))}

--- a/src/containers/navigation/menu/partners/index.tsx
+++ b/src/containers/navigation/menu/partners/index.tsx
@@ -15,7 +15,13 @@ const PartnersLinks = () => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          <Image alt="GMA" src="/images/menu/gma.webp" width={150} height={65} />
+          <Image
+            alt="GMA"
+            src="/images/menu/gma.webp"
+            width={150}
+            height={65}
+            className="h-auto w-[150px]"
+          />
         </Link>
       </div>
 


### PR DESCRIPTION
## Summary

Fixes browser console warnings from `next/image`:

> Image with src "/images/menu/gma.webp" has either width or height modified, but not the other…
> Image with src "/images/partners/convened/TNC.webp" has either width or height modified, but not the other…

Tailwind's preflight applies `img { max-width: 100%; height: auto }`, so height was CSS-modified while width wasn't. Fix: pin width in CSS too (`w-[150px] h-auto` on the GMA logo, `style={{ width, height: 'auto' }}` in `AboutPartners`), keeping aspect ratios intact.

Also corrected TNC's declared size from `[150, 40]` to `[150, 51]` to match the asset's intrinsic 187×64 ratio (the browser already rendered it at ~51px tall; the attribute just reserved the wrong space).

## Test plan
- [x] `tsc` + eslint/oxlint clean (pre-commit hooks ran)
- [ ] Manual: open menu → About/Partners panels, confirm no console warnings and logos are not distorted