### PR TITLE
fix: align national dashboard widget styles with design

### DIFF
--- a/src/containers/datasets/national-dashboard/hooks.tsx
+++ b/src/containers/datasets/national-dashboard/hooks.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import type { LayerProps, SourceProps } from 'react-map-gl';
 
@@ -47,13 +47,18 @@ export function useNationalDashboard(
     return ['national_dashboard', JSON.stringify(params), location_id];
   }, [params, location_id]);
 
-  return useQuery<DataResponse, Error, NationalDashboardResult>({
-    queryKey,
-    queryFn: fetchMangroveNationalDashboard,
-    select: (data: DataResponse) => ({
+  const select = useCallback(
+    (data: DataResponse): NationalDashboardResult => ({
       ...data,
       locationIso: iso,
     }),
+    [iso]
+  );
+
+  return useQuery<DataResponse, Error, NationalDashboardResult>({
+    queryKey,
+    queryFn: fetchMangroveNationalDashboard,
+    select,
     ...queryOptions,
   });
 }

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -46,22 +46,16 @@ const IndicatorSources = ({
     [activeLayers, layerId]
   );
 
-  const buildLayer = useCallback(
-    (): Layer => ({
-      id: layerId,
-      opacity: '1',
-      visibility: 'visible',
-      settings: {
-        name: source,
-        location: locationIso,
-        layerIndex,
-        source: dataSource?.layer_link,
-        source_layer: dataSource?.source_layer,
-        year: yearSelected,
-      },
+  const layerSettings = useMemo(
+    () => ({
+      name: source,
+      location: locationIso,
+      layerIndex,
+      source: dataSource?.layer_link,
+      source_layer: dataSource?.source_layer,
+      year: yearSelected,
     }),
     [
-      layerId,
       source,
       locationIso,
       layerIndex,
@@ -71,33 +65,24 @@ const IndicatorSources = ({
     ]
   );
 
+  const buildLayer = useCallback(
+    (): Layer => ({
+      id: layerId,
+      opacity: '1',
+      visibility: 'visible',
+      settings: layerSettings,
+    }),
+    [layerId, layerSettings]
+  );
+
   const updateCurrentLayer = useCallback(
     (layers: Layer[] = []): Layer[] =>
       layers.map((layer) =>
         layer.id === layerId
-          ? {
-              ...layer,
-              settings: {
-                ...layer.settings,
-                name: source,
-                location: locationIso,
-                layerIndex,
-                source: dataSource?.layer_link,
-                source_layer: dataSource?.source_layer,
-                year: yearSelected,
-              },
-            }
+          ? { ...layer, settings: { ...layer.settings, ...layerSettings } }
           : layer
       ),
-    [
-      layerId,
-      source,
-      locationIso,
-      layerIndex,
-      dataSource?.layer_link,
-      dataSource?.source_layer,
-      yearSelected,
-    ]
+    [layerId, layerSettings]
   );
 
   useEffect(() => {

--- a/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
@@ -1,10 +1,10 @@
 import type { IndicatorSourceProps } from './types';
 
 const IndicatorSource = ({ source, color }: IndicatorSourceProps) => (
-  <div role="cell" className="flex w-full items-start space-x-2" aria-label={source}>
+  <div role="cell" className="flex w-full items-center space-x-2.5" aria-label={source}>
     <div
       style={{ backgroundColor: color }}
-      className="mt-1 h-4 w-2 shrink-0 rounded-md"
+      className="h-4 w-2 shrink-0 rounded-sm"
       aria-hidden="true"
     />
     <span className="truncate" title={source}>

--- a/src/containers/datasets/national-dashboard/indicator-layers/types.ts
+++ b/src/containers/datasets/national-dashboard/indicator-layers/types.ts
@@ -1,13 +1,8 @@
 import type { WidgetSlugType } from 'types/widget';
 
-type DataSourceType = {
-  year: number;
-  value: number;
-  layer_link: `globalmangrovewatch.${string}`;
-  download_link: string | null;
-  layer_info: string;
-  source_layer: string;
-};
+import type { IndicatorSourceEntry } from '../types';
+
+type DataSourceType = IndicatorSourceEntry;
 
 export type IndicatorSourcesProps = {
   id: WidgetSlugType;

--- a/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/year.tsx
@@ -18,7 +18,7 @@ const IndicatorYear = ({ years, yearSelected, setYearSelected }: IndicatorYearPr
               type="button"
               aria-haspopup="listbox"
               aria-label={`Select year, current ${yearSelected}`}
-              className={`${WIDGET_SELECT_STYLES}`}
+              className={WIDGET_SELECT_STYLES}
             >
               {yearSelected}
               <ARROW_SVG

--- a/src/containers/datasets/national-dashboard/legal-status.tsx
+++ b/src/containers/datasets/national-dashboard/legal-status.tsx
@@ -1,3 +1,5 @@
+import { WIDGET_SENTENCE_STYLE } from 'styles/widgets';
+
 const LegalStatus = ({
   location,
   legalStatus,
@@ -5,9 +7,9 @@ const LegalStatus = ({
   location: string;
   legalStatus: 'forest' | 'mangrove';
 }) => (
-  <p>
+  <p className={`${WIDGET_SENTENCE_STYLE} pb-6.25`}>
     The mangroves in <span className="font-bold">{location}</span> have the legal status of{' '}
-    <span className="font-bold">{legalStatus}</span>
+    <span className="font-bold">{legalStatus}</span>.
   </p>
 );
 

--- a/src/containers/datasets/national-dashboard/mangrove-breakthrough.tsx
+++ b/src/containers/datasets/national-dashboard/mangrove-breakthrough.tsx
@@ -11,15 +11,15 @@ const MangroveBreakthrough = ({
   mangroveBreakthrough: boolean;
 }) => {
   return (
-    <section className="space-y-2 py-[25px]">
-      <div className="flex items-center justify-between">
+    <section className="space-y-2 py-6.25">
+      <div className="flex items-center justify-between gap-8">
         <p
           className={cn({
-            'text-sm first-letter:capitalize': true,
+            'text-sm leading-5 first-letter:capitalize': true,
             'max-w-[50%]': mangroveBreakthrough,
           })}
         >
-          {location} is {mangroveBreakthrough ? '' : 'not currently'} committed to{' '}
+          {location} has {mangroveBreakthrough ? '' : 'not yet '}endorsed the{' '}
           <Link
             href="https://www.mangrovealliance.org/news/the-mangrove-breakthrough"
             target="_blank"
@@ -35,6 +35,7 @@ const MangroveBreakthrough = ({
             alt="Mangrove breakthrough"
             width={135}
             height={26}
+            className="h-[26px] w-auto shrink-0 object-contain"
           />
         )}
       </div>

--- a/src/containers/datasets/national-dashboard/map-legend.tsx
+++ b/src/containers/datasets/national-dashboard/map-legend.tsx
@@ -94,10 +94,10 @@ const SourceRow = ({ layer, color, name }: SourceRowProps) => {
       >
         <DRAG_SVG aria-hidden={true} />
       </button>
-      <div className="flex min-w-0 flex-1 items-start">
+      <div className="flex min-w-0 flex-1 items-center">
         <div
           style={{ backgroundColor: color }}
-          className="my-0.5 mr-2.5 h-4 w-2 shrink-0 rounded-md text-sm"
+          className="mr-2.5 h-4 w-2 shrink-0 rounded-sm"
           aria-hidden="true"
         />
         <p className="truncate text-sm">{name}</p>

--- a/src/containers/datasets/national-dashboard/other-resources/index.tsx
+++ b/src/containers/datasets/national-dashboard/other-resources/index.tsx
@@ -1,25 +1,18 @@
-import cn from 'classnames';
+import cn from '@/lib/classnames';
 
 import { WIDGET_SUBTITLE_STYLE } from 'styles/widgets';
 
+import type { OtherResource } from '../types';
+
 import Resources from './resources';
 
-const OtherResources = ({
-  resources,
-}: {
-  resources: Array<{ name: string; description: string; link: string }>;
-}) => (
-  <>
-    <div className="bg-brand-800/30 absolute right-0 left-0 h-0.5" />
-    <section className="space-y-2 py-[25px] text-sm">
-      <h3 className={cn({ [WIDGET_SUBTITLE_STYLE]: true, 'py-2 font-normal': true })}>
-        OTHER RESOURCES
-      </h3>
-      {resources.map((resource) => (
-        <Resources key={resource.link} {...resource} />
-      ))}
-    </section>
-  </>
+const OtherResources = ({ resources }: { resources: OtherResource[] }) => (
+  <section className="space-y-2 py-6.25 text-sm">
+    <h3 className={cn(WIDGET_SUBTITLE_STYLE, 'py-2 font-normal')}>Other resources</h3>
+    {resources.map((resource) => (
+      <Resources key={resource.link} {...resource} />
+    ))}
+  </section>
 );
 
 export default OtherResources;

--- a/src/containers/datasets/national-dashboard/other-resources/resources.tsx
+++ b/src/containers/datasets/national-dashboard/other-resources/resources.tsx
@@ -8,8 +8,8 @@ type ResourceTypes = {
 
 const Resources = (resource: ResourceTypes) => {
   return (
-    <div className="flex flex-1 items-start justify-between">
-      {<p>{resource.name}</p>}
+    <div className="flex flex-1 items-center justify-between gap-4">
+      <p className="leading-5">{resource.name}</p>
       <WidgetControls content={{ ...resource }} />
     </div>
   );

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -2,6 +2,7 @@ import chroma from 'chroma-js';
 
 import { COLORS } from './constants';
 import IndicatorSource from './indicator-layers';
+import type { IndicatorDataItem } from './types';
 
 const slugify = (value: string) =>
   value
@@ -9,7 +10,7 @@ const slugify = (value: string) =>
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
 
-const Sources = ({ data, iso }) => {
+const Sources = ({ data, iso }: { data: IndicatorDataItem[]; iso: string }) => {
   const sourceColorMap = new Map<string, number>();
   data?.forEach(({ sources }) => {
     sources?.forEach(({ source }) => {
@@ -25,7 +26,7 @@ const Sources = ({ data, iso }) => {
 
   const gridCols = 'grid grid-cols-[140px_max-content_1fr_max-content] items-center gap-x-4';
   return (
-    <section className="space-y-6.25">
+    <section className="space-y-6.25 py-[25px]">
       {data?.map(({ indicator, sources }) => (
         /*
          * ARIA table roles rather than <table> markup: the visual layout is a
@@ -39,19 +40,12 @@ const Sources = ({ data, iso }) => {
          * they polluted the page outline with three entries per indicator.
          */
         <div key={indicator} role="table" aria-label={`${indicator} sources`}>
-          <div role="row" className={`${gridCols} py-2`}>
-            <span role="columnheader" className="text-sm font-normal">
-              Source
-            </span>
-            <span role="columnheader" className="text-sm font-normal">
-              Year
-            </span>
-            <span role="columnheader" className="text-sm font-normal">
-              Extent
-            </span>
-            <span role="columnheader" className="sr-only">
-              Layer controls
-            </span>
+          {/* Headers stay for screen readers; the design shows the rows without them. */}
+          <div role="row" className="sr-only">
+            <span role="columnheader">Source</span>
+            <span role="columnheader">Year</span>
+            <span role="columnheader">Extent</span>
+            <span role="columnheader">Layer controls</span>
           </div>
           {sources.map(({ source, years, unit, data_source }) => {
             const colorIndex = sourceColorMap.get(source) ?? 0;
@@ -72,7 +66,7 @@ const Sources = ({ data, iso }) => {
                 unit={unit}
                 data_source={data_source}
                 color={color}
-                className={`${gridCols} py-3`}
+                className={`${gridCols} text-2lg py-3 leading-7.5 font-light`}
               />
             );
           })}

--- a/src/containers/datasets/national-dashboard/types.d.ts
+++ b/src/containers/datasets/national-dashboard/types.d.ts
@@ -1,55 +1,10 @@
-type DataSource = {
-  download_link: string;
+export type IndicatorSourceEntry = {
+  year: number;
+  value: number;
   layer_info: string;
   layer_link: string;
-  value: number;
-  year: number;
-};
-type Source = {
-  data_source: DataSource[];
-  source: string;
-  unit: string;
-  years: number[];
-};
-
-type Data = {
-  indicator: string;
-  sources: Source[];
-  legal_status?: string;
-  mangrove_breakthrough_committed?: boolean | null;
-  [key: string]: unknown;
-};
-
-type Metadata = {
-  locations_id: string;
-  note: string;
-  other_resources: OtherResource[];
-};
-export type DataResponse = {
-  data: any;
-  metadata: Metadata;
-};
-
-export type LayerSettingsType = {
-  source?: string;
-  name?: string;
-  source_layer?: string;
-  layerIndex?: number;
-  year?: number;
-  [key: string]: string | number;
-};
-
-export type IndicatorResponse = {
-  data: IndicatorDataItem[];
-  metadata: IndicatorMetadata;
-  locationIso: string;
-};
-
-export type IndicatorDataItem = {
-  indicator: string;
-  legal_status: 'forest' | 'mangrove';
-  mangrove_breakthrough_committed: boolean | null;
-  sources: IndicatorSource[];
+  download_link: string | null;
+  source_layer: string;
 };
 
 export type IndicatorSource = {
@@ -59,13 +14,11 @@ export type IndicatorSource = {
   data_source: IndicatorSourceEntry[];
 };
 
-export type IndicatorSourceEntry = {
-  year: number;
-  value: number;
-  layer_info: string;
-  layer_link: string;
-  download_link: string | null;
-  source_layer: string;
+export type IndicatorDataItem = {
+  indicator: string;
+  legal_status: 'forest' | 'mangrove';
+  mangrove_breakthrough_committed: boolean | null;
+  sources: IndicatorSource[];
 };
 
 export type OtherResource = {
@@ -79,4 +32,18 @@ export type IndicatorMetadata = {
   legal_status_options: string[];
   other_resources: OtherResource[];
   note: string | null;
+};
+
+export type DataResponse = {
+  data: IndicatorDataItem[];
+  metadata: IndicatorMetadata;
+};
+
+export type LayerSettingsType = {
+  source?: string;
+  name?: string;
+  source_layer?: string;
+  layerIndex?: number;
+  year?: number;
+  [key: string]: string | number;
 };

--- a/src/containers/datasets/national-dashboard/widget.tsx
+++ b/src/containers/datasets/national-dashboard/widget.tsx
@@ -1,5 +1,3 @@
-import cn from '@/lib/classnames';
-
 import { useSyncLocation } from 'hooks/use-sync-location';
 
 import Loading from '@/components/ui/loading';
@@ -22,34 +20,38 @@ const NationalDashboard = () => {
   const ISO = data?.locationIso;
 
   const { data: location } = useLocation(id, locationType);
+  const locationName = location?.name;
+
+  const firstIndicator = data?.data?.[0];
 
   if (
     isFetched &&
-    !data?.data?.mangrove_breakthrough_committed &&
-    !data?.data?.legal_status &&
+    !firstIndicator?.mangrove_breakthrough_committed &&
+    !firstIndicator?.legal_status &&
     data?.data?.length === 0
   )
     return <NoMetadata />;
 
   return (
-    <div className={cn(WIDGET_CARD_WRAPPER_STYLE)}>
+    <div className={WIDGET_CARD_WRAPPER_STYLE}>
       <Loading visible={isLoading && !isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && !isFetching && data && (
-        <div className="space-y-6.25">
-          {data?.data?.legal_status && process.env.NEXT_PUBLIC_VERCEL_ENV === 'development' && (
-            <LegalStatus location={location.name} legalStatus={data?.data?.legal_status} />
+        <div>
+          {firstIndicator?.legal_status && locationName && (
+            <LegalStatus location={locationName} legalStatus={firstIndicator.legal_status} />
           )}
-          {isFetched && !data?.data.length && <NoData />}
-          {isFetched && data?.data.length > 0 && <Sources data={data?.data} iso={ISO} />}
-
-          {!!data?.metadata?.other_resources.length && isFetched && (
-            <OtherResources resources={data?.metadata?.other_resources} />
+          {data.data?.length ? <Sources data={data.data} iso={ISO} /> : <NoData />}
+          {!!data.metadata?.other_resources?.length && (
+            <>
+              <div className="bg-brand-800/30 absolute right-0 left-0 h-0.5" />
+              <OtherResources resources={data.metadata.other_resources} />
+            </>
           )}
 
-          <div className="bg-brand-800/35 absolute right-0 left-0 h-0.5" />
+          <div className="bg-brand-800/30 absolute right-0 left-0 h-0.5" />
           <MangroveBreakthrough
-            location={location.name}
-            mangroveBreakthrough={data?.data?.[0]?.mangrove_breakthrough_committed}
+            location={locationName ?? ''}
+            mangroveBreakthrough={!!firstIndicator?.mangrove_breakthrough_committed}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary

Implements the [Figma design](https://www.figma.com/design/GJCx8yGfx6JERPuxlpG3nK/GMW--Internal-?node-id=6630-14384&m=dev) for the national dashboard widget now that the Legal Status and Mangrove Breakthrough Commitment sections have been added, plus a best-practices pass over the widget.

Jira: [GMW-1088](https://vizzuality.atlassian.net/browse/GMW-1088)

### Style changes (per design)
- Legal Status sentence uses `WIDGET_SENTENCE_STYLE` with bold location/status and trailing period
- Removed the `NEXT_PUBLIC_VERCEL_ENV === 'development'` gate on Legal Status — the design ships it
- Source rows at `text-2lg`/`leading-7.5` light; column headers kept for screen readers but visually hidden (design shows rows without headers)
- Color chips centered with text, 4px radius, 10px gap (widget + map legend)
- Mangrove Breakthrough copy per design ("has endorsed the …"), logo aspect ratio controlled in CSS
- Dividers unified to `bg-brand-800/30`; the Other Resources divider only renders when there are resources
- Spacing normalized to the Tailwind scale (`py-6.25` instead of `py-[25px]`), Other Resources heading in sentence case (CSS uppercases)

### Fixes
- `legal_status` / `mangrove_breakthrough_committed` read from `data.data[0]` — the API payload is an array, so the old object-access guards never matched and Legal Status never rendered
- `location?.name` no longer crashes when the location query hasn't resolved

### Best practices
- `DataResponse.data` typed as `IndicatorDataItem[]` (was `any`); dead duplicate types removed; `Sources` and `OtherResources` props typed
- `buildLayer`/`updateCurrentLayer` share one `layerSettings` memo
- Stable `select` callback in `useNationalDashboard`
- Conditional rendering via ternary, hoisted repeated optional chains, `cn` import consistency

## Test plan
- [x] `tsc --noEmit` and ESLint clean
- [ ] Verify widget on a location with national dashboard data (e.g. Mozambique) against the Figma design
- [ ] Verify Legal Status sentence renders in production build (gate removed)
- [ ] Verify Mangrove Breakthrough yes/no copy variants
- [ ] Verify map legend rows still render correctly with an active national layer

[GMW-1088]: https://vizzuality.atlassian.net/browse/GMW-1088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ