### PR TITLE
fix: national dashboard row layout — omit empty extent cell, align columns

### DIFF
--- a/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/extent.tsx
@@ -11,8 +11,10 @@ const UNIT_ARIA = {
 };
 
 const IndicatorExtent = ({ unit, dataSource }: IndicatorExtentProps) => {
+  // No extent (missing or 0): omit the cell entirely. The row grid's 1fr extent
+  // column absorbs the gap and the controls cell keeps hugging the right edge.
   if (!dataSource?.value) {
-    return <span role="cell" />;
+    return null;
   }
   const displayUnit = unit ? LABEL_UNITS[unit] || unit : '';
   const ariaUnit = unit ? UNIT_ARIA[unit] || unit : '';

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -112,12 +112,13 @@ const IndicatorSources = ({
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
   // Without an extent cell the 1fr extent column would render as an empty gap
-  // between the year and the controls, so the source name takes the free space
-  // instead and the year/controls pack to the right.
+  // between the year and the controls, so everything packs to the left instead:
+  // the source name takes only the width it needs (minmax(0,…) still lets it
+  // shrink and truncate) and the year/controls sit right after it.
   const hasExtent = Boolean(dataSource?.value);
   const gridCols = hasExtent
     ? 'grid-cols-[140px_max-content_1fr_max-content]'
-    : 'grid-cols-[1fr_max-content_max-content]';
+    : 'grid-cols-[minmax(0,max-content)_max-content_max-content]';
 
   return (
     <div role="row" className={`grid items-center gap-x-4 ${gridCols} ${className ?? ''}`}>

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -111,14 +111,13 @@ const IndicatorSources = ({
     }
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
-  // Without an extent cell the 1fr extent column would render as an empty gap
-  // between the year and the controls, so everything packs to the left instead:
-  // the source name takes only the width it needs (minmax(0,…) still lets it
-  // shrink and truncate) and the year/controls sit right after it.
+  // Without an extent cell the source name takes only the width it needs
+  // (minmax(0,…) still lets it shrink and truncate), the year sits right after
+  // it, and the controls keep the right edge like every other row.
   const hasExtent = Boolean(dataSource?.value);
   const gridCols = hasExtent
     ? 'grid-cols-[140px_max-content_1fr_max-content]'
-    : 'grid-cols-[minmax(0,max-content)_max-content_max-content]';
+    : 'grid-cols-[minmax(0,max-content)_max-content_1fr]';
 
   return (
     <div role="row" className={`grid items-center gap-x-4 ${gridCols} ${className ?? ''}`}>

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -111,8 +111,16 @@ const IndicatorSources = ({
     }
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
+  // Without an extent cell the 1fr extent column would render as an empty gap
+  // between the year and the controls, so the source name takes the free space
+  // instead and the year/controls pack to the right.
+  const hasExtent = Boolean(dataSource?.value);
+  const gridCols = hasExtent
+    ? 'grid-cols-[140px_max-content_1fr_max-content]'
+    : 'grid-cols-[1fr_max-content_max-content]';
+
   return (
-    <div role="row" className={className}>
+    <div role="row" className={`grid items-center gap-x-4 ${gridCols} ${className ?? ''}`}>
       <IndicatorSource source={source} color={color} />
       <IndicatorYear yearSelected={yearSelected} setYearSelected={setYearSelected} years={years} />
       <IndicatorExtent unit={unit} dataSource={dataSource} />

--- a/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/index.tsx
@@ -111,21 +111,16 @@ const IndicatorSources = ({
     }
   }, [setActiveLayers, layerId, buildLayer, isNationalLayerActive, locationIso, source]);
 
-  // Without an extent cell the source name takes only the width it needs
-  // (minmax(0,…) still lets it shrink and truncate), the year sits right after
-  // it, and the controls keep the right edge like every other row.
-  const hasExtent = Boolean(dataSource?.value);
-  const gridCols = hasExtent
-    ? 'grid-cols-[140px_max-content_1fr_max-content]'
-    : 'grid-cols-[minmax(0,max-content)_max-content_1fr]';
-
   return (
-    <div role="row" className={`grid items-center gap-x-4 ${gridCols} ${className ?? ''}`}>
+    <div role="row" className={className}>
       <IndicatorSource source={source} color={color} />
       <IndicatorYear yearSelected={yearSelected} setYearSelected={setYearSelected} years={years} />
       <IndicatorExtent unit={unit} dataSource={dataSource} />
 
-      <div role="cell" className="flex min-h-min justify-end space-x-2">
+      {/* col-start-[-2] pins the controls to the table's last column even when
+          the extent cell is absent for this row/year, so the switch keeps the
+          same right-aligned position in every row. */}
+      <div role="cell" className="col-start-[-2] flex min-h-min justify-end space-x-2">
         <WidgetControls
           content={{
             link: dataSource?.download_link ?? undefined,

--- a/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
+++ b/src/containers/datasets/national-dashboard/indicator-layers/source.tsx
@@ -7,7 +7,7 @@ const IndicatorSource = ({ source, color }: IndicatorSourceProps) => (
       className="h-4 w-2 shrink-0 rounded-sm"
       aria-hidden="true"
     />
-    <span className="truncate" title={source}>
+    <span className="min-w-0 flex-1 truncate" title={source}>
       {source}
     </span>
   </div>

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -24,7 +24,6 @@ const Sources = ({ data, iso }: { data: IndicatorDataItem[]; iso: string }) => {
     .scale(COLORS)
     .colors(sourceColorMap.size > COLORS.length ? sourceColorMap.size : COLORS.length);
 
-  const gridCols = 'grid grid-cols-[140px_max-content_1fr_max-content] items-center gap-x-4';
   return (
     <section className="space-y-6.25 py-[25px]">
       {data?.map(({ indicator, sources }) => (
@@ -66,7 +65,7 @@ const Sources = ({ data, iso }: { data: IndicatorDataItem[]; iso: string }) => {
                 unit={unit}
                 data_source={data_source}
                 color={color}
-                className={`${gridCols} text-2lg py-3 leading-7.5 font-light`}
+                className="text-2lg py-3 leading-7.5 font-light"
               />
             );
           })}

--- a/src/containers/datasets/national-dashboard/sources.tsx
+++ b/src/containers/datasets/national-dashboard/sources.tsx
@@ -26,51 +26,70 @@ const Sources = ({ data, iso }: { data: IndicatorDataItem[]; iso: string }) => {
 
   return (
     <section className="space-y-6.25 py-[25px]">
-      {data?.map(({ indicator, sources }) => (
+      {data?.map(({ indicator, sources }) => {
         /*
-         * ARIA table roles rather than <table> markup: the visual layout is a
-         * CSS grid whose cells are rendered by three separate components, and
-         * real table elements would force either display:contents on the cells
-         * (which drops them from the accessibility tree in some browsers) or a
-         * layout rewrite. The roles give screen readers row/column association
-         * with no rendering change at all.
+         * The table owns the column tracks and every row inherits them via
+         * subgrid, so year/extent/controls all start on the same vertical line
+         * in every row, and the max-content controls track is as wide as the
+         * widest row (i.e. space is reserved as if every row had all buttons).
          *
-         * The column labels were <h5> elements — they are not headings, and
-         * they polluted the page outline with three entries per indicator.
+         * When no source in the table has an extent value, the extent column
+         * disappears and the source name takes the free space instead.
+         * minmax(0,…) lets the name column shrink and truncate rather than
+         * push the controls past the right edge of the row.
          */
-        <div key={indicator} role="table" aria-label={`${indicator} sources`}>
-          {/* Headers stay for screen readers; the design shows the rows without them. */}
-          <div role="row" className="sr-only">
-            <span role="columnheader">Source</span>
-            <span role="columnheader">Year</span>
-            <span role="columnheader">Extent</span>
-            <span role="columnheader">Layer controls</span>
+        const tableHasExtent = sources?.some((s) => s.data_source?.some((d) => d.value));
+        const gridCols = tableHasExtent
+          ? 'grid-cols-[minmax(0,140px)_max-content_1fr_max-content]'
+          : 'grid-cols-[minmax(0,1fr)_max-content_max-content]';
+        return (
+          /*
+           * ARIA table roles rather than <table> markup: the visual layout is a
+           * CSS grid whose cells are rendered by three separate components, and
+           * real table elements would force either display:contents on the cells
+           * (which drops them from the accessibility tree in some browsers) or a
+           * layout rewrite. The roles give screen readers row/column association
+           * with no rendering change at all.
+           */
+          <div
+            key={indicator}
+            role="table"
+            aria-label={`${indicator} sources`}
+            className={`grid ${gridCols} items-center gap-x-4`}
+          >
+            {/* Headers stay for screen readers; the design shows the rows without them. */}
+            <div role="row" className="sr-only">
+              <span role="columnheader">Source</span>
+              <span role="columnheader">Year</span>
+              {tableHasExtent && <span role="columnheader">Extent</span>}
+              <span role="columnheader">Layer controls</span>
+            </div>
+            {sources.map(({ source, years, unit, data_source }) => {
+              const colorIndex = sourceColorMap.get(source) ?? 0;
+              const color = palette[colorIndex % palette.length];
+              const layerKey = slugify(`${indicator}__${source}`);
+              return (
+                <IndicatorSource
+                  id={`mangrove_national_dashboard_layer_${iso}`}
+                  locationIso={iso}
+                  layerIndex={colorIndex}
+                  layerKey={layerKey}
+                  key={layerKey}
+                  indicator={indicator}
+                  source={source}
+                  // Deduped: the year selector keys its options by the year, and a
+                  // repeated year would also turn a single-year source into a dropdown.
+                  years={years ? [...new Set(years)] : years}
+                  unit={unit}
+                  data_source={data_source}
+                  color={color}
+                  className="text-2lg col-span-full grid grid-cols-subgrid items-center py-3 leading-7.5 font-light"
+                />
+              );
+            })}
           </div>
-          {sources.map(({ source, years, unit, data_source }) => {
-            const colorIndex = sourceColorMap.get(source) ?? 0;
-            const color = palette[colorIndex % palette.length];
-            const layerKey = slugify(`${indicator}__${source}`);
-            return (
-              <IndicatorSource
-                id={`mangrove_national_dashboard_layer_${iso}`}
-                locationIso={iso}
-                layerIndex={colorIndex}
-                layerKey={layerKey}
-                key={layerKey}
-                indicator={indicator}
-                source={source}
-                // Deduped: the year selector keys its options by the year, and a
-                // repeated year would also turn a single-year source into a dropdown.
-                years={years ? [...new Set(years)] : years}
-                unit={unit}
-                data_source={data_source}
-                color={color}
-                className="text-2lg py-3 leading-7.5 font-light"
-              />
-            );
-          })}
-        </div>
-      ))}
+        );
+      })}
     </section>
   );
 };

--- a/tests/fixtures/national-dashboard.json
+++ b/tests/fixtures/national-dashboard.json
@@ -40,6 +40,21 @@
               "source_layer": "test_2025"
             }
           ]
+        },
+        {
+          "source": "NOEXTENT",
+          "unit": "km2",
+          "years": [2025],
+          "data_source": [
+            {
+              "year": 2025,
+              "value": 0,
+              "layer_link": "globalmangrovewatch.noextent_2025",
+              "download_link": null,
+              "layer_info": "NOEXTENT 2025 mangrove extent",
+              "source_layer": "noextent_2025"
+            }
+          ]
         }
       ]
     }

--- a/tests/national-dashboard.spec.ts
+++ b/tests/national-dashboard.spec.ts
@@ -72,6 +72,20 @@ test.describe('National Dashboard multi-source', () => {
     await expect(testSwitch).toHaveAttribute('data-state', 'checked');
   });
 
+  test('source without extent renders no extent cell', async ({ page }) => {
+    const widget = page.getByTestId(WIDGET_TESTID);
+    const row = widget.getByRole('row').filter({ hasText: 'NOEXTENT' });
+
+    await expect(row).toBeVisible();
+    // Source, year and layer controls only — the extent cell is omitted when
+    // the value is missing or 0.
+    await expect(row.getByRole('cell')).toHaveCount(3);
+    await expect(row.getByText('km²')).toHaveCount(0);
+    await expect(
+      row.getByRole('switch', { name: /Toggle NOEXTENT Habitat extent area layer/ })
+    ).toBeVisible();
+  });
+
   test('year picker is per-source', async ({ page }) => {
     const widget = page.getByTestId(WIDGET_TESTID);
 


### PR DESCRIPTION
## Summary

Reworks the national dashboard widget's source-row layout:

- **Empty extent cells are removed.** When a source has no extent value for the selected year (missing or `0`), `IndicatorExtent` renders nothing instead of an empty placeholder cell.
- **Columns align across rows via CSS subgrid.** The per-indicator table (`sources.tsx`) now owns the column tracks (`minmax(0,140px) | max-content | 1fr | max-content`) and each row inherits them with `grid-cols-subgrid col-span-full`, so the year and extent columns start on the same vertical line in every row.
- **Layer controls keep a constant right-aligned slot.** The controls cell is pinned to the table's last column with `col-start-[-2]`, and the shared `max-content` track means every row reserves the width of the widest controls set (download + info + switch) even when a row has fewer buttons — the switch sits at the same right edge in every row.
- **Tables with no extent values at all** drop the extent column entirely (`minmax(0,1fr) | max-content | max-content`) and the source name takes the freed space.
- **Overflow fix:** the source-name column is `minmax(0,140px)` instead of a fixed `140px`, so tight rows truncate the name rather than pushing the controls past the row's right edge (previously overflowed by up to ~16px).
- Source name span gets `min-w-0 flex-1 truncate` so it fills its cell.

Verified with a headed Playwright measurement script: controls cell spans identical x-coordinates in every row (including no-extent rows), year/extent column starts match across rows, switch right edge identical everywhere.

## Test plan

- [x] `npx playwright test tests/national-dashboard.spec.ts` — 5 passed, including a new spec: a zero-extent source row renders only source/year/controls cells (no extent cell, no unit text) and its layer switch still works
- [x] Added `NOEXTENT` source (`value: 0`) to `tests/fixtures/national-dashboard.json`
- [x] `tsc --noEmit` and eslint/oxlint clean (pre-commit hooks)
- [x] Screenshot + bounding-box measurements of all row variants (with extent, without extent, all-zero table)
- [ ] Visual check on preview deploy against design