### PR TITLE
data: add Mangrove Breakthrough location attributes notebook

### DIFF
--- a/data/notebooks/Lab/data_processing/location_attributes.ipynb
+++ b/data/notebooks/Lab/data_processing/location_attributes.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "15e4bf77",
+   "metadata": {},
+   "source": [
+    "# Location Attributes\n",
+    "\n",
+    "Generate the `location_attributes.csv` file for the backoffice upload.\n",
+    "\n",
+    "**Input:**\n",
+    "- `data/raw/Mangrove_Breakthrough_Countries_20260528.xlsx` — list of countries that have committed to the Mangrove Breakthrough (shared by email, uploaded to bucket)\n",
+    "- `data/raw/locations_merged.csv` — platform locations with UUIDs\n",
+    "\n",
+    "**Output:**\n",
+    "- `data/processed/location_attributes.csv` — CSV with columns `location_id`, `legal_status`, `mangrove_breakthrough_committed`\n",
+    "\n",
+    "**Notes:**\n",
+    "- Uploading this file to the backoffice **replaces all** existing location attribute records.\n",
+    "- `legal_status` is left empty for now (data not yet available).\n",
+    "- South Korea (listed in the Excel) has no matching entry in `locations_merged.csv` (neither ISO `KOR` nor `PRK` exist). It is excluded from the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa0719c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import openpyxl\n",
+    "\n",
+    "RAW = Path(\"../data/raw\")\n",
+    "PROCESSED = Path(\"../data/processed\")\n",
+    "\n",
+    "EXCEL_PATH = RAW / \"Mangrove_Breakthrough_Countries_20260528.xlsx\"\n",
+    "LOCATIONS_PATH = RAW / \"locations_merged.csv\"\n",
+    "OUTPUT_PATH = PROCESSED / \"location_attributes.csv\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56416502",
+   "metadata": {},
+   "source": [
+    "## 1. Read Mangrove Breakthrough countries from Excel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de9fdba3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wb = openpyxl.load_workbook(EXCEL_PATH, read_only=True)\n",
+    "ws = wb.active\n",
+    "\n",
+    "breakthrough_countries = []\n",
+    "for i, row in enumerate(ws.iter_rows(values_only=True)):\n",
+    "    if i == 0:\n",
+    "        continue  # skip header\n",
+    "    breakthrough_countries.append(row[0].strip())\n",
+    "\n",
+    "print(f\"{len(breakthrough_countries)} Mangrove Breakthrough countries:\")\n",
+    "for c in breakthrough_countries:\n",
+    "    print(f\"  - {c}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59e891dc",
+   "metadata": {},
+   "source": [
+    "## 2. Load platform locations and build country lookup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2c06ac1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(LOCATIONS_PATH) as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    country_to_id = {\n",
+    "        row[\"name\"]: row[\"id\"]\n",
+    "        for row in reader\n",
+    "        if row[\"type\"] == \"country\"\n",
+    "    }\n",
+    "\n",
+    "print(f\"{len(country_to_id)} countries in locations_merged.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64d40a10",
+   "metadata": {},
+   "source": [
+    "## 3. Match breakthrough countries to location IDs\n",
+    "\n",
+    "Name mapping is needed for \"Mexico\" (listed as \"Mexico\" in Excel, stored as \"México\" in the platform).\n",
+    "\n",
+    "South Korea is listed in the Mangrove Breakthrough Excel but does **not** exist in `locations_merged.csv`. It is excluded from the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29a84c5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Name corrections: Excel name -> platform name\n",
+    "NAME_MAP = {\n",
+    "    \"Mexico\": \"México\",\n",
+    "}\n",
+    "\n",
+    "breakthrough_names = set()\n",
+    "unmatched = []\n",
+    "\n",
+    "for country in breakthrough_countries:\n",
+    "    name = NAME_MAP.get(country, country)\n",
+    "    if name in country_to_id:\n",
+    "        breakthrough_names.add(name)\n",
+    "    else:\n",
+    "        unmatched.append(country)\n",
+    "\n",
+    "print(f\"Matched: {len(breakthrough_names)}/{len(breakthrough_countries)}\")\n",
+    "if unmatched:\n",
+    "    print(f\"Unmatched (excluded from output): {unmatched}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69f70d10",
+   "metadata": {},
+   "source": [
+    "## 4. Write location_attributes.csv\n",
+    "\n",
+    "All 122 countries are included. Breakthrough countries get `true`, the rest get `false`. This is necessary because uploading replaces all existing location attribute records."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e06d3c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(OUTPUT_PATH, \"w\", newline=\"\") as f:\n",
+    "    writer = csv.writer(f)\n",
+    "    writer.writerow([\"location_id\", \"legal_status\", \"mangrove_breakthrough_committed\"])\n",
+    "    for name, loc_id in sorted(country_to_id.items(), key=lambda x: int(x[1])):\n",
+    "        committed = \"true\" if name in breakthrough_names else \"false\"\n",
+    "        writer.writerow([loc_id, \"\", committed])\n",
+    "\n",
+    "print(f\"Written {len(country_to_id)} rows to {OUTPUT_PATH}\")\n",
+    "print(f\"  - {len(breakthrough_names)} with mangrove_breakthrough_committed=true\")\n",
+    "print(f\"  - {len(country_to_id) - len(breakthrough_names)} with mangrove_breakthrough_committed=false\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Adds notebook to generate `location_attributes.csv` for backoffice upload
- Reads Mangrove Breakthrough countries from Excel, matches to platform location IDs from `locations_merged.csv`
- Outputs all 122 countries: 22 with `mangrove_breakthrough_committed=true`, 100 with `false`
- South Korea is listed in the Excel but does not exist in `locations_merged.csv` (no `KOR`/`PRK` ISO code) — excluded from output
- `legal_status` column left empty (data not yet available)

## Notes
- The generated CSV (`data/processed/location_attributes.csv`) is gitignored — run the notebook to produce it
- Uploading the CSV to the backoffice replaces all existing location attribute records