### PR TITLE
fix: restore visible national dashboard column headers

### DIFF
--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -40,12 +40,19 @@ const Sources = ({ data, iso }: { data: IndicatorDataItem[]; iso: string }) => {
          * they polluted the page outline with three entries per indicator.
          */
         <div key={indicator} role="table" aria-label={`${indicator} sources`}>
-          {/* Headers stay for screen readers; the design shows the rows without them. */}
-          <div role="row" className="sr-only">
-            <span role="columnheader">Source</span>
-            <span role="columnheader">Year</span>
-            <span role="columnheader">Extent</span>
-            <span role="columnheader">Layer controls</span>
+          <div role="row" className={`${gridCols} py-2`}>
+            <span role="columnheader" className="text-sm font-normal">
+              Source
+            </span>
+            <span role="columnheader" className="text-sm font-normal">
+              Year
+            </span>
+            <span role="columnheader" className="text-sm font-normal">
+              Extent
+            </span>
+            <span role="columnheader" className="sr-only">
+              Layer controls
+            </span>
           </div>
           {sources.map(({ source, years, unit, data_source }) => {
             const colorIndex = sourceColorMap.get(source) ?? 0;


### PR DESCRIPTION
## Summary

The national dashboard widget lost its visible "Source", "Year", "Extent" column headers after #1665 (`ff22c695`), which made the entire header row `sr-only` (and dropped the grid classes from it). This restores the pre-#1665 header row in `src/containers/datasets/national-dashboard/sources.tsx`:

- Header row gets back `${gridCols} py-2` so labels align with the cells below.
- Source/Year/Extent spans are visible again with `text-sm font-normal`.
- "Layer controls" keeps `sr-only` — it has no visible column, same as before #1665.

## Test plan

- [ ] Open a location with national dashboard data and confirm Source/Year/Extent headers render above the rows, column-aligned with the cells (grid `140px max-content 1fr max-content`)
- [ ] Confirm no visible fourth header ("Layer controls" remains screen-reader only)
- [x] `tsc` and eslint/oxlint pass (pre-commit hook)