### PR TITLE
fix: show loader while national dashboard widget fetches

### DIFF
--- a/src/containers/datasets/national-dashboard/widget.tsx
+++ b/src/containers/datasets/national-dashboard/widget.tsx
@@ -14,7 +14,7 @@ import OtherResources from './other-resources';
 import Sources from './sources';
 
 const NationalDashboard = () => {
-  const { data, isLoading, isFetching, isFetched } = useNationalDashboard();
+  const { data, isFetching, isFetched } = useNationalDashboard();
 
   const { type: locationType, id } = useSyncLocation();
   const ISO = data?.locationIso;
@@ -34,7 +34,7 @@ const NationalDashboard = () => {
 
   return (
     <div className={WIDGET_CARD_WRAPPER_STYLE}>
-      <Loading visible={isLoading && !isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
+      <Loading visible={isFetching} iconClassName="flex w-10 h-10 m-auto my-10" />
       {isFetched && !isFetching && data && (
         <div>
           {firstIndicator?.legal_status && locationName && (


### PR DESCRIPTION
## Summary

The national dashboard widget rendered an empty card while its data fetched — the `<Loading>` guard was `isLoading && !isFetching`, which is always false in react-query v5 (`isLoading` implies `isFetching`), so the spinner never showed.

Now `visible={isFetching}` — the exact complement of the content gate (`isFetched && !isFetching && data`), matching the pattern used by the climate-watch widget. Spinner also covers refetches on location change. Unused `isLoading` removed from the destructure.

(Originally also carried the styles-alignment commit; that merged separately as #1665 and dropped out on rebase.)

## Test plan

- [x] `tsc` + `eslint` + `oxlint` clean (pre-commit hooks)
- [x] Verified with headed Playwright against dev server: delayed `/widgets/national_dashboard` response → spinner visible during fetch, replaced by content once resolved
- [ ] Check loader shows when switching between two countries